### PR TITLE
Fix behavior when adding an empty file without --empty

### DIFF
--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -206,6 +206,20 @@ func TestAddCommand(t *testing.T) {
 			},
 		},
 		{
+			name: "add_empty_file_in_subdir",
+			args: []string{"/home/user/subdir/empty"},
+			root: map[string]interface{}{
+				"/home/user":                      &vfst.Dir{Perm: 0755},
+				"/home/user/.local/share/chezmoi": &vfst.Dir{Perm: 0700},
+				"/home/user/subdir/empty":         "",
+			},
+			tests: []vfst.Test{
+				vfst.TestPath("/home/user/.local/share/chezmoi/subdir",
+					vfst.TestIsDir,
+				),
+			},
+		},
+		{
 			name: "add_symlink",
 			args: []string{"/home/user/foo"},
 			root: map[string]interface{}{

--- a/internal/chezmoi/targetstate.go
+++ b/internal/chezmoi/targetstate.go
@@ -238,10 +238,14 @@ func (ts *TargetState) Add(fs vfs.FS, addOptions AddOptions, targetPath string, 
 	case info.Mode().IsRegular():
 		if info.Size() == 0 && !addOptions.Empty {
 			entry, err := ts.Get(fs, targetPath)
-			if err != nil {
+			switch {
+			case os.IsNotExist(err):
+				return nil
+			case err == nil:
+				return mutator.RemoveAll(filepath.Join(ts.SourceDir, entry.SourceName()))
+			default:
 				return err
 			}
-			return mutator.RemoveAll(filepath.Join(ts.SourceDir, entry.SourceName()))
 		}
 		contents, err := fs.ReadFile(targetPath)
 		if err != nil {


### PR DESCRIPTION
This fixes a [problem reported](https://github.com/twpayne/chezmoi/issues/550#issuecomment-606699229) by @iopsthecloud in #550.

chezmoi uses empty files to indicate that the file should be removed in the target state, unless the file has the `empty_` attribute. When adding an empty file with `chezmoi add` without the `--empty` option (to add the `empty_` attribute) chezmoi removes the file from the source state. This would cause an error if the file did not already exist in the source state. This PR fixes that.