### PR TITLE
Update mercurial support

### DIFF
--- a/cmd/vcsinfos.go
+++ b/cmd/vcsinfos.go
@@ -33,8 +33,9 @@ var vcsInfos = map[string]*vcsInfo{
 			return []string{"clone", repo, dir}
 		},
 		initArgs:      []string{"init"},
+		pullArgs:      []string{"pull", "--rebase", "--update"},
 		versionArgs:   []string{"version"},
-		versionRegexp: regexp.MustCompile(`^Mercurial Distributed SCM \(version (\d+\.\d+\.\d+\))`),
+		versionRegexp: regexp.MustCompile(`^Mercurial Distributed SCM \(version (\d+\.\d+(\.\d+)?\))`),
 	},
 	"svn": {
 		versionArgs:   []string{"--version"},


### PR DESCRIPTION
This addresses the Mercurial portion of #179.

- Adds support for `hg pull`, allowing `chezmoi update` to work on a
Mercurial repo.
- Updates the `hg` version regex to allow a 2-component version

My Mercurial install (Fedora package) has only two components to the
version number, which the version regex would not catch:
```
% hg --version
Mercurial Distributed SCM (version 4.9)
```

Verified new `hg pull` support by making and committing a change on
another checkout of the repo, seeing `go run main.go update`
successfully run, and see the updated content in the file changed.