### PR TITLE
go install → go get -u

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ control system of your choice to manage your configuration.
 
 Install it:
 
-    $ go install github.com/twpayne/chezmoi
+    $ go get -u github.com/twpayne/chezmoi
 
 Start using it:
 


### PR DESCRIPTION
`go install` only works if you already have the package checked out:
```
% go install github.com/twpayne/chezmoi
can't load package: package github.com/twpayne/chezmoi: cannot find package "github.com/twpayne/chezmoi" in any of:
	/home/michael/sdk/go1.11rc1/src/github.com/twpayne/chezmoi (from $GOROOT)
	/home/michael/go/src/github.com/twpayne/chezmoi (from $GOPATH)
```

`go get -u` can be used to install/update.