### PR TITLE
Use fmt.Errorf instead of errors.Errorf

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -1,10 +1,10 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/twpayne/go-vfs"
 )
@@ -44,7 +44,7 @@ func (c *Config) runAddCommandE(fs vfs.FS, command *cobra.Command, args []string
 			return err
 		}
 	case err == nil:
-		return errors.Errorf("%s: is not a directory", c.SourceDir)
+		return fmt.Errorf("%s: is not a directory", c.SourceDir)
 	default:
 		return err
 	}

--- a/cmd/cat.go
+++ b/cmd/cat.go
@@ -1,10 +1,10 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/twpayne/chezmoi/lib/chezmoi"
 	"github.com/twpayne/go-vfs"
@@ -36,11 +36,11 @@ func (c *Config) runCatCommand(fs vfs.FS, command *cobra.Command, args []string)
 			return err
 		}
 		if entry == nil {
-			return errors.Errorf("%s: not found", arg)
+			return fmt.Errorf("%s: not found", arg)
 		}
 		f, ok := entry.(*chezmoi.File)
 		if !ok {
-			return errors.Errorf("%s: not a regular file", arg)
+			return fmt.Errorf("%s: not a regular file", arg)
 		}
 		if _, err := os.Stdout.Write(f.Contents); err != nil {
 			return err

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -11,7 +11,6 @@ import (
 	"syscall"
 
 	"github.com/mitchellh/go-homedir"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/twpayne/chezmoi/lib/chezmoi"
 	"github.com/twpayne/go-vfs"
@@ -109,11 +108,11 @@ func (c *Config) getSourceNames(targetState *chezmoi.TargetState, targets []stri
 			return nil, err
 		}
 		if filepath.HasPrefix(targetName, "..") {
-			return nil, errors.Errorf("%s: not in target directory", target)
+			return nil, fmt.Errorf("%s: not in target directory", target)
 		}
 		entry, ok := allEntries[targetName]
 		if !ok {
-			return nil, errors.Errorf("%s: not found", targetName)
+			return nil, fmt.Errorf("%s: not found", targetName)
 		}
 		sourceNames = append(sourceNames, entry.SourceName())
 	}

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -1,10 +1,10 @@
 package cmd
 
 import (
+	"fmt"
 	"path/filepath"
 
 	"github.com/davecgh/go-spew/spew"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/twpayne/go-vfs"
 )
@@ -37,7 +37,7 @@ func (c *Config) runDumpCommandE(fs vfs.FS, command *cobra.Command, args []strin
 				return err
 			}
 			if state == nil {
-				return errors.Errorf("%s: not found", arg)
+				return fmt.Errorf("%s: not found", arg)
 			}
 			spew.Dump(state)
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,7 +7,6 @@ import (
 	"syscall"
 
 	"github.com/mitchellh/go-homedir"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/twpayne/go-vfs"
@@ -88,7 +87,7 @@ func (c *Config) persistentPreRunRootE(fs vfs.FS, command *cobra.Command, args [
 	info, err := fs.Stat(c.SourceDir)
 	switch {
 	case err == nil && !info.Mode().IsDir():
-		return errors.Errorf("%s: not a directory", c.SourceDir)
+		return fmt.Errorf("%s: not a directory", c.SourceDir)
 	case err == nil && info.Mode()&os.ModePerm != 0700:
 		fmt.Printf("%s: want permissions 0700, got 0%o\n", c.SourceDir, info.Mode()&os.ModePerm)
 	case os.IsNotExist(err):

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/google/renameio v0.0.0-20181108174601-76365acd908f
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/mitchellh/go-homedir v1.0.0
-	github.com/pkg/errors v0.8.0
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/viper v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,6 @@ github.com/mitchellh/mapstructure v1.0.0 h1:vVpGvMXJPqSDh2VYHF7gsfQj8Ncx+Xw5Y1KH
 github.com/mitchellh/mapstructure v1.0.0/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
-github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
-github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/spf13/afero v1.1.2 h1:m8/z1t7/fwjysjQRYbP0RD+bUIF/8tJwPdEZsI83ACI=


### PR DESCRIPTION
[`github.com/pkg/errors`](https://github.com/pkg/errors) is great, but `chezmoi` doesn't use it consistently. Use `fmt.Errorf` instead, pending a proper review of errors.