### PR TITLE
Added kernel information to data

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -320,6 +320,12 @@ func (c *Config) getDefaultData() (map[string]interface{}, error) {
 		return nil, err
 	}
 
+	kernelInfo, err := getKernelInfo(c.fs)
+	if err == nil && kernelInfo != nil {
+		data["kernel"] = kernelInfo
+	} else if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
 	return data, nil
 }
 

--- a/cmd/kernelinfo_linux.go
+++ b/cmd/kernelinfo_linux.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/twpayne/go-vfs"
+)
+
+func getKernelInfo(fs vfs.FS) (map[string]string, error) {
+	const procKernel = "/proc/sys/kernel"
+	files := []string{"version", "ostype", "osrelease"}
+
+	stat, err := fs.Stat(procKernel)
+	if err != nil {
+		return nil, err
+	}
+	if !stat.IsDir() {
+		return nil, fmt.Errorf("expected %q to be a directory", procKernel)
+	}
+
+	res := map[string]string{}
+	for _, file := range files {
+		p := filepath.Join(procKernel, file)
+		f, err := fs.Open(p)
+		if os.IsNotExist(err) {
+			continue
+		} else if err != nil {
+			return nil, err
+		}
+		defer f.Close()
+		data, err := ioutil.ReadAll(f)
+		if err != nil {
+			return nil, err
+		}
+		res[file] = strings.TrimSpace(string(data))
+	}
+
+	return res, nil
+}

--- a/cmd/kernelinfo_linux_test.go
+++ b/cmd/kernelinfo_linux_test.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/twpayne/go-vfs/vfst"
+)
+
+func TestGetKernelInfo(t *testing.T) {
+	root := map[string]interface{}{
+		"/proc/sys/kernel/version":   "#1 SMP Fri Nov 1 14:28:19 UTC 2019",
+		"/proc/sys/kernel/ostype":    "Linux",
+		"/proc/sys/kernel/osrelease": "4.19.81-microsoft-standard",
+	}
+	fs, cleanup, err := vfst.NewTestFS(root)
+	require.NoError(t, err)
+	defer cleanup()
+	info, err := getKernelInfo(fs)
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]string{
+		"version":   "#1 SMP Fri Nov 1 14:28:19 UTC 2019",
+		"ostype":    "Linux",
+		"osrelease": "4.19.81-microsoft-standard",
+	}, info)
+}

--- a/cmd/kernelinfo_notlinux.go
+++ b/cmd/kernelinfo_notlinux.go
@@ -1,0 +1,9 @@
+// +build !linux
+
+package cmd
+
+import "github.com/twpayne/go-vfs"
+
+func getKernelInfo(fs vfs.FS) (map[string]string, error) {
+	return nil, nil
+}

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -713,17 +713,18 @@ chezmoi's configuration file.
 
 chezmoi provides the following automatically populated variables:
 
-| Variable                | Value                                                                                                                  |
-| ----------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| `.chezmoi.arch`         | Architecture, e.g. `amd64`, `arm`, etc. as returned by [runtime.GOARCH](https://godoc.org/runtime#pkg-constants).      |
-| `.chezmoi.fullHostname` | The full hostname of the machine chezmoi is running on.                                                                |
-| `.chezmoi.group`        | The group of the user running chezmoi.                                                                                 |
-| `.chezmoi.homedir`      | The home directory of the user running chezmoi.                                                                        |
-| `.chezmoi.hostname`     | The hostname of the machine chezmoi is running on, up to the first `.`.                                                |
-| `.chezmoi.os`           | Operating system, e.g. `darwin`, `linux`, etc. as returned by [runtime.GOOS](https://godoc.org/runtime#pkg-constants). |
-| `.chezmoi.osRelease`    | The information from `/etc/os-release`, Linux only, run `chezmoi data` to see its output.                              |
-| `.chezmoi.sourceDir`    | The source directory.                                                                                                  |
-| `.chezmoi.username`     | The username of the user running chezmoi.                                                                              |
+| Variable                | Value                                                                                                                          |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `.chezmoi.arch`         | Architecture, e.g. `amd64`, `arm`, etc. as returned by [runtime.GOARCH](https://godoc.org/runtime#pkg-constants).              |
+| `.chezmoi.fullHostname` | The full hostname of the machine chezmoi is running on.                                                                        |
+| `.chezmoi.group`        | The group of the user running chezmoi.                                                                                         |
+| `.chezmoi.homedir`      | The home directory of the user running chezmoi.                                                                                |
+| `.chezmoi.hostname`     | The hostname of the machine chezmoi is running on, up to the first `.`.                                                        |
+| `.chezmoi.kernel`       | Contains information from `/proc/sys/kernel`. Linux only, useful for detecting specific kernels (i.e. Microsoft's WSL kernel). |
+| `.chezmoi.os`           | Operating system, e.g. `darwin`, `linux`, etc. as returned by [runtime.GOOS](https://godoc.org/runtime#pkg-constants).         |
+| `.chezmoi.osRelease`    | The information from `/etc/os-release`, Linux only, run `chezmoi data` to see its output.                                      |
+| `.chezmoi.sourceDir`    | The source directory.                                                                                                          |
+| `.chezmoi.username`     | The username of the user running chezmoi.                                                                                      |
 
 Additional variables can be defined in the config file in the `data` section.
 


### PR DESCRIPTION
The main purpose of this is to have a way to detect WSL (windows subsystem for linux).

From what I can gather, the best way is currently to look in `/proc/sys/kernel/osrelease` and look for "microsoft" in the kernel name: https://github.com/microsoft/WSL/issues/423

