### PR TITLE
Hide / display commands based on availability

### DIFF
--- a/cmd/bitwarden.go
+++ b/cmd/bitwarden.go
@@ -25,13 +25,16 @@ type bitwardenCommandConfig struct {
 var bitwardenCache = make(map[string]interface{})
 
 func init() {
-	rootCommand.AddCommand(bitwardenCommand)
-
-	persistentFlags := rootCommand.PersistentFlags()
-	persistentFlags.StringVar(&config.Bitwarden.Session, "bitwarden-session", "", "bitwarden session")
-
 	config.Bitwarden.BW = "bw"
 	config.addFunc("bitwarden", config.bitwardenFunc)
+
+	_, err := exec.LookPath(config.Bitwarden.BW)
+	if err == nil {
+		// bw is installed
+		rootCommand.AddCommand(bitwardenCommand)
+		persistentFlags := rootCommand.PersistentFlags()
+		persistentFlags.StringVar(&config.Bitwarden.Session, "bitwarden-session", "", "bitwarden session")
+	}
 }
 
 func (c *Config) runBitwardenCommand(fs vfs.FS, args []string) error {

--- a/cmd/lastpass.go
+++ b/cmd/lastpass.go
@@ -31,9 +31,13 @@ type LastPassCommandConfig struct {
 var lastPassCache = make(map[string]interface{})
 
 func init() {
-	rootCommand.AddCommand(lastpassCommand)
 	config.LastPass.Lpass = "lpass"
 	config.addFunc("lastpass", config.lastpassFunc)
+	_, err := exec.LookPath(config.LastPass.Lpass)
+	if err == nil {
+		// lpass is installed
+		rootCommand.AddCommand(lastpassCommand)
+	}
 }
 
 func (c *Config) runLastPassCommand(fs vfs.FS, args []string) error {

--- a/cmd/vault.go
+++ b/cmd/vault.go
@@ -13,7 +13,7 @@ import (
 
 var vaultCommand = &cobra.Command{
 	Use:   "vault",
-	Short: "Execute the Vault CLI",
+	Short: "Execute the Hashicorp Vault CLI",
 	RunE:  makeRunE(config.runVaultCommand),
 }
 
@@ -24,10 +24,14 @@ type vaultCommandConfig struct {
 var vaultCache = make(map[string]interface{})
 
 func init() {
-	rootCommand.AddCommand(vaultCommand)
-
 	config.Vault.Vault = "vault"
 	config.addFunc("vault", config.vaultFunc)
+
+	_, err := exec.LookPath(config.Vault.Vault)
+	if err == nil {
+		// vault is installed
+		rootCommand.AddCommand(vaultCommand)
+	}
 }
 
 func (c *Config) runVaultCommand(fs vfs.FS, args []string) error {


### PR DESCRIPTION
Fix #134 

Only display subcommands that have the necessary binary installed.

Verified using `vault`:

```
 ~/git/go/src/github.com/twpayne/chezmoi >> feature/supported_cmds $ go build -o cmoi
 ~/git/go/src/github.com/twpayne/chezmoi >> feature/supported_cmds $ ./cmoi -h
Manage your dotfiles securely across multiple machines

Usage:
  chezmoi [command]

Available Commands:
  add         Add an existing file, directory, or symlink to the source state
  apply       Update the destination directory to match the target state
  archive     Write a tar archive of the target state to stdout
  cat         Write the target state of a file or symlink to stdout
  cd          Launch a shell in the source directory
  chattr      Change the attributes of a target in the source state
  data        Write the template data to stdout
  diff        Write the diff between the target state and the destination state to stdout
  dump        Write a dump of the target state to stdout
  edit        Edit the source state of a target
  edit-config Edit the configuration file
  forget      Remove a target from the source state
  help        Help about any command
  import      Import a tar archive into the source state
  keyring     Interact with keyring
  remove      Remove a target from the source state and the destination directory
  source      Run the source version control system command in the source directory
  source-path Print the path of a target in the source state
  verify      Exit with success if the destination state matches the target state, fail otherwise

Flags:
  -c, --config string        config file (default "/Users/kkirsche/.config/chezmoi/chezmoi.yaml")
  -D, --destination string   destination directory (default "/Users/kkirsche")
  -n, --dry-run              dry run
  -h, --help                 help for chezmoi
  -S, --source string        source directory (default "/Users/kkirsche/.local/share/chezmoi")
  -u, --umask int            umask (default 022)
  -v, --verbose              verbose
      --version              version for chezmoi

Use "chezmoi [command] --help" for more information about a command.
 ~/git/go/src/github.com/twpayne/chezmoi >> feature/supported_cmds $ brew install vault
Updating Homebrew...
==> Auto-updated Homebrew!
Updated 2 taps (homebrew/core and homebrew/cask).
==> Updated Formulae
exploitdb                     grpc                          mackup                        openconnect

==> Downloading https://homebrew.bintray.com/bottles/vault-0.11.5.mojave.bottle.tar.gz
######################################################################## 100.0%
==> Pouring vault-0.11.5.mojave.bottle.tar.gz
🍺  /usr/local/Cellar/vault/0.11.5: 6 files, 91.0MB
 ~/git/go/src/github.com/twpayne/chezmoi >> feature/supported_cmds $ ./cmoi -h
Manage your dotfiles securely across multiple machines

Usage:
  chezmoi [command]

Available Commands:
  add         Add an existing file, directory, or symlink to the source state
  apply       Update the destination directory to match the target state
  archive     Write a tar archive of the target state to stdout
  cat         Write the target state of a file or symlink to stdout
  cd          Launch a shell in the source directory
  chattr      Change the attributes of a target in the source state
  data        Write the template data to stdout
  diff        Write the diff between the target state and the destination state to stdout
  dump        Write a dump of the target state to stdout
  edit        Edit the source state of a target
  edit-config Edit the configuration file
  forget      Remove a target from the source state
  help        Help about any command
  import      Import a tar archive into the source state
  keyring     Interact with keyring
  remove      Remove a target from the source state and the destination directory
  source      Run the source version control system command in the source directory
  source-path Print the path of a target in the source state
  vault       Execute the Hashicorp Vault CLI
  verify      Exit with success if the destination state matches the target state, fail otherwise

Flags:
  -c, --config string        config file (default "/Users/kkirsche/.config/chezmoi/chezmoi.yaml")
  -D, --destination string   destination directory (default "/Users/kkirsche")
  -n, --dry-run              dry run
  -h, --help                 help for chezmoi
  -S, --source string        source directory (default "/Users/kkirsche/.local/share/chezmoi")
  -u, --umask int            umask (default 022)
  -v, --verbose              verbose
      --version              version for chezmoi

Use "chezmoi [command] --help" for more information about a command.
```