### PR TITLE
Add script support

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -33,39 +33,40 @@ type sourceVCSConfig struct {
 
 // A Config represents a configuration.
 type Config struct {
-	configFile    string
-	err           error
-	SourceDir     string
-	DestDir       string
-	Umask         permValue
-	DryRun        bool
-	Verbose       bool
-	Color         string
-	GPGRecipient  string
-	SourceVCS     sourceVCSConfig
-	Merge         mergeConfig
-	Bitwarden     bitwardenCmdConfig
-	GenericSecret genericSecretCmdConfig
-	Lastpass      lastpassCmdConfig
-	Onepassword   onepasswordCmdConfig
-	Vault         vaultCmdConfig
-	Pass          passCmdConfig
-	Data          map[string]interface{}
-	colored       bool
-	templateFuncs template.FuncMap
-	add           addCmdConfig
-	data          dataCmdConfig
-	dump          dumpCmdConfig
-	edit          editCmdConfig
-	init          initCmdConfig
-	_import       importCmdConfig
-	keyring       keyringCmdConfig
-	update        updateCmdConfig
-	upgrade       upgradeCmdConfig
-	stdin         io.Reader
-	stdout        io.Writer
-	stderr        io.Writer
-	bds           *xdg.BaseDirectorySpecification
+	configFile      string
+	err             error
+	SourceDir       string
+	DestDir         string
+	Umask           permValue
+	DryRun          bool
+	Verbose         bool
+	Color           string
+	GPGRecipient    string
+	SourceVCS       sourceVCSConfig
+	Merge           mergeConfig
+	Bitwarden       bitwardenCmdConfig
+	GenericSecret   genericSecretCmdConfig
+	Lastpass        lastpassCmdConfig
+	Onepassword     onepasswordCmdConfig
+	Vault           vaultCmdConfig
+	Pass            passCmdConfig
+	Data            map[string]interface{}
+	colored         bool
+	persistentState chezmoi.PersistentState
+	templateFuncs   template.FuncMap
+	add             addCmdConfig
+	data            dataCmdConfig
+	dump            dumpCmdConfig
+	edit            editCmdConfig
+	init            initCmdConfig
+	_import         importCmdConfig
+	keyring         keyringCmdConfig
+	update          updateCmdConfig
+	upgrade         upgradeCmdConfig
+	stdin           io.Reader
+	stdout          io.Writer
+	stderr          io.Writer
+	bds             *xdg.BaseDirectorySpecification
 }
 
 var (
@@ -130,20 +131,24 @@ func (c *Config) applyArgs(fs vfs.FS, args []string, mutator chezmoi.Mutator) er
 	if err != nil {
 		return err
 	}
+	applyOptions := &chezmoi.ApplyOptions{
+		DestDir:         ts.DestDir,
+		DryRun:          c.DryRun,
+		Ignore:          ts.TargetIgnore.Match,
+		PersistentState: c.persistentState,
+		Stdout:          c.Stdout(),
+		Umask:           ts.Umask,
+		Verbose:         c.Verbose,
+	}
 	if len(args) == 0 {
-		return ts.Apply(fs, mutator)
+		return ts.Apply(fs, mutator, applyOptions)
 	}
 	entries, err := c.getEntries(fs, ts, args)
 	if err != nil {
 		return err
 	}
-	applyOptions := chezmoi.ApplyOptions{
-		DestDir: ts.DestDir,
-		Ignore:  ts.TargetIgnore.Match,
-		Umask:   ts.Umask,
-	}
 	for _, entry := range entries {
-		if err := entry.Apply(fs, mutator, &applyOptions); err != nil {
+		if err := entry.Apply(fs, mutator, applyOptions); err != nil {
 			return err
 		}
 	}
@@ -389,6 +394,16 @@ func getDefaultSourceDir(bds *xdg.BaseDirectorySpecification) string {
 	}
 	// Fallback to XDG Base Directory Specification default.
 	return filepath.Join(bds.DataHome, "chezmoi")
+}
+
+func getPersistentStateFile(bds *xdg.BaseDirectorySpecification, configFile string) string {
+	for _, configDir := range bds.ConfigDirs {
+		persistentStateFile := filepath.Join(configDir, "chezmoi", "chezmoistate.boltdb")
+		if _, err := os.Stat(persistentStateFile); err == nil {
+			return persistentStateFile
+		}
+	}
+	return filepath.Join(filepath.Dir(configFile), "chezmoistate.boltdb")
 }
 
 // isWellKnownAbbreviation returns true if word is a well known abbreviation.

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -137,8 +137,13 @@ func (c *Config) applyArgs(fs vfs.FS, args []string, mutator chezmoi.Mutator) er
 	if err != nil {
 		return err
 	}
+	applyOptions := chezmoi.ApplyOptions{
+		DestDir: ts.DestDir,
+		Ignore:  ts.TargetIgnore.Match,
+		Umask:   ts.Umask,
+	}
 	for _, entry := range entries {
-		if err := entry.Apply(fs, ts.DestDir, ts.TargetIgnore.Match, ts.Umask, mutator); err != nil {
+		if err := entry.Apply(fs, mutator, &applyOptions); err != nil {
 			return err
 		}
 	}

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -133,13 +133,20 @@ func (c *Config) runEditCmd(fs vfs.FS, args []string) error {
 
 	readOnlyFS := vfs.NewReadOnlyFS(fs)
 	applyMutator := c.getDefaultMutator(fs)
+	applyOptions := chezmoi.ApplyOptions{
+		DestDir: ts.DestDir,
+		DryRun:  c.DryRun,
+		Ignore:  ts.TargetIgnore.Match,
+		Umask:   ts.Umask,
+		Verbose: c.Verbose,
+	}
 	for i, entry := range entries {
 		anyMutator := chezmoi.NewAnyMutator(chezmoi.NullMutator)
 		var mutator chezmoi.Mutator = anyMutator
 		if c.edit.diff {
 			mutator = chezmoi.NewLoggingMutator(c.Stdout(), mutator, c.colored)
 		}
-		if err := entry.Apply(readOnlyFS, ts.DestDir, ts.TargetIgnore.Match, ts.Umask, mutator); err != nil {
+		if err := entry.Apply(readOnlyFS, mutator, &applyOptions); err != nil {
 			return err
 		}
 		if c.edit.apply && anyMutator.Mutated() {
@@ -158,7 +165,7 @@ func (c *Config) runEditCmd(fs vfs.FS, args []string) error {
 					c.edit.prompt = false
 				}
 			}
-			if err := entry.Apply(readOnlyFS, ts.DestDir, ts.TargetIgnore.Match, ts.Umask, applyMutator); err != nil {
+			if err := entry.Apply(readOnlyFS, applyMutator, &applyOptions); err != nil {
 				return err
 			}
 		}

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -137,6 +137,7 @@ func (c *Config) runEditCmd(fs vfs.FS, args []string) error {
 		DestDir: ts.DestDir,
 		DryRun:  c.DryRun,
 		Ignore:  ts.TargetIgnore.Match,
+		Stdout:  c.Stdout(),
 		Umask:   ts.Umask,
 		Verbose: c.Verbose,
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,6 +9,7 @@ import (
 	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"github.com/twpayne/chezmoi/lib/chezmoi"
 	vfs "github.com/twpayne/go-vfs"
 	xdg "github.com/twpayne/go-xdg/v3"
 )
@@ -94,6 +95,12 @@ func init() {
 		if config.err != nil {
 			config.warn(fmt.Sprintf("%s: %v", config.configFile, config.err))
 		}
+		persistentStateFile := getPersistentStateFile(config.bds, config.configFile)
+		persistentState, err := chezmoi.NewBoltPersistentState(vfs.OSFS, persistentStateFile)
+		if err != nil {
+			printErrorAndExit(err)
+		}
+		config.persistentState = persistentState
 	})
 }
 

--- a/docs/HOWTO.md
+++ b/docs/HOWTO.md
@@ -13,6 +13,7 @@
   * [Use Vault to keep your secrets](#use-vault-to-keep-your-secrets)
   * [Use a generic tool to keep your secrets](#use-a-generic-tool-to-keep-your-secrets)
   * [Use templates variables to keep your secrets](#use-templates-variables-to-keep-your-secrets)
+* [Run extra commands during chezmoi apply](#run-extra-commands-during-chezmoi-apply)
 * [Import archives](#import-archives)
 * [Export archives](#export-archives)
 * [Use non-git version control systems](#use-non-git-version-control-systems)
@@ -372,6 +373,35 @@ Your `~/.local/share/chezmoi/private_dot_gitconfig.tmpl` can then contain:
 
 Any config files containing tokens in plain text should be private (permissions
 `0600`).
+
+## Run extra commands during chezmoi apply
+
+chezmoi includes support for scripts which are run each time `chezmoi apply` is
+run. These can be useful for installing packages or performing other
+machine-specific configuration. Scripts are run in the destination directory and
+should be idempotent.
+
+Scripts must be created manually in the source directory and have the
+prefix `run_`. For example:
+
+    $ chezmoi cd
+    $ cat > run_echo_hello
+    #!/bin/sh
+    echo hello
+    <Ctrl-D>
+    $ chezmoi apply
+    hello
+
+If a script has the suffix `.tmpl` then it is expanded as a template before
+being executed.
+
+In verbose mode, the script's contents will be printed before executing it. In
+dry-run mode, the script is not executed.
+
+If you want a script to only run once, then give it the prefix `run_once_`.
+chezmoi will remember when it has executed a script and will only run it again
+if its name (excluding any `run_once_` prefix and `.tmpl` suffix) changes, or if
+its contents change.
 
 ## Import archives
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -175,16 +175,18 @@ special, and are collectively referred to as "attributes":
 | Prefix/suffix        | Effect                                                                            |
 | -------------------- | ----------------------------------------------------------------------------------|
 | `encrypted_` prefix  | Encrypt the file in the source state.                                             |
+| `once_` prefix       | Only run script once.                                                             |
 | `private_` prefix    | Remove all group and world permissions from the target file or directory.         |
 | `empty_` prefix      | Ensure the file exists, even if is empty. By default, empty files are removed.    |
 | `exact_` prefix      | Remove anything not managed by chezmoi.                                           |
 | `executable_` prefix | Add executable permissions to the target file.                                    |
+| `run_` prefix        | Treat the contents as a script to run.                                            |
 | `symlink_` prefix    | Create a symlink instead of a regular file.                                       |
 | `dot_` prefix        | Rename to use a leading dot, e.g. `dot_foo` becomes `.foo`.                       |
 | `.tmpl` suffix       | Treat the contents of the source file as a template.                              |
 
-Order is important, the order is `exact_`, `private_`, `empty_`, `executable_`,
-`symlink_`, `dot_`, `.tmpl`.
+Order is important, the order is `run_`, `exact_`, `private_`, `empty_`,
+`executable_`, `symlink_`, `once_`, `dot_`, `.tmpl`.
 
 Different target types allow different prefixes and suffixes:
 
@@ -192,6 +194,7 @@ Different target types allow different prefixes and suffixes:
 | ------------- | ------------------------------------------------------------------ |
 | Directory     | `exact_`, `private_`, `dot_`                                       |
 | Regular file  | `encrypted_`, `private_`, `empty_`, `executable_`, `dot_`, `.tmpl` |
+| Script        | `run_`, `once_`, `.tmpl`                                           |
 | Symbolic link | `symlink_`, `dot_`, `.tmpl`                                        |
 
 ## Special files

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/twpayne/go-vfsafero v1.0.0
 	github.com/twpayne/go-xdg/v3 v3.1.0
 	github.com/zalando/go-keyring v0.0.0-20180221093347-6d81c293b3fb
+	go.etcd.io/bbolt v1.3.2
 	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2
 	golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be
 	golang.org/x/sys v0.0.0-20190310054646-10058d7d4faa // indirect
@@ -40,3 +41,9 @@ require (
 // github.com/pmezard/go-difflib is unmaintained, so use a fork that includes
 // colored diff support.
 replace github.com/pmezard/go-difflib => github.com/twpayne/go-difflib v1.2.1
+
+// go.etcd.io/bbolt requires a couple of fixes before it can be used, so use a
+// fork with the fixes. This replace can be removed once
+// https://github.com/etcd-io/bbolt/pull/157 is merged and a new version of
+// go.etcd.io/bbolt is tagged.
+replace go.etcd.io/bbolt => github.com/twpayne/bbolt v1.3.3

--- a/go.sum
+++ b/go.sum
@@ -74,6 +74,8 @@ github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/twpayne/bbolt v1.3.3 h1:JC5FqHl8KI7HttyR7gjlvFubsc4O154EDtn6DqbhXMk=
+github.com/twpayne/bbolt v1.3.3/go.mod h1:LFKuADr6ZLKUTotDQbCSVz/Pl3TFiiQHsFt4Ni86lnw=
 github.com/twpayne/go-difflib v1.2.1 h1:ypoyI4LwrjSBRzuvBph0Iu8Z8tPG4G+D706ym4RXp8w=
 github.com/twpayne/go-difflib v1.2.1/go.mod h1:yDLRCpF455E1uC+kFIFhA4qoJuKg9K2uyEx1/OBNnnw=
 github.com/twpayne/go-shell v0.0.1 h1:Ako3cUeuULhWadYk37jM3FlJ8lkSSW4INBjYj9K60Gw=

--- a/lib/chezmoi/boltpersistentstate.go
+++ b/lib/chezmoi/boltpersistentstate.go
@@ -1,0 +1,119 @@
+package chezmoi
+
+import (
+	"os"
+	"path/filepath"
+
+	vfs "github.com/twpayne/go-vfs"
+	bolt "go.etcd.io/bbolt"
+)
+
+// A BoltPersistentState is a state persisted with bolt.
+type BoltPersistentState struct {
+	fs   vfs.FS
+	path string
+	perm os.FileMode
+	db   *bolt.DB
+}
+
+// NewBoltPersistentState returns a new BoltPersistentState.
+func NewBoltPersistentState(fs vfs.FS, path string) (*BoltPersistentState, error) {
+	b := &BoltPersistentState{
+		fs:   fs,
+		path: path,
+		perm: 0600,
+	}
+	_, err := fs.Stat(b.path)
+	switch {
+	case err == nil:
+		if err := b.openDB(); err != nil {
+			return nil, err
+		}
+	case os.IsNotExist(err):
+	default:
+		return nil, err
+	}
+	return b, nil
+}
+
+// Close closes b.
+func (b *BoltPersistentState) Close() error {
+	if b.db == nil {
+		return nil
+	}
+	if err := b.db.Close(); err != nil {
+		return err
+	}
+	b.db = nil
+	return nil
+}
+
+// Delete deletes the value associate with key in bucket. If bucket or key does
+// not exist then Delete does nothing.
+func (b *BoltPersistentState) Delete(bucket, key []byte) error {
+	if b.db == nil {
+		return nil
+	}
+	return b.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket(bucket)
+		if b == nil {
+			return nil
+		}
+		return b.Delete(key)
+	})
+}
+
+// Get returns the value associated with key in bucket.
+func (b *BoltPersistentState) Get(bucket, key []byte) ([]byte, error) {
+	value := []byte(nil)
+	if b.db == nil {
+		return value, nil
+	}
+	return value, b.db.View(func(tx *bolt.Tx) error {
+		b := tx.Bucket(bucket)
+		if b == nil {
+			return nil
+		}
+		v := b.Get(key)
+		if v != nil {
+			value = make([]byte, len(v))
+			copy(value, v)
+		}
+		return nil
+	})
+}
+
+// Set sets the value associated with key in bucket. bucket will be created if
+// it does not already exist.
+func (b *BoltPersistentState) Set(bucket, key, value []byte) error {
+	if b.db == nil {
+		if err := b.openDB(); err != nil {
+			return err
+		}
+	}
+	return b.db.Update(func(tx *bolt.Tx) error {
+		b, err := tx.CreateBucketIfNotExists(bucket)
+		if err != nil {
+			return err
+		}
+		return b.Put(key, value)
+	})
+}
+
+func (b *BoltPersistentState) openDB() error {
+	parentDir := filepath.Dir(b.path)
+	if _, err := b.fs.Stat(parentDir); os.IsNotExist(err) {
+		if err := vfs.MkdirAll(b.fs, parentDir, 0755); err != nil {
+			return err
+		}
+	}
+	options := &bolt.Options{
+		OpenFile: b.fs.OpenFile,
+	}
+	db, err := bolt.Open(b.path, b.perm, options)
+	if err != nil {
+		return err
+	}
+	b.db = db
+	return err
+}

--- a/lib/chezmoi/boltpersistentstate_test.go
+++ b/lib/chezmoi/boltpersistentstate_test.go
@@ -1,0 +1,72 @@
+package chezmoi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/twpayne/go-vfs/vfst"
+)
+
+var _ PersistentState = &BoltPersistentState{}
+
+func TestBoltPersistentState(t *testing.T) {
+	fs, cleanup, err := vfst.NewTestFS(map[string]interface{}{
+		"/home/user/.config/chezmoi": &vfst.Dir{Perm: 0755},
+	})
+	require.NoError(t, err)
+	defer cleanup()
+
+	path := "/home/user/.config/chezmoi/state.boltdb"
+	b, err := NewBoltPersistentState(fs, path)
+	require.NoError(t, err)
+	vfst.RunTests(t, fs, "",
+		vfst.TestPath(path,
+			vfst.TestDoesNotExist,
+		),
+	)
+
+	var (
+		bucket = []byte("bucket")
+		key    = []byte("key")
+		value  = []byte("value")
+	)
+
+	require.NoError(t, b.Delete(bucket, key))
+	vfst.RunTests(t, fs, "",
+		vfst.TestPath(path,
+			vfst.TestDoesNotExist,
+		),
+	)
+
+	actualValue, err := b.Get(bucket, key)
+	require.NoError(t, err)
+	assert.Equal(t, []byte(nil), actualValue)
+	vfst.RunTests(t, fs, "",
+		vfst.TestPath(path,
+			vfst.TestDoesNotExist,
+		),
+	)
+
+	assert.NoError(t, b.Set(bucket, key, value))
+	vfst.RunTests(t, fs, "",
+		vfst.TestPath(path,
+			vfst.TestModeIsRegular,
+		),
+	)
+
+	actualValue, err = b.Get(bucket, key)
+	require.NoError(t, err)
+	assert.Equal(t, value, actualValue)
+
+	require.NoError(t, b.Close())
+
+	b, err = NewBoltPersistentState(fs, path)
+	require.NoError(t, err)
+
+	require.NoError(t, b.Delete(bucket, key))
+
+	actualValue, err = b.Get(bucket, key)
+	require.NoError(t, err)
+	assert.Equal(t, []byte(nil), actualValue)
+}

--- a/lib/chezmoi/chezmoi.go
+++ b/lib/chezmoi/chezmoi.go
@@ -29,11 +29,21 @@ type templateFuncError struct {
 	err error
 }
 
+// A PersistentState is an interface to a persistent state.
+type PersistentState interface {
+	Delete(bucket, key []byte) error
+	Get(bucket, key []byte) ([]byte, error)
+	Set(bucket, key, value []byte) error
+}
+
 // An ApplyOptions is a big ball of mud for things that affect Entry.Apply.
 type ApplyOptions struct {
-	DestDir string
-	Ignore  func(string) bool
-	Umask   os.FileMode
+	DestDir         string
+	DryRun          bool
+	Ignore          func(string) bool
+	PersistentState PersistentState
+	Umask           os.FileMode
+	Verbose         bool
 }
 
 // An Entry is either a Dir, a File, or a Symlink.

--- a/lib/chezmoi/chezmoi.go
+++ b/lib/chezmoi/chezmoi.go
@@ -81,8 +81,8 @@ func parseSourceFilePath(path string) parsedSourceFilePath {
 	das := parseDirNameComponents(components[0 : len(components)-1])
 	fa := ParseFileAttributes(components[len(components)-1])
 	return parsedSourceFilePath{
-		FileAttributes: fa,
 		dirAttributes:  das,
+		fileAttributes: &fa,
 	}
 }
 

--- a/lib/chezmoi/chezmoi.go
+++ b/lib/chezmoi/chezmoi.go
@@ -29,9 +29,16 @@ type templateFuncError struct {
 	err error
 }
 
+// An ApplyOptions is a big ball of mud for things that affect Entry.Apply.
+type ApplyOptions struct {
+	DestDir string
+	Ignore  func(string) bool
+	Umask   os.FileMode
+}
+
 // An Entry is either a Dir, a File, or a Symlink.
 type Entry interface {
-	Apply(fs vfs.FS, destDir string, ignore func(string) bool, umask os.FileMode, mutator Mutator) error
+	Apply(fs vfs.FS, mutator Mutator, applyOptions *ApplyOptions) error
 	ConcreteValue(destDir string, ignore func(string) bool, sourceDir string, umask os.FileMode, recursive bool) (interface{}, error)
 	Evaluate(ignore func(string) bool) error
 	SourceName() string

--- a/lib/chezmoi/script.go
+++ b/lib/chezmoi/script.go
@@ -1,0 +1,236 @@
+package chezmoi
+
+import (
+	"archive/tar"
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	vfs "github.com/twpayne/go-vfs"
+)
+
+var scriptStateBucket = []byte("script")
+
+// FIXME allow encrypted scripts
+// FIXME add pre- and post- attributes
+
+// A ScriptAttributes holds attributes parsed from a source script name.
+type ScriptAttributes struct {
+	Name     string
+	Once     bool
+	Template bool
+}
+
+// A ScriptState represents the state of a script.
+type ScriptState struct {
+	Name       string    `json:"name"`
+	ExecutedAt time.Time `json:"executedAt"`
+}
+
+// A Script represents a script to run.
+type Script struct {
+	sourceName       string
+	targetName       string
+	Once             bool
+	Template         bool
+	contents         []byte
+	contentsErr      error
+	evaluateContents func() ([]byte, error)
+}
+
+type scriptConcreteValue struct {
+	Type       string `json:"type" yaml:"type"`
+	SourcePath string `json:"sourcePath" yaml:"sourcePath"`
+	TargetPath string `json:"targetPath" yaml:"targetPath"`
+	Once       bool   `json:"once" yaml:"once"`
+	Template   bool   `json:"template" yaml:"template"`
+	Contents   string `json:"contents" yaml:"contents"`
+}
+
+// ParseScriptAttributes parses a source script file name.
+func ParseScriptAttributes(sourceName string) ScriptAttributes {
+	name := strings.TrimPrefix(sourceName, runPrefix)
+	once := false
+	template := false
+	if strings.HasPrefix(name, oncePrefix) {
+		once = true
+		name = strings.TrimPrefix(name, oncePrefix)
+	}
+	if strings.HasSuffix(name, TemplateSuffix) {
+		template = true
+		name = strings.TrimSuffix(name, TemplateSuffix)
+	}
+	return ScriptAttributes{
+		Name:     name,
+		Once:     once,
+		Template: template,
+	}
+}
+
+// SourceName returns sa's source name.
+func (sa ScriptAttributes) SourceName() string {
+	sourceName := runPrefix
+	if sa.Once {
+		sourceName += oncePrefix
+	}
+	sourceName += sa.Name
+	if sa.Template {
+		sourceName += TemplateSuffix
+	}
+	return sourceName
+}
+
+// Apply runs s.
+func (s *Script) Apply(fs vfs.FS, mutator Mutator, applyOptions *ApplyOptions) error {
+	if applyOptions.Ignore(s.targetName) {
+		return nil
+	}
+	contents, err := s.Contents()
+	if err != nil {
+		return err
+	}
+	if len(bytes.TrimSpace(contents)) == 0 {
+		return nil
+	}
+
+	var key []byte
+	if s.Once {
+		contentsKeyArr := sha256.Sum256(contents)
+		key = []byte(s.targetName + ":" + hex.EncodeToString(contentsKeyArr[:]))
+		scriptStateData, err := applyOptions.PersistentState.Get(scriptStateBucket, key)
+		if err != nil {
+			return err
+		}
+		if scriptStateData != nil {
+			return nil
+		}
+	}
+
+	if applyOptions.Verbose {
+		if _, err := applyOptions.Stdout.Write(contents); err != nil {
+			return err
+		}
+	}
+	if applyOptions.DryRun {
+		return nil
+	}
+
+	// Write the temporary script file.
+	f, err := ioutil.TempFile("", filepath.Base(s.targetName))
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = os.RemoveAll(f.Name())
+	}()
+	if err := os.Chmod(f.Name(), 0700); err != nil {
+		return err
+	}
+	if _, err := f.Write(contents); err != nil {
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+
+	// Run the temporary script file.
+	c := exec.Command(f.Name())
+	c.Dir = filepath.Join(applyOptions.DestDir, filepath.Dir(s.targetName))
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	c.Stdin = os.Stdin
+	if err := c.Run(); err != nil {
+		return err
+	}
+
+	if s.Once {
+		scriptState := &ScriptState{
+			Name:       s.sourceName,
+			ExecutedAt: time.Now(),
+		}
+		scriptStateData, err := json.Marshal(&scriptState)
+		if err != nil {
+			return err
+		}
+		if err := applyOptions.PersistentState.Set(scriptStateBucket, key, scriptStateData); err != nil {
+			return err
+		}
+	}
+
+	return err
+}
+
+// ConcreteValue implements Entry.ConcreteValue.
+func (s *Script) ConcreteValue(destDir string, ignore func(string) bool, sourceDir string, umask os.FileMode, recursive bool) (interface{}, error) {
+	if ignore(s.targetName) {
+		return nil, nil
+	}
+	contents, err := s.Contents()
+	if err != nil {
+		return nil, err
+	}
+	return &scriptConcreteValue{
+		Type:       "script",
+		SourcePath: filepath.Join(sourceDir, s.SourceName()),
+		TargetPath: filepath.Join(destDir, s.TargetName()),
+		Once:       s.Once,
+		Template:   s.Template,
+		Contents:   string(contents),
+	}, nil
+}
+
+// Contents returns s's contents.
+func (s *Script) Contents() ([]byte, error) {
+	if s.evaluateContents != nil {
+		s.contents, s.contentsErr = s.evaluateContents()
+		s.evaluateContents = nil
+	}
+	return s.contents, s.contentsErr
+}
+
+// Evaluate evaluates s's contents.
+func (s *Script) Evaluate(ignore func(string) bool) error {
+	if ignore(s.targetName) {
+		return nil
+	}
+	_, err := s.Contents()
+	return err
+}
+
+// SourceName implements Entry.SourceName.
+func (s *Script) SourceName() string {
+	return s.sourceName
+}
+
+// TargetName implements Entry.TargetName.
+func (s *Script) TargetName() string {
+	return s.targetName
+}
+
+// archive writes s to w.
+func (s *Script) archive(w *tar.Writer, ignore func(string) bool, headerTemplate *tar.Header, umask os.FileMode) error {
+	if ignore(s.targetName) {
+		return nil
+	}
+	contents, err := s.Contents()
+	if err != nil {
+		return err
+	}
+	header := *headerTemplate
+	header.Typeflag = tar.TypeReg
+	header.Name = s.targetName
+	header.Size = int64(len(contents))
+	header.Mode = int64(0777 &^ umask)
+	if err := w.WriteHeader(&header); err != nil {
+		return nil
+	}
+	_, err = w.Write(contents)
+	return err
+}

--- a/lib/chezmoi/symlink.go
+++ b/lib/chezmoi/symlink.go
@@ -27,15 +27,15 @@ type symlinkConcreteValue struct {
 }
 
 // Apply ensures that the state of s's target in fs matches s.
-func (s *Symlink) Apply(fs vfs.FS, destDir string, ignore func(string) bool, umask os.FileMode, mutator Mutator) error {
-	if ignore(s.targetName) {
+func (s *Symlink) Apply(fs vfs.FS, mutator Mutator, applyOptions *ApplyOptions) error {
+	if applyOptions.Ignore(s.targetName) {
 		return nil
 	}
 	target, err := s.Linkname()
 	if err != nil {
 		return err
 	}
-	targetPath := filepath.Join(destDir, s.targetName)
+	targetPath := filepath.Join(applyOptions.DestDir, s.targetName)
 	info, err := fs.Lstat(targetPath)
 	switch {
 	case err == nil && info.Mode()&os.ModeType == os.ModeSymlink:

--- a/lib/chezmoi/targetstate.go
+++ b/lib/chezmoi/targetstate.go
@@ -152,8 +152,13 @@ func (ts *TargetState) Add(fs vfs.FS, addOptions AddOptions, targetPath string, 
 
 // Apply ensures that ts.DestDir in fs matches ts.
 func (ts *TargetState) Apply(fs vfs.FS, mutator Mutator) error {
+	applyOptions := ApplyOptions{
+		DestDir: ts.DestDir,
+		Ignore:  ts.TargetIgnore.Match,
+		Umask:   ts.Umask,
+	}
 	for _, entryName := range sortedEntryNames(ts.Entries) {
-		if err := ts.Entries[entryName].Apply(fs, ts.DestDir, ts.TargetIgnore.Match, ts.Umask, mutator); err != nil {
+		if err := ts.Entries[entryName].Apply(fs, mutator, &applyOptions); err != nil {
 			return err
 		}
 	}

--- a/lib/chezmoi/targetstate_test.go
+++ b/lib/chezmoi/targetstate_test.go
@@ -99,7 +99,13 @@ func TestEndToEnd(t *testing.T) {
 			defer cleanup()
 			ts := NewTargetState(tc.destDir, tc.umask, tc.sourceDir, tc.data, tc.templateFuncs, "")
 			assert.NoError(t, ts.Populate(fs))
-			assert.NoError(t, ts.Apply(fs, NewLoggingMutator(os.Stderr, NewFSMutator(fs), false)))
+			applyOptions := &ApplyOptions{
+				DestDir: ts.DestDir,
+				Ignore:  ts.TargetIgnore.Match,
+				Stdout:  os.Stdout,
+				Umask:   022,
+			}
+			assert.NoError(t, ts.Apply(fs, NewLoggingMutator(os.Stderr, NewFSMutator(fs), false), applyOptions))
 			vfst.RunTests(t, fs, "", tc.tests)
 		})
 	}


### PR DESCRIPTION
This PR is inspired by @schrej's work in #206 but takes a somewhat different approach:

* Scripts are stored in the source directory as files with the prefix `run_`, rather than using a separate directory.
* Scripts that should only be executed once are given the prefix `run_once_`, rather than scanning for a regexp in the script.
* Run state is persisted in a database stored next to the configuration file,
* In the code, scripts are treated as `Entry`s, and applied using the same interface, rather than having a separate set of commands and functions to handle them.