### PR TITLE
Add sourceDir to default template data

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -127,7 +127,7 @@ func (c *Config) createConfigFile() error {
 		return err
 	}
 
-	defaultData, err := getDefaultData(c.fs)
+	defaultData, err := c.getDefaultData()
 	if err != nil {
 		return err
 	}

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -716,6 +716,7 @@ chezmoi provides the following automatically populated variables:
 | `.chezmoi.hostname`     | The hostname of the machine chezmoi is running on, up to the first `.`.                                                |
 | `.chezmoi.os`           | Operating system, e.g. `darwin`, `linux`, etc. as returned by [runtime.GOOS](https://godoc.org/runtime#pkg-constants). |
 | `.chezmoi.osRelease`    | The information from `/etc/os-release`, Linux only, run `chezmoi data` to see its output.                              |
+| `.chezmoi.sourceDir`    | The source directory.                                                                                                  |
 | `.chezmoi.username`     | The username of the user running chezmoi.                                                                              |
 
 Additional variables can be defined in the config file in the `data` section.


### PR DESCRIPTION
cc @duckbrain refs #467.

This PR adds `sourceDir` to the default template variables.