### PR TITLE
dirNames: use make for init slice of string

### DIFF
--- a/lib/chezmoi/chezmoi.go
+++ b/lib/chezmoi/chezmoi.go
@@ -50,9 +50,9 @@ func ReturnTemplateFuncError(err error) {
 
 // dirNames returns the dir names from dirAttributes.
 func dirNames(dirAttributes []DirAttributes) []string {
-	dns := []string{}
-	for _, da := range dirAttributes {
-		dns = append(dns, da.Name)
+	dns := make([]string, len(dirAttributes))
+	for i, da := range dirAttributes {
+		dns[i] = da.Name
 	}
 	return dns
 }


### PR DESCRIPTION
Hi! I little refactoring of the `dirNames` method. Use `make` method for allocations of slice with known size instead allocation without defined size