### PR TITLE
Remove CVS and Subversion support skeleton

### DIFF
--- a/cmd/vcsinfos.go
+++ b/cmd/vcsinfos.go
@@ -15,10 +15,6 @@ var vcsInfos = map[string]*vcsInfo{
 		versionArgs:   []string{"--version"},
 		versionRegexp: regexp.MustCompile(`^Bazaar (bzr) (\d+\.\d+\.\d+)`),
 	},
-	"cvs": {
-		versionArgs:   []string{"--version"},
-		versionRegexp: regexp.MustCompile(`^Concurrent Versions System \(CVS\) (\d+\.\d+\.\d+)`),
-	},
 	"git": {
 		cloneArgsFunc: func(repo, dir string) []string {
 			return []string{"clone", repo, dir}

--- a/cmd/vcsinfos.go
+++ b/cmd/vcsinfos.go
@@ -33,8 +33,4 @@ var vcsInfos = map[string]*vcsInfo{
 		versionArgs:   []string{"version"},
 		versionRegexp: regexp.MustCompile(`^Mercurial Distributed SCM \(version (\d+\.\d+(\.\d+)?\))`),
 	},
-	"svn": {
-		versionArgs:   []string{"--version"},
-		versionRegexp: regexp.MustCompile(`^svn, version (\d+\.\d+\.\d+)`),
-	},
 }


### PR DESCRIPTION
Support for these is incomplete, and it is unlikely that anyone is actually using them.