### PR TITLE
Fix typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ variables allow you to change behaviour depending on operating system,
 architecture, and hostname. You can share as much configuration across machines
 as you want, while still being able to control machine-specific details.
 
- * Secure: `chezmoi` can retreive secrets from
+ * Secure: `chezmoi` can retrieve secrets from
    [1Password](https://1password.com/), [Bitwarden](https://bitwarden.com/),
 [LastPass](https://lastpass.com/), [pass](https://www.passwordstore.org/),
 [Vault](https://www.vaultproject.io/), your Keychain (on macOS), [GNOME
@@ -23,7 +23,7 @@ Keyring](https://wiki.gnome.org/Projects/GnomeKeyring) (on Linux), or any
 command-line utility of your choice. You can checkout your dotfiles repo on as
 many machines as you want without revealing any secrets to anyone.
 
- * Personal: Nothing leaves your machine, unlesss you want it to. You can use
+ * Personal: Nothing leaves your machine, unless you want it to. You can use
    the version control system of your choice to manage your configuration, and
 you can write the configuration file in the format of your choice.
 


### PR DESCRIPTION
These are the typo fixes from #174 rebased on `master`.