### PR TITLE
Add bash completion in snap package

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -150,3 +150,6 @@ snapcrafts:
   publish: true
   grade: stable
   confinement: classic
+  apps:
+    chezmoi:
+      completer: completions/chezmoi-completion.bash


### PR DESCRIPTION
Fixes #347. This requires a modification to goreleaser before it can be merged.