### PR TITLE
Add nodocs and noembeddocs build tags

### DIFF
--- a/cmd/docs.go
+++ b/cmd/docs.go
@@ -5,7 +5,6 @@ import (
 	"regexp"
 	"strings"
 
-	packr "github.com/gobuffalo/packr/v2"
 	"github.com/spf13/cobra"
 	vfs "github.com/twpayne/go-vfs"
 )
@@ -24,7 +23,6 @@ func init() {
 }
 
 func (c *Config) runDocsCmd(fs vfs.FS, args []string) error {
-	box := packr.New("docs", "../docs")
 	filename := "REFERENCE.md"
 	if len(args) > 0 {
 		pattern := args[0]
@@ -32,8 +30,12 @@ func (c *Config) runDocsCmd(fs vfs.FS, args []string) error {
 		if err != nil {
 			return err
 		}
+		docsFilenames, err := getDocsFilenames()
+		if err != nil {
+			return err
+		}
 		var filenames []string
-		for _, fn := range box.List() {
+		for _, fn := range docsFilenames {
 			if re.FindStringIndex(strings.ToLower(fn)) != nil {
 				filenames = append(filenames, fn)
 			}
@@ -47,7 +49,7 @@ func (c *Config) runDocsCmd(fs vfs.FS, args []string) error {
 			return fmt.Errorf("%s: ambiguous pattern, matches %s", pattern, strings.Join(filenames, ", "))
 		}
 	}
-	data, err := box.Find(filename)
+	data, err := getDoc(filename)
 	if err != nil {
 		return err
 	}

--- a/cmd/docs.go
+++ b/cmd/docs.go
@@ -1,3 +1,5 @@
+// +build !nodocs
+
 package cmd
 
 import (

--- a/cmd/docs_embeddocs.go
+++ b/cmd/docs_embeddocs.go
@@ -1,0 +1,18 @@
+// +build !noembeddocs
+
+package cmd
+
+import packr "github.com/gobuffalo/packr/v2"
+
+// DocsDir is unused when chezmoi is built with embedded docs.
+var DocsDir = ""
+
+var docsBox = packr.New("docs", "../docs")
+
+func getDocsFilenames() ([]string, error) {
+	return docsBox.List(), nil
+}
+
+func getDoc(filename string) ([]byte, error) {
+	return docsBox.Find(filename)
+}

--- a/cmd/docs_embeddocs.go
+++ b/cmd/docs_embeddocs.go
@@ -1,3 +1,4 @@
+// +build !nodocs
 // +build !noembeddocs
 
 package cmd

--- a/cmd/docs_noembeddocs.go
+++ b/cmd/docs_noembeddocs.go
@@ -1,3 +1,4 @@
+// +build !nodocs
 // +build noembeddocs
 
 package cmd

--- a/cmd/docs_noembeddocs.go
+++ b/cmd/docs_noembeddocs.go
@@ -1,0 +1,26 @@
+// +build noembeddocs
+
+package cmd
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+// DocsDir is the directory containing docs when chezmoi is built without
+// embedded docs. It should be an absolute path.
+var DocsDir = "docs"
+
+func getDocsFilenames() ([]string, error) {
+	f, err := os.Open(DocsDir)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return f.Readdirnames(-1)
+}
+
+func getDoc(filename string) ([]byte, error) {
+	return ioutil.ReadFile(filepath.Join(DocsDir, filename))
+}

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -96,6 +96,17 @@ If you plan to package chezmoi for your distibution, then note:
 * Please enable CGO, if possible. chezmoi can be built and run without CGO, but
   the `.chezmoi.group` template variable may not be set on some systems.
 
+* chezmoi includes a `docs` command which prints its documentation. By default,
+  the docs are embedded in the binary. You can disable this behaviour, and have
+  chezmoi read its docs from the filesystem by building with the `noembeddocs`
+  build tag and setting the directory where chezmoi can find them with the `-X
+  github.com/twpayne/chezmoi/cmd.DocDir={{ .PathToDocs }}` linker flag. For
+  example:
+
+  ```
+  go build -tags noembeddocs -ldflags "-X github.com/twpayne/chezmoi/cmd.DocsDir=/usr/share/doc/chezmoi" .
+  ```
+
 * chezmoi includes an `upgrade` command which attempts to self-upgrade. You can
   remove this command completely by building chezmoi with the `noupgrade` build
   tag.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -107,6 +107,8 @@ If you plan to package chezmoi for your distibution, then note:
   go build -tags noembeddocs -ldflags "-X github.com/twpayne/chezmoi/cmd.DocsDir=/usr/share/doc/chezmoi" .
   ```
 
+  To disable the `docs` command completely, use the `nodocs` build tag.
+
 * chezmoi includes an `upgrade` command which attempts to self-upgrade. You can
   remove this command completely by building chezmoi with the `noupgrade` build
   tag.


### PR DESCRIPTION
@daurnimator this allows you to build chezmoi without embedded documentation, as requested in #427. See the changes to `CONTRIBUTING.md` in this PR for instructions on how to do this.

If this looks OK to you, I'll merge it and tag a new release with it so you can update the Arch Linux package.