### PR TITLE
Fix dump command with targets

### DIFF
--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -54,7 +54,7 @@ func (c *Config) runDumpCmd(fs vfs.FS, args []string) error {
 			if err != nil {
 				return err
 			}
-			if concreteValue != nil {
+			if entryConcreteValue != nil {
 				concreteValues = append(concreteValues, entryConcreteValue)
 			}
 		}


### PR DESCRIPTION
Before this fix, running `chezmoi dump target` would always print `null`.