### PR TITLE
Add support for "secret" command namespace

### DIFF
--- a/cmd/bitwarden.go
+++ b/cmd/bitwarden.go
@@ -31,7 +31,7 @@ func init() {
 	_, err := exec.LookPath(config.Bitwarden.BW)
 	if err == nil {
 		// bw is installed
-		rootCommand.AddCommand(bitwardenCommand)
+		secretCommand.AddCommand(bitwardenCommand)
 		persistentFlags := rootCommand.PersistentFlags()
 		persistentFlags.StringVar(&config.Bitwarden.Session, "bitwarden-session", "", "bitwarden session")
 	}

--- a/cmd/lastpass.go
+++ b/cmd/lastpass.go
@@ -36,7 +36,7 @@ func init() {
 	_, err := exec.LookPath(config.LastPass.Lpass)
 	if err == nil {
 		// lpass is installed
-		rootCommand.AddCommand(lastpassCommand)
+		secretCommand.AddCommand(lastpassCommand)
 	}
 }
 

--- a/cmd/pass.go
+++ b/cmd/pass.go
@@ -24,7 +24,7 @@ type PassCommandConfig struct {
 var passCache = make(map[string]string)
 
 func init() {
-	rootCommand.AddCommand(passCommand)
+	secretCommand.AddCommand(passCommand)
 	config.Pass.Pass = "pass"
 	config.addFunc("pass", config.passFunc)
 }

--- a/cmd/secret.go
+++ b/cmd/secret.go
@@ -1,0 +1,13 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+var secretCommand = &cobra.Command{
+	Use:   "secret",
+	Args:  cobra.NoArgs,
+	Short: "Interact with a secret manager",
+}
+
+func init() {
+	rootCommand.AddCommand(secretCommand)
+}

--- a/cmd/vault.go
+++ b/cmd/vault.go
@@ -30,7 +30,7 @@ func init() {
 	_, err := exec.LookPath(config.Vault.Vault)
 	if err == nil {
 		// vault is installed
-		rootCommand.AddCommand(vaultCommand)
+		secretCommand.AddCommand(vaultCommand)
 	}
 }
 


### PR DESCRIPTION
Fix #141 

Adds support for secret namespace:

```
 ~/git/go/src/github.com/twpayne/chezmoi >> enhancement/secret_toplevel $ go build -o cmoi
 ~/git/go/src/github.com/twpayne/chezmoi >> enhancement/secret_toplevel $ ./cmoi secretInteract with a secret manager

Usage:
  chezmoi secret [command]

Available Commands:
  pass        Execute the pass CLI
  vault       Execute the Hashicorp Vault CLI

Flags:
  -h, --help   help for secret

Global Flags:
  -c, --config string        config file (default "/Users/kkirsche/.config/chezmoi/chezmoi.yaml")
  -D, --destination string   destination directory (default "/Users/kkirsche")
  -n, --dry-run              dry run
  -S, --source string        source directory (default "/Users/kkirsche/.local/share/chezmoi")
  -u, --umask int            umask (default 022)
  -v, --verbose              verbose

Use "chezmoi secret [command] --help" for more information about a command.
 ~/git/go/src/github.com/twpayne/chezmoi >> enhancement/secret_toplevel $ ./cmoi secret vault -h
Execute the Hashicorp Vault CLI

Usage:
  chezmoi secret vault [flags]

Flags:
  -h, --help   help for vault

Global Flags:
  -c, --config string        config file (default "/Users/kkirsche/.config/chezmoi/chezmoi.yaml")
  -D, --destination string   destination directory (default "/Users/kkirsche")
  -n, --dry-run              dry run
  -S, --source string        source directory (default "/Users/kkirsche/.local/share/chezmoi")
  -u, --umask int            umask (default 022)
  -v, --verbose              verbose
```