### PR TITLE
Use go-shell with 32-bit support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/spf13/viper v1.5.0
 	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/stretchr/testify v1.4.0
-	github.com/twpayne/go-shell v0.1.0
+	github.com/twpayne/go-shell v0.1.1
 	github.com/twpayne/go-vfs v1.3.6
 	github.com/twpayne/go-vfsafero v1.0.0
 	github.com/twpayne/go-xdg/v3 v3.1.0

--- a/go.sum
+++ b/go.sum
@@ -194,8 +194,8 @@ github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/twpayne/go-acl v0.0.2 h1:kGrBVkNNLBuQicfgSCCanepMKWdk4+JSNynF+MapLOQ=
 github.com/twpayne/go-acl v0.0.2/go.mod h1:lVOy2syxHw2MVrvUnQhkFUXlPFKuFm3gdNMnybTbMuA=
-github.com/twpayne/go-shell v0.1.0 h1:1rb6SwXRU7hWBBZVJgH/Mv+81hkaeYgVOR7JIJcvm/E=
-github.com/twpayne/go-shell v0.1.0/go.mod h1:H/gzux0DOH5jsjQSHXs6rs2Onxy+V4j6ycZTOulC0l8=
+github.com/twpayne/go-shell v0.1.1 h1:Kr1hSEFrPBTRmhOW8woaj7ZxV3/OH7Qefg86OFJ5DFc=
+github.com/twpayne/go-shell v0.1.1/go.mod h1:H/gzux0DOH5jsjQSHXs6rs2Onxy+V4j6ycZTOulC0l8=
 github.com/twpayne/go-vfs v1.0.1/go.mod h1:OIXA6zWkcn7Jk46XT7ceYqBMeIkfzJ8WOBhGJM0W4y8=
 github.com/twpayne/go-vfs v1.0.5/go.mod h1:OIXA6zWkcn7Jk46XT7ceYqBMeIkfzJ8WOBhGJM0W4y8=
 github.com/twpayne/go-vfs v1.3.6 h1:dKR5suwT6WnNweNNQjts3Wih/sBTHLt4XbbEbapnWEE=


### PR DESCRIPTION
This incorporates https://github.com/twpayne/go-shell/pull/5 which fixes building chezmoi on 32-bit operating systems.

cc @Ikke