### PR TITLE
Fix for #227 - Add ppc64 and ppc64le targets

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -69,6 +69,8 @@ nfpm:
   formats:
     - deb
     - rpm
+  dependencies:
+    - git
   overrides:
     rpm:
       name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Env.TRAVIS_BUILD_NUMBER }}-{{ .Arch }}"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -21,6 +21,8 @@ builds:
     - amd64
     - arm
     - arm64
+    - ppc64
+    - ppc64le
   goarm:
     - ''
   ignore:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing
 
 `chezmoi` development happens on Github. When contributing, please first [open
-an issue](https://github.com/twpayne/dotfiles/issues/new) to discuss the change
+an issue](https://github.com/twpayne/chezmoi/issues/new) to discuss the change
 that you want to make. Bug reports and documentation improvements are
 particularly welcome.
 


### PR DESCRIPTION
Updates goreleaser to target ppc64 and ppc64le. I've run the build on my machine using the command below and it generates working binaries.

```bash
TRAVIS_BUILD_NUMBER=1 goreleaser --snapshot --rm-dist --debug --skip-publish
```

Note that I'm using go 1.12.1 on Gentoo to compile.

I also made a minor tweak to the contributing guide as it linked to the issues page for a different repo.

Closes #227 
