### PR TITLE
Fixed typo in 1Password instructions

### DIFF
--- a/docs/HOWTO.md
+++ b/docs/HOWTO.md
@@ -299,7 +299,7 @@ expose data as a template function.
 
 Log in and get a session using:
 
-    eval $(op login <subdomain>.1password.com <email>)
+    eval $(op signin <subdomain>.1password.com <email>)
 
 The structured data from `op get item <uuid>` is available as the `onepassword`
 template function, for example:


### PR DESCRIPTION
Current instructions result in this
```
 eval $(op login <subdomain>.1password.com <email>)
-bash: unexpected EOF while looking for matching `''
-bash: syntax error: unexpected end of file
```
correct instruction below result in user being prompted for Secret Key:

`eval $(op signin <subdomain>.1password.com <email>)`