### PR TITLE
Fix execution with partial templates

### DIFF
--- a/lib/chezmoi/targetstate.go
+++ b/lib/chezmoi/targetstate.go
@@ -660,7 +660,7 @@ func (ts *TargetState) executeTemplateData(name string, data []byte) ([]byte, er
 		}
 	}
 	output := &bytes.Buffer{}
-	if err = tmpl.Execute(output, ts.Data); err != nil {
+	if err = tmpl.ExecuteTemplate(output, name, ts.Data); err != nil {
 		return nil, err
 	}
 	return output.Bytes(), nil


### PR DESCRIPTION
Fixes #382.

This is the fix for #382 written by @zb140, slightly tidied-up.

I'm also not familiar enough with the details of `text/template` to understand why this works. My guess that the sorcery used to add the partial templates was somehow changing the default template executed, and specifying an explicit template fixes this.

Thanks again @zb140!
