### PR TITLE
Improve detection of the user's shell

### DIFF
--- a/cmd/cd_posix.go
+++ b/cmd/cd_posix.go
@@ -15,14 +15,9 @@ func (c *Config) runCDCmd(fs vfs.FS, args []string) error {
 		return err
 	}
 
-	shell, err := shell.CurrentUserShell()
-	if err != nil {
-		return err
-	}
-
+	shell, _ := shell.CurrentUserShell()
 	if err := os.Chdir(c.SourceDir); err != nil {
 		return err
 	}
-
 	return c.exec(fs, []string{shell})
 }

--- a/cmd/cd_windows.go
+++ b/cmd/cd_windows.go
@@ -13,10 +13,6 @@ func (c *Config) runCDCmd(fs vfs.FS, args []string) error {
 		return err
 	}
 
-	shell, err := shell.CurrentUserShell()
-	if err != nil {
-		return err
-	}
-
+	shell, _ := shell.CurrentUserShell()
 	return c.run(fs, c.SourceDir, shell)
 }

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/stretchr/testify v1.3.0
-	github.com/twpayne/go-shell v0.0.2
+	github.com/twpayne/go-shell v0.0.3
 	github.com/twpayne/go-vfs v1.3.4
 	github.com/twpayne/go-vfsafero v1.0.0
 	github.com/twpayne/go-xdg/v3 v3.1.0

--- a/go.sum
+++ b/go.sum
@@ -176,8 +176,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/twpayne/go-acl v0.0.2 h1:kGrBVkNNLBuQicfgSCCanepMKWdk4+JSNynF+MapLOQ=
 github.com/twpayne/go-acl v0.0.2/go.mod h1:lVOy2syxHw2MVrvUnQhkFUXlPFKuFm3gdNMnybTbMuA=
-github.com/twpayne/go-shell v0.0.2 h1:sZH588mQpnR7422kS4bhqydn8JFb7HCnAcqaDNy98y0=
-github.com/twpayne/go-shell v0.0.2/go.mod h1:H/gzux0DOH5jsjQSHXs6rs2Onxy+V4j6ycZTOulC0l8=
+github.com/twpayne/go-shell v0.0.3 h1:Tzi3t9zCNudAAsxd9UrmhZhqWfp7pjFh/xlJ6M8HmrQ=
+github.com/twpayne/go-shell v0.0.3/go.mod h1:H/gzux0DOH5jsjQSHXs6rs2Onxy+V4j6ycZTOulC0l8=
 github.com/twpayne/go-vfs v1.0.1/go.mod h1:OIXA6zWkcn7Jk46XT7ceYqBMeIkfzJ8WOBhGJM0W4y8=
 github.com/twpayne/go-vfs v1.0.5 h1:i45a6Ykg/asDB94fHH5OmScCQHFx/P9A//9M5dfXwQk=
 github.com/twpayne/go-vfs v1.0.5/go.mod h1:OIXA6zWkcn7Jk46XT7ceYqBMeIkfzJ8WOBhGJM0W4y8=


### PR DESCRIPTION
This PR improves the detection of the user's shell, which should allow the `chezmoi cd` command to work on a wider variety of platforms, including termux.

Refs #445.