### PR TITLE
Go mod workarounds

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/twpayne/go-vfsafero v1.0.0
 	github.com/twpayne/go-xdg/v3 v3.1.0
 	github.com/zalando/go-keyring v0.0.0-20180221093347-6d81c293b3fb
-	go.etcd.io/bbolt v1.3.2
+	go.etcd.io/bbolt v1.3.3-0.20190510211640-4af6cfab7010
 	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2
 	golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be
 	golang.org/x/sys v0.0.0-20190310054646-10058d7d4faa // indirect
@@ -41,9 +41,3 @@ require (
 // github.com/pmezard/go-difflib is unmaintained, so use a fork that includes
 // colored diff support.
 replace github.com/pmezard/go-difflib => github.com/twpayne/go-difflib v1.2.1
-
-// go.etcd.io/bbolt requires a couple of fixes before it can be used, so use a
-// fork with the fixes. This replace can be removed once
-// https://github.com/etcd-io/bbolt/pull/157 is merged and a new version of
-// go.etcd.io/bbolt is tagged.
-replace go.etcd.io/bbolt => github.com/twpayne/bbolt v1.3.3

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/kr/text v0.1.0
 	github.com/mattn/go-isatty v0.0.7
-	github.com/pmezard/go-difflib v1.0.0
 	github.com/russross/blackfriday/v2 v2.0.1
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/spf13/afero v1.2.2 // indirect
@@ -26,6 +25,7 @@ require (
 	github.com/spf13/viper v1.3.1
 	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/stretchr/testify v1.3.0
+	github.com/twpayne/go-difflib v1.3.0
 	github.com/twpayne/go-shell v0.0.1
 	github.com/twpayne/go-vfs v1.0.6
 	github.com/twpayne/go-vfsafero v1.0.0
@@ -37,7 +37,3 @@ require (
 	golang.org/x/sys v0.0.0-20190310054646-10058d7d4faa // indirect
 	gopkg.in/yaml.v2 v2.2.2
 )
-
-// github.com/pmezard/go-difflib is unmaintained, so use a fork that includes
-// colored diff support.
-replace github.com/pmezard/go-difflib => github.com/twpayne/go-difflib v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQz
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
@@ -74,8 +76,8 @@ github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/twpayne/go-difflib v1.2.1 h1:ypoyI4LwrjSBRzuvBph0Iu8Z8tPG4G+D706ym4RXp8w=
-github.com/twpayne/go-difflib v1.2.1/go.mod h1:yDLRCpF455E1uC+kFIFhA4qoJuKg9K2uyEx1/OBNnnw=
+github.com/twpayne/go-difflib v1.3.0 h1:diKcqcs0d4zkEPe8EQcsc5WTwgYoiEEFRJ7JhfjHtbA=
+github.com/twpayne/go-difflib v1.3.0/go.mod h1:3pM7Os07f1tPwfKPDOsPJ/Cr6lDh7ztw2t75/SFtQUM=
 github.com/twpayne/go-shell v0.0.1 h1:Ako3cUeuULhWadYk37jM3FlJ8lkSSW4INBjYj9K60Gw=
 github.com/twpayne/go-shell v0.0.1/go.mod h1:QCjEvdZndTuPObd+11NYAI1UeNLSuGZVxJ+67Wl+IU4=
 github.com/twpayne/go-vfs v1.0.1/go.mod h1:OIXA6zWkcn7Jk46XT7ceYqBMeIkfzJ8WOBhGJM0W4y8=

--- a/go.sum
+++ b/go.sum
@@ -74,8 +74,6 @@ github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/twpayne/bbolt v1.3.3 h1:JC5FqHl8KI7HttyR7gjlvFubsc4O154EDtn6DqbhXMk=
-github.com/twpayne/bbolt v1.3.3/go.mod h1:LFKuADr6ZLKUTotDQbCSVz/Pl3TFiiQHsFt4Ni86lnw=
 github.com/twpayne/go-difflib v1.2.1 h1:ypoyI4LwrjSBRzuvBph0Iu8Z8tPG4G+D706ym4RXp8w=
 github.com/twpayne/go-difflib v1.2.1/go.mod h1:yDLRCpF455E1uC+kFIFhA4qoJuKg9K2uyEx1/OBNnnw=
 github.com/twpayne/go-shell v0.0.1 h1:Ako3cUeuULhWadYk37jM3FlJ8lkSSW4INBjYj9K60Gw=
@@ -93,6 +91,8 @@ github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljT
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/zalando/go-keyring v0.0.0-20180221093347-6d81c293b3fb h1:tXbazu9ZlecQbyCczvA22mWj+lw/36Bdwxapk8v7e7s=
 github.com/zalando/go-keyring v0.0.0-20180221093347-6d81c293b3fb/go.mod h1:XlXBIfkGawHNVOHlenOaBW7zlfCh8LovwjOgjamYnkQ=
+go.etcd.io/bbolt v1.3.3-0.20190510211640-4af6cfab7010 h1:XWsASCLIxZzlppASNxGVCVRoGd8z1e7Kr5EXUAMPsjE=
+go.etcd.io/bbolt v1.3.3-0.20190510211640-4af6cfab7010/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9 h1:mKdxBk7AujPs8kU4m80U72y/zjbZ3UcXC7dClwKbUI0=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=

--- a/lib/chezmoi/loggingmutator.go
+++ b/lib/chezmoi/loggingmutator.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/pmezard/go-difflib/difflib"
+	"github.com/twpayne/go-difflib/difflib"
 )
 
 // A LoggingMutator wraps an Mutator and logs all of the actions it executes


### PR DESCRIPTION
This should fix building from source (#289) by not relying on `replace` directives in `go.mod` to rewrite import paths.