### PR TITLE
Don't attempt to use ANSI colors or terminal width on Windows

### DIFF
--- a/cmd/docs.go
+++ b/cmd/docs.go
@@ -4,14 +4,11 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"regexp"
 	"strings"
 
 	"github.com/charmbracelet/glamour"
-	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
-	"golang.org/x/crypto/ssh/terminal"
 )
 
 var docsCmd = &cobra.Command{
@@ -60,17 +57,9 @@ func (c *Config) runDocsCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	width := 80
-	if stdout, ok := c.Stdout().(*os.File); ok && isatty.IsTerminal(stdout.Fd()) {
-		width, _, err = terminal.GetSize(int(stdout.Fd()))
-		if err != nil {
-			return err
-		}
-	}
-
 	tr, err := glamour.NewTermRenderer(
 		glamour.WithStyles(glamour.ASCIIStyleConfig),
-		glamour.WithWordWrap(width),
+		glamour.WithWordWrap(getWriterWidth(c.Stdout())),
 	)
 	if err != nil {
 		return err

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/Masterminds/sprig"
 	"github.com/coreos/go-semver/semver"
-	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/twpayne/chezmoi/internal/chezmoi"
@@ -139,11 +138,7 @@ func (c *Config) persistentPreRunRootE(cmd *cobra.Command, args []string) error 
 	case "off":
 		c.colored = false
 	case "auto":
-		if stdout, ok := c.Stdout().(*os.File); ok {
-			c.colored = isatty.IsTerminal(stdout.Fd())
-		} else {
-			c.colored = false
-		}
+		c.colored = getWriterSupportsColor(c.Stdout())
 	default:
 		return fmt.Errorf("invalid --color value: %s", c.Color)
 	}

--- a/cmd/terminal_posix.go
+++ b/cmd/terminal_posix.go
@@ -1,0 +1,27 @@
+// +build !windows
+
+package cmd
+
+import (
+	"io"
+	"os"
+
+	"github.com/mattn/go-isatty"
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+func getWriterSupportsColor(w io.Writer) bool {
+	if f, ok := w.(*os.File); ok {
+		return isatty.IsTerminal(f.Fd())
+	}
+	return false
+}
+
+func getWriterWidth(w io.Writer) int {
+	if f, ok := w.(*os.File); ok && isatty.IsTerminal(f.Fd()) {
+		if width, _, err := terminal.GetSize(int(f.Fd())); err == nil {
+			return width
+		}
+	}
+	return 80
+}

--- a/cmd/terminal_windows.go
+++ b/cmd/terminal_windows.go
@@ -1,0 +1,13 @@
+package cmd
+
+import (
+	"io"
+)
+
+func getWriterSupportsColor(w io.Writer) bool {
+	return false
+}
+
+func getWriterWidth(w io.Writer) int {
+	return 80
+}


### PR DESCRIPTION
Fixes #554.