### PR TITLE
Add source-path command

### DIFF
--- a/cmd/source_path.go
+++ b/cmd/source_path.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	vfs "github.com/twpayne/go-vfs"
+)
+
+var sourcePathCommand = &cobra.Command{
+	Use:   "source-path",
+	Args:  cobra.MinimumNArgs(1),
+	Short: "Print the source path of the specified targets",
+	RunE:  makeRunE(config.runSourcePathCommand),
+}
+
+func init() {
+	rootCommand.AddCommand(sourcePathCommand)
+}
+
+func (c *Config) runSourcePathCommand(fs vfs.FS, cmd *cobra.Command, args []string) error {
+	targetState, err := c.getTargetState(fs)
+	if err != nil {
+		return err
+	}
+	entries, err := c.getEntries(targetState, args)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		if _, err := fmt.Println(filepath.Join(targetState.SourceDir, entry.SourceName())); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cmd/source_path.go
+++ b/cmd/source_path.go
@@ -10,7 +10,6 @@ import (
 
 var sourcePathCommand = &cobra.Command{
 	Use:   "source-path",
-	Args:  cobra.MinimumNArgs(1),
 	Short: "Print the source path of the specified targets",
 	RunE:  makeRunE(config.runSourcePathCommand),
 }
@@ -22,6 +21,10 @@ func init() {
 func (c *Config) runSourcePathCommand(fs vfs.FS, cmd *cobra.Command, args []string) error {
 	targetState, err := c.getTargetState(fs)
 	if err != nil {
+		return err
+	}
+	if len(args) == 0 {
+		_, err := fmt.Println(targetState.SourceDir)
 		return err
 	}
 	entries, err := c.getEntries(targetState, args)


### PR DESCRIPTION
This PR adds a `source-path` command that prints out a target's source path, for example:

```
$ chezmoi source-path ~/.vimrc
/Users/twp/.chezmoi/dot_vimrc
```

It can be useful for scripts that need to modify files in `~/.chezmoi`.