### PR TITLE
Re-enable bash completion in snaps

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -150,13 +150,6 @@ snapcrafts:
   publish: true
   grade: stable
   confinement: classic
-  # FIXME on 2020-02-06 the snapcraft store was automatically rejecting
-  # generated snaps with the message:
-  #   chezmoi-completion.bash does not exist lint-snap-v2_completer (chezmoi)
-  # See, for example:
-  # https://dashboard.snapcraft.io/snaps/chezmoi/revisions/123/
-  # This might be related to the completer script being in a subdirectory.
-  # For now, disable bash completion.
-  # apps:
-  #   chezmoi:
-  #     completer: completions/chezmoi-completion.bash
+  apps:
+    chezmoi:
+      completer: completions/chezmoi-completion.bash


### PR DESCRIPTION
This reverts commit ed3584c00b85ef96b0314824c74c335f138a459b.

Thanks to https://github.com/goreleaser/goreleaser/pull/1346.