### PR TITLE
Add version command

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -17,6 +17,13 @@ import (
 	"github.com/twpayne/go-vfs"
 )
 
+// A Version represents a version.
+type Version struct {
+	Version string
+	Commit  string
+	Date    string
+}
+
 // An AddCommandConfig is a configuration for the add command.
 type AddCommandConfig struct {
 	Empty     bool
@@ -33,6 +40,7 @@ type KeyringCommandConfig struct {
 
 // A Config represents a configuration.
 type Config struct {
+	version          Version
 	SourceDir        string
 	TargetDir        string
 	Umask            int

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -77,7 +77,8 @@ func init() {
 }
 
 // Execute executes the root command.
-func Execute() {
+func Execute(version Version) {
+	config.version = version
 	if err := rootCommand.Execute(); err != nil {
 		printErrorAndExit(err)
 	}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/twpayne/go-vfs"
+)
+
+var versionCommand = &cobra.Command{
+	Use:   "version",
+	Args:  cobra.NoArgs,
+	Short: "Print version",
+	RunE:  makeRunE(config.runVersionCommandE),
+}
+
+func init() {
+	rootCommand.AddCommand(versionCommand)
+}
+
+func (c *Config) runVersionCommandE(fs vfs.FS, cmd *cobra.Command, args []string) error {
+	fmt.Printf("Version: %s Commit: %s Date: %s\n", c.version.Version, c.version.Commit, c.version.Date)
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -4,6 +4,17 @@ import (
 	"github.com/twpayne/chezmoi/cmd"
 )
 
+var (
+	// These variables are set goreleaser
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
 func main() {
-	cmd.Execute()
+	cmd.Execute(cmd.Version{
+		Version: version,
+		Commit:  commit,
+		Date:    date,
+	})
 }


### PR DESCRIPTION
[goreleaser](https://goreleaser.com) sets various helpful version number variables. This PR adds a `version` command to print them.