### PR TITLE
Re-enable checking for LookupGroup errors

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,6 +25,18 @@ builds:
   ignore:
     - goos: darwin
       goarch: 386
+    - goos: linux
+      goarch: 386
+    - goos: linux
+      goarch: amd64
+- binary: chezmoi
+  env:
+    - CGO_ENABLED=1
+  goos:
+    - linux
+  goarch:
+    - 386
+    - amd64
 
 ## generate .tar.gz archives
 archive:

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -113,12 +113,11 @@ func getDefaultData() (map[string]interface{}, error) {
 	}
 	data["username"] = currentUser.Username
 
-	// user.LookupGroupId reads /etc/group, which is not populated on some
-	// systems, causing lookup to fail. Instead of returning the error, simply
-	// ignore it and only set group if lookup succeeds.
-	if group, err := user.LookupGroupId(currentUser.Gid); err == nil {
-		data["group"] = group.Name
+	group, err := user.LookupGroupId(currentUser.Gid)
+	if err != nil {
+		return nil, err
 	}
+	data["group"] = group.Name
 
 	homedir, err := homedir.Dir()
 	if err != nil {


### PR DESCRIPTION
#65 turns out to be a bit more nuanced that I realized.

- Go's standard library will use the `mygetgrnam_r` library function to lookup groups on Linux, but only if cgo is enabled. Otherwise it falls back to searching `/etc/group`.
- `chezmoi` is built with [`goreleaser`](https://github.com/goreleaser/goreleaser.git), which has limited cgo support but this is currently disabled in `chezmoi`'s `.goreleaser.yml` config.

This PR enables cgo on Linux, and reverts the original fix.