### PR TITLE
Hide internal config

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -16,13 +16,20 @@ var addCommand = &cobra.Command{
 	RunE:  makeRunE(config.runAddCommandE),
 }
 
+// An AddCommandConfig is a configuration for the add command.
+type addCommandConfig struct {
+	empty     bool
+	recursive bool
+	template  bool
+}
+
 func init() {
 	rootCommand.AddCommand(addCommand)
 
 	persistentFlags := addCommand.PersistentFlags()
-	persistentFlags.BoolVarP(&config.Add.Empty, "empty", "e", false, "add empty files")
-	persistentFlags.BoolVarP(&config.Add.Recursive, "recursive", "r", false, "recurse in to subdirectories")
-	persistentFlags.BoolVarP(&config.Add.Template, "template", "T", false, "add files as templates")
+	persistentFlags.BoolVarP(&config.add.empty, "empty", "e", false, "add empty files")
+	persistentFlags.BoolVarP(&config.add.recursive, "recursive", "r", false, "recurse in to subdirectories")
+	persistentFlags.BoolVarP(&config.add.template, "template", "T", false, "add files as templates")
 }
 
 func (c *Config) runAddCommandE(fs vfs.FS, command *cobra.Command, args []string) error {
@@ -53,17 +60,17 @@ func (c *Config) runAddCommandE(fs vfs.FS, command *cobra.Command, args []string
 		if err != nil {
 			return err
 		}
-		if c.Add.Recursive {
+		if c.add.recursive {
 			if err := vfs.Walk(fs, path, func(path string, info os.FileInfo, err error) error {
 				if err != nil {
 					return err
 				}
-				return targetState.Add(fs, path, info, c.Add.Empty, c.Add.Template, actuator)
+				return targetState.Add(fs, path, info, c.add.empty, c.add.template, actuator)
 			}); err != nil {
 				return err
 			}
 		} else {
-			if err := targetState.Add(fs, path, nil, c.Add.Empty, c.Add.Template, actuator); err != nil {
+			if err := targetState.Add(fs, path, nil, c.add.empty, c.add.template, actuator); err != nil {
 				return err
 			}
 		}

--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -8,11 +8,11 @@ import (
 
 func TestAddCommand(t *testing.T) {
 	for _, tc := range []struct {
-		name             string
-		args             []string
-		addCommandConfig AddCommandConfig
-		root             interface{}
-		tests            interface{}
+		name  string
+		args  []string
+		add   addCommandConfig
+		root  interface{}
+		tests interface{}
 	}{
 		{
 			name: "add_first_file",
@@ -28,8 +28,8 @@ func TestAddCommand(t *testing.T) {
 		{
 			name: "add_template",
 			args: []string{"/home/jenkins/.gitconfig"},
-			addCommandConfig: AddCommandConfig{
-				Template: true,
+			add: addCommandConfig{
+				template: true,
 			},
 			root: map[string]interface{}{
 				"/home/jenkins":            &vfst.Dir{Perm: 0755},
@@ -43,8 +43,8 @@ func TestAddCommand(t *testing.T) {
 		{
 			name: "add_recursive",
 			args: []string{"/home/jenkins/.config"},
-			addCommandConfig: AddCommandConfig{
-				Recursive: true,
+			add: addCommandConfig{
+				recursive: true,
 			},
 			root: map[string]interface{}{
 				"/home/jenkins":                             &vfst.Dir{Perm: 0755},
@@ -70,8 +70,8 @@ func TestAddCommand(t *testing.T) {
 		{
 			name: "add_empty_file",
 			args: []string{"/home/jenkins/empty"},
-			addCommandConfig: AddCommandConfig{
-				Empty: true,
+			add: addCommandConfig{
+				empty: true,
 			},
 			root: map[string]interface{}{
 				"/home/jenkins":          &vfst.Dir{Perm: 0755},
@@ -97,8 +97,8 @@ func TestAddCommand(t *testing.T) {
 		{
 			name: "add_symlink_in_dir_recursive",
 			args: []string{"/home/jenkins/foo"},
-			addCommandConfig: AddCommandConfig{
-				Recursive: true,
+			add: addCommandConfig{
+				recursive: true,
 			},
 			root: map[string]interface{}{
 				"/home/jenkins":          &vfst.Dir{Perm: 0755},
@@ -137,7 +137,7 @@ func TestAddCommand(t *testing.T) {
 					"name":  "John Smith",
 					"email": "john.smith@company.com",
 				},
-				Add: tc.addCommandConfig,
+				add: tc.add,
 			}
 			fs, cleanup, err := vfst.NewTestFS(tc.root)
 			defer cleanup()

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -24,13 +24,6 @@ type Version struct {
 	Date    string
 }
 
-// An AddCommandConfig is a configuration for the add command.
-type AddCommandConfig struct {
-	Empty     bool
-	Recursive bool
-	Template  bool
-}
-
 // A KeyringCommandConfig is a configuration for the keyring command.
 type KeyringCommandConfig struct {
 	Service  string
@@ -49,7 +42,7 @@ type Config struct {
 	SourceVCSCommand string
 	Data             map[string]interface{}
 	Funcs            template.FuncMap
-	Add              AddCommandConfig
+	add              addCommandConfig
 	Keyring          KeyringCommandConfig
 }
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -24,13 +24,6 @@ type Version struct {
 	Date    string
 }
 
-// A KeyringCommandConfig is a configuration for the keyring command.
-type KeyringCommandConfig struct {
-	Service  string
-	User     string
-	Password string
-}
-
 // A Config represents a configuration.
 type Config struct {
 	version          Version
@@ -43,7 +36,7 @@ type Config struct {
 	Data             map[string]interface{}
 	Funcs            template.FuncMap
 	add              addCommandConfig
-	Keyring          KeyringCommandConfig
+	keyring          keyringCommandConfig
 }
 
 func (c *Config) addFunc(key string, value interface{}) {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -34,19 +34,19 @@ type Config struct {
 	Verbose          bool
 	SourceVCSCommand string
 	Data             map[string]interface{}
-	Funcs            template.FuncMap
+	funcs            template.FuncMap
 	add              addCommandConfig
 	keyring          keyringCommandConfig
 }
 
 func (c *Config) addFunc(key string, value interface{}) {
-	if c.Funcs == nil {
-		c.Funcs = make(template.FuncMap)
+	if c.funcs == nil {
+		c.funcs = make(template.FuncMap)
 	}
-	if _, ok := c.Funcs[key]; ok {
+	if _, ok := c.funcs[key]; ok {
 		panic(fmt.Sprintf("Config.addFunc: %s already defined", key))
 	}
-	c.Funcs[key] = value
+	c.funcs[key] = value
 }
 
 func (c *Config) exec(argv []string) error {
@@ -144,7 +144,7 @@ func (c *Config) getTargetState(fs vfs.FS) (*chezmoi.TargetState, error) {
 	for key, value := range c.Data {
 		data[key] = value
 	}
-	targetState := chezmoi.NewTargetState(c.TargetDir, os.FileMode(c.Umask), c.SourceDir, data, c.Funcs)
+	targetState := chezmoi.NewTargetState(c.TargetDir, os.FileMode(c.Umask), c.SourceDir, data, c.funcs)
 	if err := targetState.Populate(fs); err != nil {
 		return nil, err
 	}

--- a/cmd/keyring.go
+++ b/cmd/keyring.go
@@ -11,15 +11,22 @@ var keyringCommand = &cobra.Command{
 	Short: "Interact with keyring",
 }
 
+// A keyringCommandConfig is a configuration for the keyring command.
+type keyringCommandConfig struct {
+	service  string
+	user     string
+	password string
+}
+
 func init() {
 	rootCommand.AddCommand(keyringCommand)
 
 	persistentFlags := keyringCommand.PersistentFlags()
 
-	persistentFlags.StringVar(&config.Keyring.Service, "service", "", "service")
+	persistentFlags.StringVar(&config.keyring.service, "service", "", "service")
 	keyringCommand.MarkPersistentFlagRequired("service")
 
-	persistentFlags.StringVar(&config.Keyring.User, "user", "", "user")
+	persistentFlags.StringVar(&config.keyring.user, "user", "", "user")
 	keyringCommand.MarkPersistentFlagRequired("user")
 
 	config.addFunc("keyring", func(service, user string) string {

--- a/cmd/keyring_get.go
+++ b/cmd/keyring_get.go
@@ -20,7 +20,7 @@ func init() {
 }
 
 func (c *Config) runKeyringGetCommand(fs vfs.FS, cmd *cobra.Command, args []string) error {
-	password, err := keyring.Get(c.Keyring.Service, c.Keyring.User)
+	password, err := keyring.Get(c.keyring.service, c.keyring.user)
 	if err != nil {
 		return err
 	}

--- a/cmd/keyring_set.go
+++ b/cmd/keyring_set.go
@@ -21,11 +21,11 @@ func init() {
 	keyringCommand.AddCommand(keyringSetCommand)
 
 	persistentFlags := keyringSetCommand.PersistentFlags()
-	persistentFlags.StringVar(&config.Keyring.Password, "password", "", "password")
+	persistentFlags.StringVar(&config.keyring.password, "password", "", "password")
 }
 
 func (c *Config) runKeyringSetCommand(fs vfs.FS, cmd *cobra.Command, args []string) error {
-	passwordString := c.Keyring.Password
+	passwordString := c.keyring.password
 	if passwordString == "" {
 		fmt.Print("Password: ")
 		password, err := terminal.ReadPassword(syscall.Stdin)
@@ -34,5 +34,5 @@ func (c *Config) runKeyringSetCommand(fs vfs.FS, cmd *cobra.Command, args []stri
 		}
 		passwordString = string(password)
 	}
-	return keyring.Set(c.Keyring.Service, c.Keyring.User, passwordString)
+	return keyring.Set(c.keyring.service, c.keyring.user, passwordString)
 }


### PR DESCRIPTION
A number of fields of `Config` were exported, meaning that they could be overridden in the config file. This PR makes them private so they cannot be overridden in the config file.