### PR TITLE
WIP: Script execution

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -57,6 +57,7 @@ type Config struct {
 	data          dataCmdConfig
 	dump          dumpCmdConfig
 	edit          editCmdConfig
+	editScripts   editScriptsCmdConfig
 	init          initCmdConfig
 	_import       importCmdConfig
 	keyring       keyringCmdConfig

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -62,6 +62,7 @@ type Config struct {
 	keyring       keyringCmdConfig
 	update        updateCmdConfig
 	upgrade       upgradeCmdConfig
+	scripts       scriptsCmdConfig
 	stdin         io.Reader
 	stdout        io.Writer
 	stderr        io.Writer

--- a/cmd/edit-script.go
+++ b/cmd/edit-script.go
@@ -1,0 +1,76 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/twpayne/chezmoi/lib/chezmoi"
+	vfs "github.com/twpayne/go-vfs"
+)
+
+var editScriptsCmd = &cobra.Command{
+	Use:   "edit-scripts scripts",
+	Args:  cobra.MinimumNArgs(1),
+	Short: "Edit scripts in the scripts folder",
+	RunE:  makeRunE(config.runEditScriptCmd),
+}
+
+type editScriptsCmdConfig struct {
+	run    bool
+	prompt bool
+}
+
+func init() {
+	rootCmd.AddCommand(editScriptsCmd)
+
+	persistentFlags := editScriptsCmd.PersistentFlags()
+	persistentFlags.BoolVarP(&config.editScripts.run, "run", "r", false, "run after editing")
+	persistentFlags.BoolVarP(&config.editScripts.prompt, "prompt", "p", false, "prompt before running")
+}
+
+func (c *Config) runEditScriptCmd(fs vfs.FS, args []string) error {
+	ts, err := c.getTargetState(fs)
+	if err != nil {
+		return err
+	}
+	//entries, err := c.getEntries(ts, args)
+	var scripts []*chezmoi.Script
+	for _, arg := range args {
+		if s, ok := ts.Scripts[chezmoi.StripTemplateExtension(arg)]; ok {
+			scripts = append(scripts, s)
+		}
+	}
+	println(scripts)
+	argv := []string{}
+	for _, s := range scripts {
+		argv = append(argv, s.SourcePath)
+	}
+	if !c.editScripts.run {
+		return c.execEditor(argv...)
+	}
+	if err := c.runEditor(argv...); err != nil {
+		return err
+	}
+
+	for _, s := range scripts {
+		if c.editScripts.prompt {
+			choice, err := prompt(fmt.Sprintf("Apply %s", s.Name), "ynqa")
+			if err != nil {
+				return err
+			}
+			switch choice {
+			case 'y':
+			case 'n':
+				continue
+			case 'q':
+				return nil
+			case 'a':
+				c.editScripts.prompt = false
+			}
+		}
+		if err := s.Apply(c.DestDir, c.DryRun); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cmd/edit-script.go
+++ b/cmd/edit-script.go
@@ -33,14 +33,13 @@ func (c *Config) runEditScriptCmd(fs vfs.FS, args []string) error {
 	if err != nil {
 		return err
 	}
-	//entries, err := c.getEntries(ts, args)
 	var scripts []*chezmoi.Script
 	for _, arg := range args {
 		if s, ok := ts.Scripts[chezmoi.StripTemplateExtension(arg)]; ok {
 			scripts = append(scripts, s)
 		}
 	}
-	println(scripts)
+
 	argv := []string{}
 	for _, s := range scripts {
 		argv = append(argv, s.SourcePath)

--- a/cmd/edit-script.go
+++ b/cmd/edit-script.go
@@ -53,7 +53,7 @@ func (c *Config) runEditScriptCmd(fs vfs.FS, args []string) error {
 
 	for _, s := range scripts {
 		if c.editScripts.prompt {
-			choice, err := prompt(fmt.Sprintf("Apply %s", s.Name), "ynqa")
+			choice, err := c.prompt(fmt.Sprintf("Apply %s", s.Name), "ynqa")
 			if err != nil {
 				return err
 			}

--- a/cmd/scripts.go
+++ b/cmd/scripts.go
@@ -42,16 +42,6 @@ func (c *Config) runScriptsCmd(fs vfs.FS, args []string) error {
 		return ts.ApplyScripts(fs, config.scripts.force)
 	}
 
-	var quit int
-	defer func() {
-		if r := recover(); r != nil {
-			if p, ok := r.(*int); ok && p == &quit {
-				err = nil
-			} else {
-				panic(r)
-			}
-		}
-	}()
 	var scripts []*chezmoi.Script
 	if len(args) == 0 {
 		for _, s := range ts.Scripts {
@@ -68,7 +58,7 @@ func (c *Config) runScriptsCmd(fs vfs.FS, args []string) error {
 					scripts = append(scripts, s)
 				case 'n':
 				case 'q':
-					panic(&quit) // abort vfs.Walk by panicking
+					return nil
 				}
 			} else {
 				scripts = append(scripts, s)
@@ -90,7 +80,7 @@ func (c *Config) runScriptsCmd(fs vfs.FS, args []string) error {
 						scripts = append(scripts, s)
 					case 'n':
 					case 'q':
-						panic(&quit) // abort vfs.Walk by panicking
+						return nil
 					case 'a':
 						c.scripts.prompt = false
 					}

--- a/cmd/scripts.go
+++ b/cmd/scripts.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	vfs "github.com/twpayne/go-vfs"
+)
+
+var scriptsCmd = &cobra.Command{
+	Use:   "scripts [targets...]",
+	Short: "Run scripts that need to run",
+	RunE:  makeRunE(config.runScriptsCmd),
+}
+
+func init() {
+	rootCmd.AddCommand(scriptsCmd)
+}
+
+func (c *Config) runScriptsCmd(fs vfs.FS, args []string) error {
+	ts, err := c.getTargetState(fs)
+	if err != nil {
+		return err
+	}
+	return ts.ApplyScripts()
+}

--- a/cmd/scripts.go
+++ b/cmd/scripts.go
@@ -28,18 +28,13 @@ func init() {
 }
 
 func (c *Config) runScriptsCmd(fs vfs.FS, args []string) error {
-	if config.DryRun {
-		println("chezmoi: the scripts subcommand doesn't support dry-run yet")
-		return nil
-	}
-
 	ts, err := c.getTargetState(fs)
 	if err != nil {
 		return err
 	}
 
 	if len(args) == 0 && !config.scripts.prompt {
-		return ts.ApplyScripts(fs, config.scripts.force)
+		return ts.ApplyScripts(fs, config.scripts.force, c.DryRun)
 	}
 
 	var scripts []*chezmoi.Script
@@ -55,7 +50,7 @@ func (c *Config) runScriptsCmd(fs vfs.FS, args []string) error {
 					c.scripts.prompt = false
 					fallthrough
 				case 'y':
-					if err := s.Apply(); err != nil {
+					if err := s.Apply(c.DestDir, c.DryRun); err != nil {
 						return err
 					}
 				case 'n':
@@ -79,7 +74,7 @@ func (c *Config) runScriptsCmd(fs vfs.FS, args []string) error {
 					}
 					switch choice {
 					case 'y':
-						if err := s.Apply(); err != nil {
+						if err := s.Apply(c.DestDir, c.DryRun); err != nil {
 							return err
 						}
 					case 'n':
@@ -93,7 +88,7 @@ func (c *Config) runScriptsCmd(fs vfs.FS, args []string) error {
 		}
 	}
 	for _, s := range scripts {
-		if err := s.Apply(); err != nil {
+		if err := s.Apply(c.DestDir, c.DryRun); err != nil {
 			return err
 		}
 	}

--- a/cmd/scripts.go
+++ b/cmd/scripts.go
@@ -42,7 +42,6 @@ func (c *Config) runScriptsCmd(fs vfs.FS, args []string) error {
 		return ts.ApplyScripts(fs, config.scripts.force)
 	}
 
-	scripts := make([]*chezmoi.Script, 0)
 	var quit int
 	defer func() {
 		if r := recover(); r != nil {
@@ -53,6 +52,7 @@ func (c *Config) runScriptsCmd(fs vfs.FS, args []string) error {
 			}
 		}
 	}()
+	var scripts []*chezmoi.Script
 	if len(args) == 0 {
 		for _, s := range ts.Scripts {
 			if config.scripts.prompt {

--- a/cmd/scripts.go
+++ b/cmd/scripts.go
@@ -1,7 +1,10 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
+	"github.com/twpayne/chezmoi/lib/chezmoi"
 	vfs "github.com/twpayne/go-vfs"
 )
 
@@ -11,14 +14,94 @@ var scriptsCmd = &cobra.Command{
 	RunE:  makeRunE(config.runScriptsCmd),
 }
 
+type scriptsCmdConfig struct {
+	force  bool
+	prompt bool
+}
+
 func init() {
 	rootCmd.AddCommand(scriptsCmd)
+
+	persistentFlags := scriptsCmd.PersistentFlags()
+	persistentFlags.BoolVarP(&config.scripts.force, "force", "f", false, "run all scripts")
+	persistentFlags.BoolVarP(&config.scripts.prompt, "prompt", "p", false, "prompt before running each script")
 }
 
 func (c *Config) runScriptsCmd(fs vfs.FS, args []string) error {
+	if config.DryRun {
+		println("chezmoi: the scripts subcommand doesn't support dry-run yet")
+		return nil
+	}
+
 	ts, err := c.getTargetState(fs)
 	if err != nil {
 		return err
 	}
-	return ts.ApplyScripts()
+
+	if len(args) == 0 && !config.scripts.prompt {
+		return ts.ApplyScripts(fs, config.scripts.force)
+	}
+
+	scripts := make([]*chezmoi.Script, 0)
+	var quit int
+	defer func() {
+		if r := recover(); r != nil {
+			if p, ok := r.(*int); ok && p == &quit {
+				err = nil
+			} else {
+				panic(r)
+			}
+		}
+	}()
+	if len(args) == 0 {
+		for _, s := range ts.Scripts {
+			if config.scripts.prompt {
+				choice, err := c.prompt(fmt.Sprintf("Run %s", s.Name), "ynqa")
+				if err != nil {
+					return err
+				}
+				switch choice {
+				case 'a':
+					c.scripts.prompt = false
+					fallthrough
+				case 'y':
+					scripts = append(scripts, s)
+				case 'n':
+				case 'q':
+					panic(&quit) // abort vfs.Walk by panicking
+				}
+			} else {
+				scripts = append(scripts, s)
+			}
+		}
+	} else {
+		for _, arg := range args {
+			s, ok := ts.Scripts[chezmoi.StripTemplateExtension(arg)]
+			if ok {
+				if !config.scripts.prompt {
+					scripts = append(scripts, s)
+				} else {
+					choice, err := c.prompt(fmt.Sprintf("Run %s", s.Name), "ynqa")
+					if err != nil {
+						return err
+					}
+					switch choice {
+					case 'y':
+						scripts = append(scripts, s)
+					case 'n':
+					case 'q':
+						panic(&quit) // abort vfs.Walk by panicking
+					case 'a':
+						c.scripts.prompt = false
+					}
+				}
+			}
+		}
+	}
+	for _, s := range scripts {
+		if err := s.Apply(); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/cmd/scripts.go
+++ b/cmd/scripts.go
@@ -55,7 +55,9 @@ func (c *Config) runScriptsCmd(fs vfs.FS, args []string) error {
 					c.scripts.prompt = false
 					fallthrough
 				case 'y':
-					scripts = append(scripts, s)
+					if err := s.Apply(); err != nil {
+						return err
+					}
 				case 'n':
 				case 'q':
 					return nil
@@ -77,7 +79,9 @@ func (c *Config) runScriptsCmd(fs vfs.FS, args []string) error {
 					}
 					switch choice {
 					case 'y':
-						scripts = append(scripts, s)
+						if err := s.Apply(); err != nil {
+							return err
+						}
 					case 'n':
 					case 'q':
 						return nil

--- a/lib/chezmoi/chezmoi.go
+++ b/lib/chezmoi/chezmoi.go
@@ -21,6 +21,7 @@ const (
 	executablePrefix = "executable_"
 	dotPrefix        = "dot_"
 	TemplateSuffix   = ".tmpl"
+	scriptsDir       = ".scripts"
 )
 
 // A templateFuncError is an error encountered while executing a template
@@ -94,6 +95,15 @@ func sortedEntryNames(entries map[string]Entry) []string {
 	}
 	sort.Strings(entryNames)
 	return entryNames
+}
+
+func sortedScriptNames(entries map[string]*Script) []string {
+	scriptNames := []string{}
+	for scriptName := range entries {
+		scriptNames = append(scriptNames, scriptName)
+	}
+	sort.Strings(scriptNames)
+	return scriptNames
 }
 
 func splitPathList(path string) []string {

--- a/lib/chezmoi/chezmoi.go
+++ b/lib/chezmoi/chezmoi.go
@@ -112,3 +112,12 @@ func splitPathList(path string) []string {
 	}
 	return strings.Split(path, string(filepath.Separator))
 }
+
+// StripTemplateExtension removes the template extension at the end of the passed filename
+func StripTemplateExtension(name string) string {
+	i := strings.LastIndex(name, TemplateSuffix)
+	if i > 0 {
+		return name[0:i]
+	}
+	return name
+}

--- a/lib/chezmoi/chezmoi.go
+++ b/lib/chezmoi/chezmoi.go
@@ -115,9 +115,5 @@ func splitPathList(path string) []string {
 
 // StripTemplateExtension removes the template extension at the end of the passed filename
 func StripTemplateExtension(name string) string {
-	i := strings.LastIndex(name, TemplateSuffix)
-	if i > 0 {
-		return name[0:i]
-	}
-	return name
+	return strings.TrimSuffix(name, TemplateSuffix)
 }

--- a/lib/chezmoi/scripts.go
+++ b/lib/chezmoi/scripts.go
@@ -28,8 +28,7 @@ func (s *Script) Apply(destDir string, dryRun bool) error {
 		return nil
 	}
 
-	s.Contents()
-	if s.contentsErr != nil {
+	if _, err := s.Contents(); err != nil {
 		return s.contentsErr
 	}
 

--- a/lib/chezmoi/scripts.go
+++ b/lib/chezmoi/scripts.go
@@ -9,19 +9,12 @@ import (
 	"regexp"
 )
 
-var shebangRegex *regexp.Regexp
-var onceRegex *regexp.Regexp
-
-func init() {
-	shebangRegex = regexp.MustCompile(`(?m)^#!([^;\n]+)$`)
-	onceRegex = regexp.MustCompile(`(?m)^#\s*chezmoi:\s*once$`)
-}
+var onceRegex = regexp.MustCompile(`(?m)^#\s*chezmoi:\s*once$`)
 
 // Script is a script supposed to run.
 type Script struct {
 	Name             string
 	SourcePath       string
-	executor         string
 	once             bool
 	alreadyExecuted  bool
 	contents         []byte
@@ -55,11 +48,6 @@ func (s *Script) parse() error {
 	if s.contentsErr != nil {
 		return s.contentsErr
 	}
-	reg := shebangRegex.FindStringSubmatch(string(s.contents))
-	if len(reg) < 2 {
-		return fmt.Errorf("Shebang missing in script \"%s\"", s.Name)
-	}
-	s.executor = string(reg[1])
 	s.once = onceRegex.Match(s.contents)
 	return nil
 }

--- a/lib/chezmoi/scripts.go
+++ b/lib/chezmoi/scripts.go
@@ -76,6 +76,7 @@ func (s *Script) execute() error {
 		return err
 	}
 	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
 
 	go func() {
 		defer in.Close()

--- a/lib/chezmoi/scripts.go
+++ b/lib/chezmoi/scripts.go
@@ -20,7 +20,7 @@ func init() {
 // Script is a script supposed to run.
 type Script struct {
 	Name             string
-	sourcePath       string
+	SourcePath       string
 	executor         string
 	once             bool
 	alreadyExecuted  bool
@@ -79,7 +79,7 @@ func (s *Script) execute(destDir string) error {
 	}
 	c := exec.Command(f.Name())
 	c.Dir = destDir
-	c.Env = append(os.Environ(), "CHEZMOI_SCRIPT_DIR="+path.Dir(s.sourcePath))
+	c.Env = append(os.Environ(), "CHEZMOI_SCRIPT_DIR="+path.Dir(s.SourcePath))
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
 	c.Stdin = os.Stdin

--- a/lib/chezmoi/scripts.go
+++ b/lib/chezmoi/scripts.go
@@ -1,0 +1,97 @@
+package chezmoi
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"regexp"
+	"strings"
+)
+
+var shebangRegex *regexp.Regexp
+var onceRegex *regexp.Regexp
+
+func init() {
+	shebangRegex = regexp.MustCompile(`(?m)^#!([^;\n]+)$`)
+	onceRegex = regexp.MustCompile(`(?m)^#\s*chezmoi:\s*once$`)
+}
+
+// Script is a script supposed to run
+type Script struct {
+	name             string
+	sourcePath       string
+	executor         string
+	once             bool
+	alreadyExecuted  bool
+	contents         []byte
+	contentsErr      error
+	evaluateContents func() ([]byte, error)
+}
+
+func toScriptName(name string) string {
+	i := strings.LastIndex(name, TemplateSuffix)
+	if i > 0 {
+		return name[0:i]
+	}
+	return name
+}
+
+// Apply executes the script if necessary to reach target state
+func (s *Script) Apply() error {
+	if s.once && s.alreadyExecuted {
+		return nil
+	}
+
+	s.Contents()
+	if s.contentsErr != nil {
+		return s.contentsErr
+	}
+
+	if err := s.parse(); err != nil {
+		return err
+	}
+	fmt.Printf("chezmoi: Running script %s\n", s.name)
+	return s.execute()
+}
+
+func (s *Script) parse() error {
+	if s.contentsErr != nil {
+		return s.contentsErr
+	}
+	reg := shebangRegex.FindStringSubmatch(string(s.contents))
+	if len(reg) < 2 {
+		return fmt.Errorf("Shebang missing in script \"%s\"", s.name)
+	}
+	s.executor = string(reg[1])
+	s.once = onceRegex.Match(s.contents)
+	return nil
+}
+
+func (s *Script) execute() error {
+	c := exec.Command(s.executor)
+	c.Dir = path.Dir(s.sourcePath)
+	in, err := c.StdinPipe()
+	if err != nil {
+		return err
+	}
+	c.Stdout = os.Stdout
+
+	go func() {
+		defer in.Close()
+		if _, err := in.Write(s.contents); err != nil {
+			panic(err)
+		}
+	}()
+
+	return c.Run()
+}
+
+// Contents returns f's contents.
+func (s *Script) Contents() ([]byte, error) {
+	if s.evaluateContents != nil {
+		s.contents, s.contentsErr = s.evaluateContents()
+		s.evaluateContents = nil
+	}
+	return s.contents, s.contentsErr
+}

--- a/lib/chezmoi/scripts.go
+++ b/lib/chezmoi/scripts.go
@@ -17,7 +17,7 @@ func init() {
 	onceRegex = regexp.MustCompile(`(?m)^#\s*chezmoi:\s*once$`)
 }
 
-// Script is a script supposed to run
+// Script is a script supposed to run.
 type Script struct {
 	Name             string
 	sourcePath       string
@@ -29,7 +29,7 @@ type Script struct {
 	evaluateContents func() ([]byte, error)
 }
 
-// Apply executes the script if necessary to reach target state
+// Apply executes the script if necessary to reach target state.
 func (s *Script) Apply() error {
 	if s.once && s.alreadyExecuted {
 		return nil

--- a/lib/chezmoi/scripts.go
+++ b/lib/chezmoi/scripts.go
@@ -79,6 +79,7 @@ func (s *Script) execute(destDir string) error {
 	}
 	c := exec.Command(f.Name())
 	c.Dir = destDir
+	c.Env = append(os.Environ(), "CHEZMOI_SCRIPT_DIR="+path.Dir(s.sourcePath))
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
 	c.Stdin = os.Stdin

--- a/lib/chezmoi/scripts.go
+++ b/lib/chezmoi/scripts.go
@@ -38,7 +38,7 @@ func (s *Script) Apply(destDir string, dryRun bool) error {
 	}
 	fmt.Printf("chezmoi: Running script %s\n", s.Name)
 	if dryRun {
-		println(string(s.contents), "\n")
+		fmt.Print(string(s.contents), "\n\n")
 		return nil
 	}
 	return s.execute(destDir)

--- a/lib/chezmoi/scripts.go
+++ b/lib/chezmoi/scripts.go
@@ -87,3 +87,11 @@ func (s *Script) Contents() ([]byte, error) {
 	}
 	return s.contents, s.contentsErr
 }
+
+// Evaluate evaluates s's script.
+func (s *Script) Evaluate() error {
+	if _, err := s.Contents(); err != nil {
+		return err
+	}
+	return s.parse()
+}

--- a/lib/chezmoi/scripts.go
+++ b/lib/chezmoi/scripts.go
@@ -80,6 +80,7 @@ func (s *Script) execute() error {
 	}
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
+	c.Stdin = os.Stdin
 
 	return c.Run()
 }

--- a/lib/chezmoi/scripts.go
+++ b/lib/chezmoi/scripts.go
@@ -6,7 +6,6 @@ import (
 	"os/exec"
 	"path"
 	"regexp"
-	"strings"
 )
 
 var shebangRegex *regexp.Regexp
@@ -19,7 +18,7 @@ func init() {
 
 // Script is a script supposed to run
 type Script struct {
-	name             string
+	Name             string
 	sourcePath       string
 	executor         string
 	once             bool
@@ -27,14 +26,6 @@ type Script struct {
 	contents         []byte
 	contentsErr      error
 	evaluateContents func() ([]byte, error)
-}
-
-func toScriptName(name string) string {
-	i := strings.LastIndex(name, TemplateSuffix)
-	if i > 0 {
-		return name[0:i]
-	}
-	return name
 }
 
 // Apply executes the script if necessary to reach target state
@@ -51,7 +42,7 @@ func (s *Script) Apply() error {
 	if err := s.parse(); err != nil {
 		return err
 	}
-	fmt.Printf("chezmoi: Running script %s\n", s.name)
+	fmt.Printf("chezmoi: Running script %s\n", s.Name)
 	return s.execute()
 }
 
@@ -61,7 +52,7 @@ func (s *Script) parse() error {
 	}
 	reg := shebangRegex.FindStringSubmatch(string(s.contents))
 	if len(reg) < 2 {
-		return fmt.Errorf("Shebang missing in script \"%s\"", s.name)
+		return fmt.Errorf("Shebang missing in script \"%s\"", s.Name)
 	}
 	s.executor = string(reg[1])
 	s.once = onceRegex.Match(s.contents)

--- a/lib/chezmoi/targetstate.go
+++ b/lib/chezmoi/targetstate.go
@@ -168,7 +168,7 @@ func (ts *TargetState) Apply(fs vfs.FS, mutator Mutator) error {
 }
 
 // ApplyScripts that scripts get executed as required
-func (ts *TargetState) ApplyScripts() error {
+func (ts *TargetState) ApplyScripts(fs vfs.FS, force bool) error {
 	for _, scriptName := range sortedScriptNames(ts.Scripts) {
 		if err := ts.Scripts[scriptName].Apply(); err != nil {
 			return err
@@ -437,11 +437,11 @@ func (ts *TargetState) populateScripts(fs vfs.FS) error {
 				}
 			}
 			s := &Script{
-				name:             toScriptName(f.Name()),
+				Name:             StripTemplateExtension(f.Name()),
 				sourcePath:       fp,
 				evaluateContents: evaluateContents,
 			}
-			ts.Scripts[s.name] = s
+			ts.Scripts[s.Name] = s
 		}
 	}
 	return nil

--- a/lib/chezmoi/targetstate.go
+++ b/lib/chezmoi/targetstate.go
@@ -443,7 +443,7 @@ func (ts *TargetState) populateScripts(fs vfs.FS) error {
 			}
 			s := &Script{
 				Name:             StripTemplateExtension(f.Name()),
-				sourcePath:       fp,
+				SourcePath:       fp,
 				evaluateContents: evaluateContents,
 			}
 			ts.Scripts[s.Name] = s

--- a/lib/chezmoi/targetstate.go
+++ b/lib/chezmoi/targetstate.go
@@ -210,6 +210,11 @@ func (ts *TargetState) Archive(w *tar.Writer, umask os.FileMode) error {
 			return err
 		}
 	}
+	for _, scriptName := range sortedScriptNames(ts.Scripts) {
+		if err := ts.Scripts[scriptName].Evaluate(); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/lib/chezmoi/targetstate.go
+++ b/lib/chezmoi/targetstate.go
@@ -258,6 +258,11 @@ func (ts *TargetState) Evaluate() error {
 			return err
 		}
 	}
+	for _, scriptName := range sortedScriptNames(ts.Scripts) {
+		if err := ts.Scripts[scriptName].Evaluate(); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/lib/chezmoi/targetstate.go
+++ b/lib/chezmoi/targetstate.go
@@ -168,9 +168,9 @@ func (ts *TargetState) Apply(fs vfs.FS, mutator Mutator) error {
 }
 
 // ApplyScripts that scripts get executed as required
-func (ts *TargetState) ApplyScripts(fs vfs.FS, force bool) error {
+func (ts *TargetState) ApplyScripts(fs vfs.FS, force bool, dryRun bool) error {
 	for _, scriptName := range sortedScriptNames(ts.Scripts) {
-		if err := ts.Scripts[scriptName].Apply(); err != nil {
+		if err := ts.Scripts[scriptName].Apply(ts.DestDir, dryRun); err != nil {
 			return err
 		}
 	}

--- a/lib/chezmoi/targetstate_test.go
+++ b/lib/chezmoi/targetstate_test.go
@@ -133,6 +133,7 @@ func TestTargetStatePopulate(t *testing.T) {
 						contents:   []byte("bar"),
 					},
 				},
+				Scripts: map[string]*Script{},
 			},
 		},
 		{
@@ -154,6 +155,7 @@ func TestTargetStatePopulate(t *testing.T) {
 						contents:   []byte("bar"),
 					},
 				},
+				Scripts: map[string]*Script{},
 			},
 		},
 		{
@@ -175,6 +177,7 @@ func TestTargetStatePopulate(t *testing.T) {
 						contents:   []byte("bar"),
 					},
 				},
+				Scripts: map[string]*Script{},
 			},
 		},
 		{
@@ -204,6 +207,7 @@ func TestTargetStatePopulate(t *testing.T) {
 						},
 					},
 				},
+				Scripts: map[string]*Script{},
 			},
 		},
 		{
@@ -233,6 +237,7 @@ func TestTargetStatePopulate(t *testing.T) {
 						},
 					},
 				},
+				Scripts: map[string]*Script{},
 			},
 		},
 		{
@@ -261,6 +266,7 @@ func TestTargetStatePopulate(t *testing.T) {
 						contents:   []byte("[user]\n\temail = user@example.com\n"),
 					},
 				},
+				Scripts: map[string]*Script{},
 			},
 		},
 		{
@@ -290,6 +296,7 @@ func TestTargetStatePopulate(t *testing.T) {
 						},
 					},
 				},
+				Scripts: map[string]*Script{},
 			},
 		},
 		{
@@ -310,6 +317,7 @@ func TestTargetStatePopulate(t *testing.T) {
 						linkname:   "bar",
 					},
 				},
+				Scripts: map[string]*Script{},
 			},
 		},
 		{
@@ -330,6 +338,7 @@ func TestTargetStatePopulate(t *testing.T) {
 						linkname:   "bar",
 					},
 				},
+				Scripts: map[string]*Script{},
 			},
 		},
 		{
@@ -357,6 +366,7 @@ func TestTargetStatePopulate(t *testing.T) {
 						linkname:   "bar-example.com",
 					},
 				},
+				Scripts: map[string]*Script{},
 			},
 		},
 		{
@@ -380,6 +390,7 @@ func TestTargetStatePopulate(t *testing.T) {
 				Umask:     0,
 				SourceDir: "/",
 				Entries:   map[string]Entry{},
+				Scripts:   map[string]*Script{},
 			},
 		},
 		{
@@ -410,6 +421,7 @@ func TestTargetStatePopulate(t *testing.T) {
 						Entries:    map[string]Entry{},
 					},
 				},
+				Scripts: map[string]*Script{},
 			},
 		},
 		{

--- a/lib/chezmoi/targetstate_test.go
+++ b/lib/chezmoi/targetstate_test.go
@@ -466,8 +466,7 @@ func TestTargetStatePopulate(t *testing.T) {
 				Scripts: map[string]*Script{
 					"test.sh": &Script{
 						Name:       "test.sh",
-						sourcePath: "/.scripts/test.sh",
-						executor:   "/bin/bash",
+						SourcePath: "/.scripts/test.sh",
 						once:       false,
 						contents:   []byte("#!/bin/bash\necho test"),
 					},
@@ -510,8 +509,7 @@ func TestTargetStatePopulate(t *testing.T) {
 				Scripts: map[string]*Script{
 					"test.sh": &Script{
 						Name:       "test.sh",
-						sourcePath: "/.scripts/test.sh",
-						executor:   "/bin/bash",
+						SourcePath: "/.scripts/test.sh",
 						once:       true,
 						contents:   []byte("#!/bin/bash\n#chezmoi: once\necho test"),
 					},
@@ -542,8 +540,7 @@ func TestTargetStatePopulate(t *testing.T) {
 				Scripts: map[string]*Script{
 					"test.sh": &Script{
 						Name:       "test.sh",
-						sourcePath: "/.scripts/test.sh.tmpl",
-						executor:   "/bin/bash",
+						SourcePath: "/.scripts/test.sh.tmpl",
 						contents:   []byte("#!/bin/bash\necho user@example.com"),
 					},
 				},


### PR DESCRIPTION
I was previously using Ben Alman's [dotfiles](github.com/cowboy/dotfiles), which contain an "init" step. It basically executes a few scripts that are in a directory. It has a prompt that allows disabling and enabling scripts before execution each time his `dotfiles` script is run.
It was very useful for stuff that can't be handled by copying files, like installing some tools or OS configuration.

As I was missing that feature in chezmoi, I started adding it. I know the contributing guidelines recommend to open an issue first, but I had time today and wanted to write some go.

The features I had in mind:
- A specific directory that contains scripts in the chezmoi source folder (`.scripts`, as that get's ignored and is good name)
- All scripts directly within that folder get detected (no recursion)
- Scripts run either once or every time the subcommand is called (currently configured by adding `#chezmoi: once` to the script)
- Template support, also to handle different operating systems

I've added a subcommand called `scripts` that runs all scripts. It supports passing a list of scripts to run as well as the `--prompt` flag.
Scripts are ran with the binary defined using a Shebang (`#!`) within the script.
Scripts support the template syntax, like all files do. This allows to handle different OSes and so on.
The "run once" feature isn't implemented yet, and because of that the `--force` flag isn't either.

I've opened this PR mainly to get feedback on the Idea itself, as well as some open decisions & future ideas I have:
- To allow single execution chezmoi needs to remember whether a script was executed already. I'm not sure how & where to store that, I was thinking in an extra file next to the local config.
- Whether the name of the scripts folder should be configurable (probably yes)
- How to handle dry-runs (maybe by just outputting the templated script?)
- A `edit-script` command to edit scripts
- adding os(<osname>) to the `#chezmoi:` to limit it to the specified os

Tests are also missing.