### PR TITLE
Dump in JSON and YAML formats

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -38,6 +38,7 @@ type Config struct {
 	Data             map[string]interface{}
 	funcs            template.FuncMap
 	add              addCommandConfig
+	dump             dumpCommandConfig
 	edit             editCommandConfig
 	keyring          keyringCommandConfig
 }

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -46,7 +46,7 @@ func (c *Config) runDumpCommand(fs vfs.FS, command *cobra.Command, args []string
 		}
 		var concreteValues []interface{}
 		for _, entry := range entries {
-			entryConcreteValue, err := entry.ConcreteValue()
+			entryConcreteValue, err := entry.ConcreteValue(targetState.TargetDir, targetState.SourceDir)
 			if err != nil {
 				return err
 			}

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -12,7 +12,8 @@ import (
 )
 
 type dumpCommandConfig struct {
-	format string
+	format    string
+	recursive bool
 }
 
 var dumpCommand = &cobra.Command{
@@ -26,6 +27,7 @@ func init() {
 
 	persistentFlags := dumpCommand.PersistentFlags()
 	persistentFlags.StringVarP(&config.dump.format, "format", "f", "json", "format (JSON or YAML)")
+	persistentFlags.BoolVarP(&config.dump.recursive, "recursive", "r", true, "recursive")
 }
 
 func (c *Config) runDumpCommand(fs vfs.FS, command *cobra.Command, args []string) error {
@@ -35,7 +37,7 @@ func (c *Config) runDumpCommand(fs vfs.FS, command *cobra.Command, args []string
 	}
 	var concreteValue interface{}
 	if len(args) == 0 {
-		concreteValue, err = targetState.ConcreteValue()
+		concreteValue, err = targetState.ConcreteValue(c.dump.recursive)
 		if err != nil {
 			return err
 		}
@@ -46,7 +48,7 @@ func (c *Config) runDumpCommand(fs vfs.FS, command *cobra.Command, args []string
 		}
 		var concreteValues []interface{}
 		for _, entry := range entries {
-			entryConcreteValue, err := entry.ConcreteValue(targetState.TargetDir, targetState.SourceDir)
+			entryConcreteValue, err := entry.ConcreteValue(targetState.TargetDir, targetState.SourceDir, c.dump.recursive)
 			if err != nil {
 				return err
 			}

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 	vfs "github.com/twpayne/go-vfs"
+	yaml "gopkg.in/yaml.v2"
 )
 
 type dumpCommandConfig struct {
@@ -24,7 +25,7 @@ func init() {
 	rootCommand.AddCommand(dumpCommand)
 
 	persistentFlags := dumpCommand.PersistentFlags()
-	persistentFlags.StringVarP(&config.dump.format, "format", "f", "json", "format (JSON)")
+	persistentFlags.StringVarP(&config.dump.format, "format", "f", "json", "format (JSON or YAML)")
 }
 
 func (c *Config) runDumpCommand(fs vfs.FS, command *cobra.Command, args []string) error {
@@ -58,6 +59,8 @@ func (c *Config) runDumpCommand(fs vfs.FS, command *cobra.Command, args []string
 		e := json.NewEncoder(os.Stdout)
 		e.SetIndent("", "  ")
 		return e.Encode(concreteValue)
+	case "yaml":
+		return yaml.NewEncoder(os.Stdout).Encode(concreteValue)
 	default:
 		return fmt.Errorf("unknown format: %s", c.dump.format)
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/d4l3k/messagediff v1.2.1
 	github.com/danieljoos/wincred v1.0.1 // indirect
-	github.com/davecgh/go-spew v1.1.1
 	github.com/godbus/dbus v4.1.0+incompatible // indirect
 	github.com/google/renameio v0.0.0-20181108174601-76365acd908f
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -17,4 +17,5 @@ require (
 	github.com/twpayne/go-vfs v0.1.5
 	github.com/zalando/go-keyring v0.0.0-20180221093347-6d81c293b3fb
 	golang.org/x/crypto v0.0.0-20181127143415-eb0de9b17e85
+	gopkg.in/yaml.v2 v2.2.1
 )

--- a/lib/chezmoi/chezmoi.go
+++ b/lib/chezmoi/chezmoi.go
@@ -34,7 +34,7 @@ type templateFuncError struct {
 // An Entry is either a Dir, a File, or a Symlink.
 type Entry interface {
 	Apply(fs vfs.FS, targetDir string, umask os.FileMode, actuator Actuator) error
-	ConcreteValue(targetDir, sourceDir string) (interface{}, error)
+	ConcreteValue(targetDir, sourceDir string, recursive bool) (interface{}, error)
 	Evaluate() error
 	SourceName() string
 	TargetName() string
@@ -182,14 +182,16 @@ func (d *Dir) Apply(fs vfs.FS, targetDir string, umask os.FileMode, actuator Act
 }
 
 // ConcreteValue implements Entry.ConcreteValue.
-func (d *Dir) ConcreteValue(targetDir, sourceDir string) (interface{}, error) {
+func (d *Dir) ConcreteValue(targetDir, sourceDir string, recursive bool) (interface{}, error) {
 	var entryConcreteValues []interface{}
-	for _, entryName := range sortedEntryNames(d.Entries) {
-		entryConcreteValue, err := d.Entries[entryName].ConcreteValue(targetDir, sourceDir)
-		if err != nil {
-			return nil, err
+	if recursive {
+		for _, entryName := range sortedEntryNames(d.Entries) {
+			entryConcreteValue, err := d.Entries[entryName].ConcreteValue(targetDir, sourceDir, recursive)
+			if err != nil {
+				return nil, err
+			}
+			entryConcreteValues = append(entryConcreteValues, entryConcreteValue)
 		}
-		entryConcreteValues = append(entryConcreteValues, entryConcreteValue)
 	}
 	return &dirConcreteValue{
 		SourcePath: filepath.Join(sourceDir, d.SourceName()),
@@ -287,7 +289,7 @@ func (f *File) Apply(fs vfs.FS, targetDir string, umask os.FileMode, actuator Ac
 }
 
 // ConcreteValue implements Entry.ConcreteValue.
-func (f *File) ConcreteValue(targetDir, sourceDir string) (interface{}, error) {
+func (f *File) ConcreteValue(targetDir, sourceDir string, recursive bool) (interface{}, error) {
 	contents, err := f.Contents()
 	if err != nil {
 		return nil, err
@@ -376,7 +378,7 @@ func (s *Symlink) Apply(fs vfs.FS, targetDir string, umask os.FileMode, actuator
 }
 
 // ConcreteValue implements Entry.ConcreteValue.
-func (s *Symlink) ConcreteValue(targetDir, sourceDir string) (interface{}, error) {
+func (s *Symlink) ConcreteValue(targetDir, sourceDir string, recursive bool) (interface{}, error) {
 	linkName, err := s.LinkName()
 	if err != nil {
 		return nil, err
@@ -615,10 +617,10 @@ func (ts *TargetState) Apply(fs vfs.FS, actuator Actuator) error {
 }
 
 // ConcreteValue returns a value suitable for serialization.
-func (ts *TargetState) ConcreteValue() (interface{}, error) {
+func (ts *TargetState) ConcreteValue(recursive bool) (interface{}, error) {
 	var entryConcreteValues []interface{}
 	for _, entryName := range sortedEntryNames(ts.Entries) {
-		entryConcreteValue, err := ts.Entries[entryName].ConcreteValue(ts.TargetDir, ts.SourceDir)
+		entryConcreteValue, err := ts.Entries[entryName].ConcreteValue(ts.TargetDir, ts.SourceDir, recursive)
 		if err != nil {
 			return nil, err
 		}

--- a/lib/chezmoi/chezmoi.go
+++ b/lib/chezmoi/chezmoi.go
@@ -54,6 +54,7 @@ type File struct {
 }
 
 type fileConcreteValue struct {
+	Type       string `json:"type" yaml:"type"`
 	SourcePath string `json:"sourcePath" yaml:"sourcePath"`
 	TargetPath string `json:"targetPath" yaml:"targetPath"`
 	Empty      bool   `json:"empty" yaml:"empty"`
@@ -71,6 +72,7 @@ type Dir struct {
 }
 
 type dirConcreteValue struct {
+	Type       string        `json:"type" yaml:"type"`
 	SourcePath string        `json:"sourcePath" yaml:"sourcePath"`
 	TargetPath string        `json:"targetPath" yaml:"targetPath"`
 	Perm       int           `json:"perm" yaml:"perm"`
@@ -88,6 +90,7 @@ type Symlink struct {
 }
 
 type symlinkConcreteValue struct {
+	Type       string `json:"type" yaml:"type"`
 	SourcePath string `json:"sourcePath" yaml:"sourcePath"`
 	TargetPath string `json:"targetPath" yaml:"targetPath"`
 	Template   bool   `json:"template" yaml:"template"`
@@ -194,6 +197,7 @@ func (d *Dir) ConcreteValue(targetDir, sourceDir string, recursive bool) (interf
 		}
 	}
 	return &dirConcreteValue{
+		Type:       "dir",
 		SourcePath: filepath.Join(sourceDir, d.SourceName()),
 		TargetPath: filepath.Join(targetDir, d.TargetName()),
 		Perm:       int(d.Perm),
@@ -295,6 +299,7 @@ func (f *File) ConcreteValue(targetDir, sourceDir string, recursive bool) (inter
 		return nil, err
 	}
 	return &fileConcreteValue{
+		Type:       "file",
 		SourcePath: filepath.Join(sourceDir, f.SourceName()),
 		TargetPath: filepath.Join(targetDir, f.TargetName()),
 		Empty:      f.Empty,
@@ -384,6 +389,7 @@ func (s *Symlink) ConcreteValue(targetDir, sourceDir string, recursive bool) (in
 		return nil, err
 	}
 	return &symlinkConcreteValue{
+		Type:       "symlink",
 		SourcePath: filepath.Join(sourceDir, s.SourceName()),
 		TargetPath: filepath.Join(targetDir, s.TargetName()),
 		Template:   s.Template,

--- a/lib/chezmoi/chezmoi.go
+++ b/lib/chezmoi/chezmoi.go
@@ -54,12 +54,12 @@ type File struct {
 }
 
 type fileConcreteValue struct {
-	SourceName string `json:"sourceName"`
-	TargetName string `json:"targetName"`
-	Empty      bool   `json:"empty"`
-	Perm       int    `json:"perm"`
-	Template   bool   `json:"template"`
-	Contents   string `json:"contents"`
+	SourceName string `json:"sourceName" yaml:"sourceName"`
+	TargetName string `json:"targetName" yaml:"targetName"`
+	Empty      bool   `json:"empty" yaml:"empty"`
+	Perm       int    `json:"perm" yaml:"perm"`
+	Template   bool   `json:"template" yaml:"template"`
+	Contents   string `json:"contents" yaml:"contents"`
 }
 
 // A Dir represents the target state of a directory.
@@ -71,10 +71,10 @@ type Dir struct {
 }
 
 type dirConcreteValue struct {
-	SourceName string        `json:"sourceName"`
-	TargetName string        `json:"targetName"`
-	Perm       int           `json:"perm"`
-	Entries    []interface{} `json:"entries"`
+	SourceName string        `json:"sourceName" yaml:"sourceName"`
+	TargetName string        `json:"targetName" yaml:"targetName"`
+	Perm       int           `json:"perm" yaml:"perm"`
+	Entries    []interface{} `json:"entries" yaml:"entries"`
 }
 
 // A Symlink represents the target state of a symlink.
@@ -88,10 +88,10 @@ type Symlink struct {
 }
 
 type symlinkConcreteValue struct {
-	SourceName string `json:"sourceName"`
-	TargetName string `json:"targetName"`
-	Template   bool   `json:"template"`
-	LinkName   string `json:"linkName"`
+	SourceName string `json:"sourceName" yaml:"sourceName"`
+	TargetName string `json:"targetName" yaml:"targetName"`
+	Template   bool   `json:"template" yaml:"template"`
+	LinkName   string `json:"linkName" yaml:"linkName"`
 }
 
 // A TargetState represents the root target state.


### PR DESCRIPTION
This PR adds `--format` and `--recursive` commands to the `dump` command. Supported formats are JSON and YAML.