### PR TITLE
Fixed a type in completion example

### DIFF
--- a/cmd/helps.gen.go
+++ b/cmd/helps.gen.go
@@ -100,7 +100,7 @@ var helps = map[string]help{
 			"Output shell completion code for the specified shell (\"bash\", \"fish\", or \"zsh\").\n",
 		example: "" +
 			"  chezmoi completion bash\n" +
-			"  chezmoi completion fish > ~/.config/fish/completions/chezmoi\n" +
+			"  chezmoi completion fish > ~/.config/fish/completions/chezmoi.fish\n" +
 			"  chezmoi completion zsh",
 	},
 	"data": {

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -419,7 +419,7 @@ Output shell completion code for the specified shell (`bash`, `fish`, or `zsh`).
 #### `completion` examples
 
     chezmoi completion bash
-    chezmoi completion fish > ~/.config/fish/completions/chezmoi
+    chezmoi completion fish > ~/.config/fish/completions/chezmoi.fish
     chezmoi completion zsh
 
 ### `data`


### PR DESCRIPTION
Just a quick fix, `fish` shell completions files must end in `.fish`