### PR TITLE
Implement config file creation from template during init command

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -59,6 +59,7 @@ type Config struct {
 	stdin         io.Reader
 	stdout        io.Writer
 	stderr        io.Writer
+	bds           *xdg.BaseDirectorySpecification
 }
 
 var (

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,12 +1,20 @@
 package cmd
 
 import (
+	"bufio"
+	"bytes"
 	"fmt"
+	"io"
+	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
+	"text/template"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	vfs "github.com/twpayne/go-vfs"
+	"github.com/twpayne/go-vfs/vfst"
 )
 
 var initCmd = &cobra.Command{
@@ -96,12 +104,148 @@ func (c *Config) runInitCmd(fs vfs.FS, args []string) error {
 				}
 			}
 		}
-		if c.init.apply {
-			if err := c.applyArgs(fs, nil, mutator); err != nil {
-				return err
-			}
+	}
+
+	if err := c.createConfigFile(fs); err != nil {
+		return err
+	}
+
+	if c.init.apply {
+		if err := c.applyArgs(fs, nil, mutator); err != nil {
+			return err
 		}
 	}
 
 	return nil
+}
+
+func (c *Config) createConfigFile(fs vfs.FS) error {
+	templatePath, extension, err := c.findConfigTemplate(fs)
+	if err != nil {
+		return fmt.Errorf("failed to lookup config template: %v", err)
+	}
+
+	if templatePath == "" {
+		// no config template file exists
+		return nil
+	}
+
+	fmt.Fprintf(c.Stdout(), "Creating new configuration file from template %q\n", templatePath)
+	configDir := c.bds.ConfigHome
+	if _, err := fs.Stat(configDir); os.IsNotExist(err) {
+		err = fs.Mkdir(configDir, 0775)
+		if err != nil {
+			return fmt.Errorf("failed to create config directory %q: %v", configDir, err)
+		}
+	}
+
+	configDir = filepath.Join(configDir, "chezmoi")
+	if _, err := fs.Stat(configDir); os.IsNotExist(err) {
+		err = fs.Mkdir(configDir, 0775)
+		if err != nil {
+			return fmt.Errorf("failed to create chezmoi config directory %q: %v", configDir, err)
+		}
+	}
+
+	data, err := fs.ReadFile(templatePath)
+	if err != nil {
+		return fmt.Errorf("failed to read config template: %v", err)
+	}
+
+	t := template.New(templatePath)
+	funcs := c.templateFuncs
+	if funcs == nil {
+		funcs = template.FuncMap{}
+	}
+
+	funcs["promptString"] = c.promptString
+	t.Funcs(funcs)
+
+	t, err = t.Parse(string(data))
+	if err != nil {
+		return fmt.Errorf("failed to parse config template: %v", err)
+	}
+
+	contents := new(bytes.Buffer)
+	err = t.Execute(contents, nil)
+	if err != nil {
+		return fmt.Errorf("failed to execute config template: %v", err)
+	}
+
+	configFile := filepath.Join(configDir, "chezmoi."+extension)
+
+	if c.DryRun {
+		fmt.Fprintf(c.Stdout(), "Would have written the following configuration file to %q\n", configFile)
+		fmt.Fprint(c.Stdout(), contents.String())
+		return nil
+	} else {
+		fmt.Fprintf(c.Stdout(), "Writing configuration file to %q\n", configFile)
+		err = fs.WriteFile(configFile, contents.Bytes(), 0644)
+		if err != nil {
+			return fmt.Errorf("failed to write config file: %v", err)
+		}
+	}
+
+	// The last step is to reload the configuration so it can be used directly
+	// if we want to apply the dotfiles. In unit tests the fs is typically a
+	// *vfst.TestFS that actually operates in a temporary directory. Thus we
+	// have to find the full absolute path to the configuration file now so
+	// viper can load the correct configuration.
+	if tfs, ok := fs.(*vfst.TestFS); ok {
+		configFile = filepath.Join(tfs.TempDir(), configFile)
+	}
+
+	err = loadConfigFile(configFile, c)
+	if err != nil {
+		return fmt.Errorf("failed to reload config file: %v", err)
+	}
+
+	return nil
+}
+
+func (c *Config) findConfigTemplate(fs vfs.FS) (path, extension string, err error) {
+	files, err := fs.ReadDir(c.SourceDir)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to open directory %q: %v", c.SourceDir, err)
+	}
+
+	extensions := viper.SupportedExts
+	for i, ext := range extensions {
+		extensions[i] = regexp.QuoteMeta(ext)
+	}
+
+	re := regexp.MustCompile(fmt.Sprintf(`^\.chezmoi\.(%s)\.tmpl$`,
+		strings.Join(extensions, "|"),
+	))
+
+	for _, f := range files {
+		name := f.Name()
+		matches := re.FindStringSubmatch(name)
+		if matches == nil {
+			continue
+		}
+
+		ext := matches[1]
+		return filepath.Join(c.SourceDir, name), ext, nil
+	}
+
+	return "", "", nil
+}
+
+func (c *Config) promptString(field string) string {
+	reader := bufio.NewReader(c.Stdin())
+	for {
+		fmt.Fprintf(c.Stdout(), "Enter value for field %q: ", field)
+		val, err := reader.ReadString('\n')
+		if err == io.EOF {
+			fmt.Fprintf(c.Stdout(), "ERROR: failed to read input from stdin: EOF\n")
+			os.Exit(1) // TODO?
+		}
+		if err != nil {
+			fmt.Fprintf(c.Stdout(), "ERROR: %v: \n", err)
+			continue
+		}
+
+		return val[:len(val)-1] // strip trailing newline
+	}
 }

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -1,0 +1,82 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/twpayne/go-vfs/vfst"
+	xdg "github.com/twpayne/go-xdg/v3"
+)
+
+func TestCreateConfigFile(t *testing.T) {
+	path := "/home/user/.local/share/chezmoi/.chezmoi.yaml.tmpl"
+	content := `
+{{- $email := promptString "email" }}
+data:
+    email: "{{ $email }}"
+    mailtoURL: "mailto:{{ $email }}"
+`
+
+	fs, cleanup, err := vfst.NewTestFS(map[string]interface{}{path: content}, vfst.BuilderVerbose(true))
+	require.NoError(t, err)
+	defer cleanup()
+
+	out := testingWriter{t}
+	in := new(bytes.Buffer)
+	in.WriteString("grace.hopper@example.com\n")
+
+	conf := &Config{
+		SourceDir: "/home/user/.local/share/chezmoi",
+		stdout:    out,
+		stdin:     in,
+		bds:       &xdg.BaseDirectorySpecification{ConfigHome: "/home/user/.config"},
+	}
+
+	err = conf.createConfigFile(fs)
+	require.NoError(t, err)
+
+	expected := `
+data:
+    email: "grace.hopper@example.com"
+    mailtoURL: "mailto:grace.hopper@example.com"
+`
+
+	expectedPath := "/home/user/.config/chezmoi/chezmoi.yaml"
+	actual, err := fs.ReadFile(expectedPath)
+	if os.IsNotExist(err) {
+		t.Fatalf("Configuration file was not written to %q", expectedPath)
+	}
+
+	require.NoError(t, err)
+	assert.Equal(t, expected, string(actual))
+
+	s, err := fs.Stat(expectedPath)
+	require.NoError(t, err)
+	assert.Equal(t, "-rw-r--r--", s.Mode().String(), "bad file mode")
+
+	// Make sure we are loading the config that we just created
+	assert.Equal(t, map[string]interface{}{
+		"email":     "grace.hopper@example.com",
+		"mailtourl": "mailto:grace.hopper@example.com",
+	}, conf.Data)
+}
+
+// The testingWriter implements io.Writer by sending all written bytes to the
+// testing.T log.
+type testingWriter struct {
+	*testing.T
+}
+
+func (w testingWriter) Write(data []byte) (int, error) {
+	msg := string(data)
+	if msg[len(msg)-1] == '\n' {
+		// The Log function of the testing.T automatically adds a newline
+		msg = msg[:len(msg)-1]
+	}
+
+	w.Log(msg)
+	return len(data), nil
+}


### PR DESCRIPTION
This implements using a config file template to bootstrap config files during `chezmoi init` as discussed via #241 

I did my best to cover this with tests but currently its not really possible to test the entire init command end to end. Instead I chose to test the config creation part that I added in isolation so no big refactoring was required.

Cheers