### PR TITLE
Use latest go-vfs with Windows support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/stretchr/testify v1.3.0
 	github.com/twpayne/go-difflib v1.3.0
 	github.com/twpayne/go-shell v0.0.1
-	github.com/twpayne/go-vfs v1.0.6
+	github.com/twpayne/go-vfs v1.1.0
 	github.com/twpayne/go-vfsafero v1.0.0
 	github.com/twpayne/go-xdg/v3 v3.1.0
 	github.com/zalando/go-keyring v0.0.0-20180221093347-6d81c293b3fb

--- a/go.sum
+++ b/go.sum
@@ -83,8 +83,8 @@ github.com/twpayne/go-shell v0.0.1/go.mod h1:QCjEvdZndTuPObd+11NYAI1UeNLSuGZVxJ+
 github.com/twpayne/go-vfs v1.0.1/go.mod h1:OIXA6zWkcn7Jk46XT7ceYqBMeIkfzJ8WOBhGJM0W4y8=
 github.com/twpayne/go-vfs v1.0.5 h1:i45a6Ykg/asDB94fHH5OmScCQHFx/P9A//9M5dfXwQk=
 github.com/twpayne/go-vfs v1.0.5/go.mod h1:OIXA6zWkcn7Jk46XT7ceYqBMeIkfzJ8WOBhGJM0W4y8=
-github.com/twpayne/go-vfs v1.0.6 h1:simuCsNdFE5juFWp2saFB03uUHdwpjX24gtusrl1CK8=
-github.com/twpayne/go-vfs v1.0.6/go.mod h1:A7YkNSb8q0vkRm4fPKNntU6tKePPh96OOwxHYxhZzOU=
+github.com/twpayne/go-vfs v1.1.0 h1:UPEV+YPvnCTFTJCuZWd+5Fg5TvXjs7CODNKemZZdcNE=
+github.com/twpayne/go-vfs v1.1.0/go.mod h1:A7YkNSb8q0vkRm4fPKNntU6tKePPh96OOwxHYxhZzOU=
 github.com/twpayne/go-vfsafero v1.0.0 h1:ZlH32HF4OoVX/aRqc5bZa+2+M+/ezmJ4XYpT0ShtZNc=
 github.com/twpayne/go-vfsafero v1.0.0/go.mod h1:rs2H15b2z0euJzwyoBS63eUHZgBhNXVQfIFfRp8DKEk=
 github.com/twpayne/go-xdg/v3 v3.1.0 h1:AxX5ZLJIzqYHJh+4uGxWT97ySh1ND1bJLjqMxdYF+xs=


### PR DESCRIPTION
Thanks to @zb140, a step on the way to fixing #23.