### PR TITLE
Only open BoltDB when required

### DIFF
--- a/lib/chezmoi/chezmoi.go
+++ b/lib/chezmoi/chezmoi.go
@@ -28,6 +28,8 @@ const (
 
 // A PersistentState is an interface to a persistent state.
 type PersistentState interface {
+	Open(write bool) error
+	Close() error
 	Delete(bucket, key []byte) error
 	Get(bucket, key []byte) ([]byte, error)
 	Set(bucket, key, value []byte) error

--- a/lib/chezmoi/targetstate.go
+++ b/lib/chezmoi/targetstate.go
@@ -184,6 +184,9 @@ func (ts *TargetState) Add(fs vfs.FS, addOptions AddOptions, targetPath string, 
 
 // Apply ensures that ts.DestDir in fs matches ts.
 func (ts *TargetState) Apply(fs vfs.FS, mutator Mutator, follow bool, applyOptions *ApplyOptions) error {
+	applyOptions.PersistentState.Open(!applyOptions.DryRun)
+	defer applyOptions.PersistentState.Close()
+
 	if applyOptions.Remove {
 		// Build a set of targets to remove.
 		targetsToRemove := make(map[string]struct{})


### PR DESCRIPTION
The current implementation blocks chezmoi from running in parallel, e.g. within chezmoi scripts. This was caused by BoltDB blocking when trying to open the same database in read-mode twice.

This PR changes the behavior to only open the db when it is required. It also opens it in read-mode only when doing a dry-run.

fixes #433 