### PR TITLE
Add merge command

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -40,6 +40,7 @@ type Config struct {
 	Verbose       bool
 	GPGRecipient  string
 	SourceVCS     sourceVCSConfig
+	Merge         mergeConfig
 	Bitwarden     bitwardenCmdConfig
 	GenericSecret genericSecretCmdConfig
 	Lastpass      lastpassCmdConfig
@@ -287,6 +288,10 @@ func (c *Config) run(dir, name string, argv ...string) error {
 
 func (c *Config) runEditor(argv ...string) error {
 	return c.run("", c.getEditor(), argv...)
+}
+
+func (c *Config) warn(s string) {
+	fmt.Fprintf(c.Stderr(), "warning: %s\n", s)
 }
 
 func getDefaultConfigFile(bds *xdg.BaseDirectorySpecification) string {

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -1,0 +1,92 @@
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"github.com/twpayne/chezmoi/lib/chezmoi"
+	vfs "github.com/twpayne/go-vfs"
+)
+
+var mergeCmd = &cobra.Command{
+	Use:   "merge targets...",
+	Args:  cobra.MinimumNArgs(1),
+	Short: "Perform a three-way merge between the destination state, the source state, and the target state",
+	RunE:  makeRunE(config.runMergeCmd),
+}
+
+type mergeConfig struct {
+	Command string
+	Args    []string
+}
+
+func init() {
+	rootCmd.AddCommand(mergeCmd)
+}
+
+func (c *Config) runMergeCmd(fs vfs.FS, args []string) error {
+	ts, err := c.getTargetState(fs)
+	if err != nil {
+		return err
+	}
+
+	entries, err := c.getEntries(fs, ts, args)
+	if err != nil {
+		return err
+	}
+
+	// Create a temporary directory to store the target state and ensure that it
+	// is removed afterwards. We cannot use fs as it lacks TempDir
+	// functionality.
+	tempDir, err := ioutil.TempDir("", "chezmoi")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tempDir)
+
+	for i, entry := range entries {
+		if err := c.runMergeCommand(args[i], entry, tempDir); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *Config) runMergeCommand(arg string, entry chezmoi.Entry, tempDir string) error {
+	file, ok := entry.(*chezmoi.File)
+	if !ok {
+		return fmt.Errorf("%s: not a file", arg)
+	}
+
+	// By default, perform a two-way merge between the destination state and the
+	// source state.
+	args := append(
+		append([]string{}, c.Merge.Args...),
+		filepath.Join(c.DestDir, file.TargetName()),
+		filepath.Join(c.SourceDir, file.SourceName()),
+	)
+
+	// Try to evaluate the target state. If this succeeds, perform a three-way
+	// merge between the destination state, the source state, and the target
+	// state. Target state evaluation might fail if the source state contains
+	// template errors or cannot be decrypted.
+	if contents, err := file.Contents(); err != nil {
+		c.warn(fmt.Sprintf("%s: cannot evaluate target state: %v", arg, err))
+	} else {
+		targetStatePath := filepath.Join(tempDir, filepath.Base(file.TargetName()))
+		if err := ioutil.WriteFile(targetStatePath, contents, 0600); err != nil {
+			return err
+		}
+		args = append(args, targetStatePath)
+	}
+
+	if err := c.run("", c.Merge.Command, args...); err != nil {
+		return fmt.Errorf("%s: %v", arg, err)
+	}
+
+	return nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,6 +17,9 @@ var (
 		SourceVCS: sourceVCSConfig{
 			Command: "git",
 		},
+		Merge: mergeConfig{
+			Command: "vimdiff",
+		},
 		templateFuncs: sprig.HermeticTxtFuncMap(),
 	}
 	version = "dev"


### PR DESCRIPTION
Fixes #224.

This PR adds a merge command that invokes `merge.command` to do a three-way merge between the destination state, the source state, and the target state.

`merge.command` defaults to `vimdiff`. You can set a different one in your config file, for example (in TOML):

```toml
[merge]
  command = "gvimdiff"
  args = ["-f"]
```

cc @markstos