### PR TITLE
Init command

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,16 @@ For a full list of commands run:
 
     $ chezmoi help
 
+## Setting up from existing source
+
+If you put your source directory under version control you will eventually want
+to check it out on another host. `chezmoi` can do this for you and make sure all
+directory permissions are setup correctly:
+
+    $ chezmoi init git@github.com:example/dotfiles.git
+    
+Like all other commands, `chezmoi init` also accepts the `-v` (verbose) and `-n`
+(dry run) flag. 
 
 ## Using templates to manage files that vary from machine to machine
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Manage your dotfiles securely across multiple machines.
 
 ## Features
 
- * Secure: `chezmoi` can retreive secrets from
+ * Secure: `chezmoi` can retrieve secrets from
    [1Password](https://1password.com/), [Bitwarden](https://bitwarden.com/),
 [LastPass](https://lastpass.com/), [pass](https://www.passwordstore.org/),
 [Vault](https://www.vaultproject.io/), your Keychain (on macOS), [GNOME
@@ -23,7 +23,7 @@ variables allow you to change behaviour depending on operating system,
 architecture, and hostname. You can share as much configuration across machines
 as you want, while still being able to control machine-specific details.
 
- * Personal: Nothing leaves your machine, unlesss you want it to. You can use
+ * Personal: Nothing leaves your machine, unless you want it to. You can use
    the version control system of your choice to manage your configuration, and
 you can write the configuration file in the format of your choice.
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -45,6 +45,7 @@ type Config struct {
 	data             dataCommandConfig
 	dump             dumpCommandConfig
 	edit             editCommandConfig
+	init             initCommandConfig
 	_import          importCommandConfig
 	keyring          keyringCommandConfig
 }
@@ -111,6 +112,22 @@ func (c *Config) exec(argv []string) error {
 		return nil
 	}
 	return syscall.Exec(path, argv, os.Environ())
+}
+
+// execCmd is like exec but without doing a syscall.
+func (c *Config) execCmd(name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	if c.Verbose {
+		fmt.Printf("exec %s %s\n", name, strings.Join(args, " "))
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stdout
+	}
+
+	if c.DryRun {
+		return nil
+	}
+
+	return cmd.Run()
 }
 
 func (c *Config) execEditor(argv ...string) error {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,0 +1,176 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/twpayne/chezmoi/lib/chezmoi"
+	"github.com/twpayne/go-vfs"
+	"os"
+	"path/filepath"
+)
+
+// initCmd represents the init command
+var initCommand = &cobra.Command{
+	Args:  cobra.ExactArgs(1),
+	Use:   "init <repo URL>",
+	Short: "Initial setup of the source directory then update the destination directory to match the target state",
+	Long: `Initial setup of the source directory then update the destination directory to match the target state.
+
+This command is supposed to run once when you want to setup your dotfiles on a
+new host. It will clone the given repository into your source directory (see --source flag)
+and make sure that all directory permissions are correct.
+
+After your source directory was checked out and setup (e.g. git submodules) this
+command will automatically invoke the "apply" command to update the destination
+directory. You can use the --no-apply flag to prevent this from happening.
+`,
+	Example: `
+  # Checkout from github using the public HTTPS API
+  chezmoi init https://github.com/example/dotfiles.git
+
+  # Checkout from github using your private key
+  chezmoi init git@github.com:example/dotfiles.git
+`,
+	RunE: makeRunE(config.runInitCommand),
+}
+
+type initCommandConfig struct {
+	noApply bool
+}
+
+func init() {
+	rootCommand.AddCommand(initCommand)
+
+	persistentFlags := initCommand.PersistentFlags()
+	persistentFlags.BoolVar(&config.init.noApply, "no-apply", false, "do not update destination directory")
+}
+
+func (c *Config) runInitCommand(fs vfs.FS, args []string) error {
+	mutator := c.getDefaultMutator(fs)
+	err := c.initSourceParentDirs(fs, mutator)
+	if err != nil {
+		return err
+	}
+
+	err = c.checkoutSourceDir(fs, mutator, args[0])
+	if err != nil {
+		return err
+	}
+
+	if config.init.noApply {
+		fmt.Println("Did not update target directory (--no-apply)")
+		return nil
+	}
+
+	fmt.Printf("Updating target directory %q\n", c.DestDir)
+	ts, err := c.getTargetState(fs)
+	return ts.Apply(fs, mutator)
+}
+
+func (c *Config) initSourceParentDirs(fs vfs.FS, mutator chezmoi.Mutator) error {
+	dirMode := os.FileMode(0700)
+	parts := splitPath(c.SourceDir)
+	parts = parts[:len(parts)-1] // all parent directories of the source directory
+
+	var createdDir string
+	for _, path := range parts {
+		_, err := fs.Stat(path)
+		switch {
+		case os.IsNotExist(err):
+			createdDir = path
+			err = mutator.Mkdir(path, dirMode)
+			if err != nil {
+				return err
+			}
+		case err != nil:
+			return err
+		}
+	}
+
+	if createdDir != "" {
+		fmt.Printf("Created source directory %q with file mode 0%o (%v) \n", createdDir, dirMode, dirMode)
+	}
+
+	return nil
+}
+
+func (c *Config) checkoutSourceDir(fs vfs.FS, mutator chezmoi.Mutator, repo string) error {
+	fmt.Printf("Checking out dotfiles repository %q into %q\n", repo, c.SourceDir)
+
+	vcsCmd := c.SourceVCSCommand
+	if vcsCmd == "" {
+		vcsCmd = "git"
+	}
+
+	var args []string
+	switch vcsCmd {
+	case "git", "hg":
+		args = []string{"clone", repo, c.SourceDir}
+	case "test":
+		// While "test" isn't actually checking out anything, this command is
+		// used to unit test this function and potentially for debugging.
+		vcsCmd = "echo"
+		args = []string{"-n", "clone", repo, c.SourceDir}
+		err := mutator.Mkdir(c.SourceDir, 0777)
+		if err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("VCS command %q is not yet support in chezmoi init", c.SourceVCSCommand)
+	}
+
+	err := c.execCmd(vcsCmd, args...)
+	if err != nil {
+		return err
+	}
+
+	err = mutator.Chmod(c.SourceDir, 0700)
+	if err != nil {
+		return err
+	}
+
+	if info, err := fs.Stat(filepath.Join(c.SourceDir, ".gitmodules")); err == nil && !info.IsDir() {
+		return c.initSourceSubmodules()
+	}
+
+	return nil
+}
+
+func (c *Config) initSourceSubmodules() error {
+	fmt.Printf("Initializing git submodules in %q\n", c.SourceDir)
+
+	if c.Verbose {
+		fmt.Printf("cd %s\n", c.SourceDir)
+	}
+
+	if !c.DryRun {
+		if err := os.Chdir(c.SourceDir); err != nil {
+			return err
+		}
+	}
+
+	err := c.execCmd("git", "submodule", "init")
+	if err != nil {
+		return err
+	}
+
+	return c.execCmd("git", "submodule", "update")
+}
+
+func splitPath(p string) []string {
+	dirs := []string{p}
+
+	dir := filepath.Dir(p)
+	for dir != string(filepath.Separator) {
+		dirs = append(dirs, dir)
+		dir = filepath.Dir(dir)
+	}
+
+	// reverse dirs slice (i.e. order by path length in ascending order)
+	for i := 0; i < len(dirs)/2; i++ {
+		j := len(dirs) - i - 1 // index from the end of dirs
+		dirs[i], dirs[j] = dirs[j], dirs[i]
+	}
+
+	return dirs
+}

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/twpayne/go-vfs/vfst"
+)
+
+func TestInit(t *testing.T) {
+	c := &Config{
+		SourceDir:        "/home/user/.local/share/chezmoi",
+		DestDir:          "/home/user",
+		SourceVCSCommand: "test", // hack to work around untestable Config.exec(…)
+		Umask:            022,
+		DryRun:           false,
+		Verbose:          true,
+	}
+	fs, cleanup, err := vfst.NewTestFS(map[string]interface{}{
+		"/home/user":          &vfst.Dir{Perm: 0755},
+		"/home/user/.chezmoi": &vfst.Dir{Perm: 0700},
+		"/home/user/.bashrc":  "# contents of .bashrc\n",
+	})
+	defer cleanup()
+	if err != nil {
+		t.Fatalf("vfst.NewTestFS(_) == _, _, %v, want _, _, <nil>", err)
+	}
+	args := []string{"git@github.com:example/dotfiles.git"}
+	if err := c.runInitCommand(fs, args); err != nil {
+		t.Errorf("c.runInitCommand(fs, nil, %+v) == %v, want <nil>", args, err)
+	}
+	vfst.RunTests(t, fs, "",
+		vfst.TestPath("/home/user/.local",
+			vfst.TestIsDir,
+			vfst.TestModePerm(0700),
+		),
+		vfst.TestPath("/home/user/.local/share",
+			vfst.TestIsDir,
+			vfst.TestModePerm(0700),
+		),
+		vfst.TestPath("/home/user/.local/share/chezmoi",
+			vfst.TestIsDir,
+			vfst.TestModePerm(0700),
+		),
+	)
+}


### PR DESCRIPTION
This PR implements the change I proposed in #170 

I had some problems testing it because of the exec that is required during init (for git commands). I wanted to avoid any bigger refactoring so I ended up not using the existing `Config.exec` function but instead provide a different one that does not use `syscall.Exec`.

Another noteworthy thing here is that I also made the `chezmoi init` command apply the source dir in order to avoid always having to run `chezmoi init  … && chezmoi apply`). I left a flag to opt out but I think its up to you to decide if that flag is really required or should be removed to reduce the surface of the CLI. 