### PR TITLE
Allow EDITOR and VISUAL to include arguments

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -109,6 +109,13 @@ func (c *Config) runDoctorCmd(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	editorName, _ := c.getEditor()
+	editorCheck := &doctorBinaryCheck{
+		name:        "editor",
+		binaryName:  editorName,
+		mustSucceed: true,
+	}
+
 	allOK := true
 	for _, dc := range []doctorCheck{
 		&doctorVersionCheck{},
@@ -142,11 +149,7 @@ func (c *Config) runDoctorCmd(cmd *cobra.Command, args []string) error {
 			path:    c.KeePassXC.Database,
 			canSkip: true,
 		},
-		&doctorBinaryCheck{
-			name:        "editor",
-			binaryName:  c.getEditor(),
-			mustSucceed: true,
-		},
+		editorCheck,
 		&doctorBinaryCheck{
 			name:       "merge command",
 			binaryName: c.Merge.Command,

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -57,7 +57,7 @@ func (c *Config) runEditCmd(cmd *cobra.Command, args []string) error {
 		if c.edit.prompt {
 			cmd.Printf("warning: --prompt is currently ignored when edit is run with no arguments\n")
 		}
-		return c.run("", c.getEditor(), c.SourceDir)
+		return c.runEditor(c.SourceDir)
 	}
 
 	if c.edit.prompt {


### PR DESCRIPTION
Fixes #625.

@joeshaw I would be very happy to hear your input on this. This PR in its current form splits `$EDITOR` on whitespace to extract any extra arguments. Another possibility would be to pass `$EDITOR` unchanged to `/bin/sh -c '$EDITOR'`. Is there a more standard way of doing this?