### PR TITLE
fix broken link

### DIFF
--- a/chezmoi.io/content/_index.md
+++ b/chezmoi.io/content/_index.md
@@ -8,7 +8,7 @@ type: docs
 Manage your dotfiles across multiple machines, securely.
 
 * [What does chezmoi do and why should I use it?](#what-does-chezmoi-do-and-why-should-i-use-it)
-* [What are chezmoi's key features?](#what-are-chezmois-key-features)
+* [What are chezmoi's key features?](#what-are-chezmoi-s-key-features)
 * [I already have a system to manage my dotfiles, why should I use chezmoi?](#i-already-have-a-system-to-manage-my-dotfiles-why-should-i-use-chezmoi)
 * [How do I start with chezmoi?](#how-do-i-start-with-chezmoi)
 * [License](#license)

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -2,18 +2,18 @@
 
 * [How can I quickly check for problems with chezmoi on my machine?](#how-can-i-quickly-check-for-problems-with-chezmoi-on-my-machine)
 * [What are the consequences of "bare" modifications to the target files? If my `.zshrc` is managed by chezmoi and I edit `~/.zshrc` without using `chezmoi edit`, what happens?](#what-are-the-consequences-of-bare-modifications-to-the-target-files-if-my-zshrc-is-managed-by-chezmoi-and-i-edit-zshrc-without-using-chezmoi-edit-what-happens)
-* [How can I tell what dotfiles in my home directory aren't managed by chezmoi? Is there an easy way to have chezmoi manage a subset of them?](#how-can-i-tell-what-dotfiles-in-my-home-directory-arent-managed-by-chezmoi-is-there-an-easy-way-to-have-chezmoi-manage-a-subset-of-them)
-* [If there's a mechanism in place for the above, is there also a way to tell chezmoi to ignore specific files or groups of files (e.g. by directory name or by glob)?](#if-theres-a-mechanism-in-place-for-the-above-is-there-also-a-way-to-tell-chezmoi-to-ignore-specific-files-or-groups-of-files-eg-by-directory-name-or-by-glob)
+* [How can I tell what dotfiles in my home directory aren't managed by chezmoi? Is there an easy way to have chezmoi manage a subset of them?](#how-can-i-tell-what-dotfiles-in-my-home-directory-aren-t-managed-by-chezmoi-is-there-an-easy-way-to-have-chezmoi-manage-a-subset-of-them)
+* [If there's a mechanism in place for the above, is there also a way to tell chezmoi to ignore specific files or groups of files (e.g. by directory name or by glob)?](#if-there-s-a-mechanism-in-place-for-the-above-is-there-also-a-way-to-tell-chezmoi-to-ignore-specific-files-or-groups-of-files-e-g-by-directory-name-or-by-glob)
 * [If the target already exists, but is "behind" the source, can chezmoi be configured to preserve the target version before replacing it with one derived from the source?](#if-the-target-already-exists-but-is-behind-the-source-can-chezmoi-be-configured-to-preserve-the-target-version-before-replacing-it-with-one-derived-from-the-source)
 * [How do I only run a script when a file has changed?](#how-do-i-only-run-a-script-when-a-file-has-changed)
-* [I've made changes to both the destination state and the source state that I want to keep. How can I keep them both?](#ive-made-changes-to-both-the-destination-state-and-the-source-state-that-i-want-to-keep-how-can-i-keep-them-both)
-* [chezmoi's source file naming system cannot handle all possible filenames](#chezmois-source-file-naming-system-cannot-handle-all-possible-filenames)
+* [I've made changes to both the destination state and the source state that I want to keep. How can I keep them both?](#i-ve-made-changes-to-both-the-destination-state-and-the-source-state-that-i-want-to-keep-how-can-i-keep-them-both)
+* [chezmoi's source file naming system cannot handle all possible filenames](#chezmoi-s-source-file-naming-system-cannot-handle-all-possible-filenames)
 * [gpg encryption fails. What could be wrong?](#gpg-encryption-fails-what-could-be-wrong)
 * [What inspired chezmoi?](#what-inspired-chezmoi)
 * [Can I use chezmoi outside my home directory?](#can-i-use-chezmoi-outside-my-home-directory)
 * [Where does the name "chezmoi" come from?](#where-does-the-name-chezmoi-come-from)
 * [What other questions have been asked about chezmoi?](#what-other-questions-have-been-asked-about-chezmoi)
-* [Where do I ask a question that isn't answered here?](#where-do-i-ask-a-question-that-isnt-answered-here)
+* [Where do I ask a question that isn't answered here?](#where-do-i-ask-a-question-that-isn-t-answered-here)
 
 ## How can I quickly check for problems with chezmoi on my machine?
 


### PR DESCRIPTION
I was checking out the website and noticed the second link wasn't working. It's because it links to `what-are-chezmois-key-features`, [missing the hyphen](http://www.chezmoi.io/#what-are-chezmoi-s-key-features) which is meant to be in place of the quotation mark in "chezmoi's". There is the same problem elsewhere where there is certain punctuation e.g. [this](http://chezmoi.io/docs/faq/#if-theres-a-mechanism-in-place-for-the-above-is-there-also-a-way-to-tell-chezmoi-to-ignore-specific-files-or-groups-of-files-eg-by-directory-name-or-by-glob) link in the FAQs is [missing a hyphen as well](http://chezmoi.io/docs/faq/#if-there-s-a-mechanism-in-place-for-the-above-is-there-also-a-way-to-tell-chezmoi-to-ignore-specific-files-or-groups-of-files-e-g-by-directory-name-or-by-glob) in place of the quotation mark and full stop (afaict not on GitHub hence why it's not fixed in this commit)