### PR TITLE
Improve windows support by removing carriage return from prompts

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -177,5 +177,5 @@ func (c *Config) promptString(field string) string {
 	fmt.Fprintf(c.Stdout, "%s? ", field)
 	value, err := bufio.NewReader(c.Stdin).ReadString('\n')
 	panicOnError(err)
-	return strings.TrimSuffix(value, "\n")
+	return strings.TrimRight(value, "\r\n")
 }

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -13,6 +13,42 @@ import (
 	"github.com/twpayne/go-vfs/vfst"
 )
 
+func TestPromptStringIgnoreWindowsNewline(t *testing.T) {
+	fs, cleanup, err := vfst.NewTestFS(map[string]interface{}{
+		"/home/user/.local/share/chezmoi/.chezmoi.toml.tmpl": strings.Join([]string{
+			`{{ $env := promptString "environment [work/home]" -}}`,
+			`[data]`,
+			`  environment = "{{ $env }}"`,
+		}, "\n"),
+	})
+	require.NoError(t, err)
+	defer cleanup()
+
+	c := newTestConfig(
+		fs,
+		withStdin(bytes.NewBufferString("home\r\n")),
+	)
+
+	require.NoError(t, c.createConfigFile())
+
+	vfst.RunTests(t, fs, "",
+		vfst.TestPath("/home/user/.config/chezmoi/chezmoi.toml",
+			vfst.TestModeIsRegular,
+			vfst.TestModePerm(0600),
+			vfst.TestContentsString(
+				strings.Join([]string{
+					`[data]`,
+					`  environment = "home"`,
+				}, "\n"),
+			),
+		),
+	)
+
+	assert.Equal(t, map[string]interface{}{
+		"environment": "home",
+	}, c.Data)
+}
+
 func TestCreateConfigFile(t *testing.T) {
 	fs, cleanup, err := vfst.NewTestFS(map[string]interface{}{
 		"/home/user/.local/share/chezmoi/.chezmoi.yaml.tmpl": strings.Join([]string{


### PR DESCRIPTION
Windows uses `\r\n` for newlines, so when reading input it needs extra attention to avoid creating data with extra `\r` in the contents