### PR TITLE
Add possibility to configure GPG cli command in config file

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -139,6 +139,9 @@ func newConfig(options ...configOption) *Config {
 		Merge: mergeConfig{
 			Command: "vimdiff",
 		},
+		GPG: chezmoi.GPG{
+			Command: "gpg",
+		},
 		maxDiffDataSize:   1 * 1024 * 1024, // 1MB
 		templateFuncs:     sprig.TxtFuncMap(),
 		scriptStateBucket: []byte("script"),

--- a/cmd/docs.gen.go
+++ b/cmd/docs.gen.go
@@ -1569,6 +1569,7 @@ func init() {
 		"| `follow`                | bool     | `false`                   | Follow symlinks                                     |\n" +
 		"| `genericSecret.command` | string   | *none*                    | Generic secret command                              |\n" +
 		"| `gopass.command`        | string   | `gopass`                  | gopass CLI command                                  |\n" +
+		"| `gpg.command`           | string   | `gpg`                     | GPG CLI command                                     |\n" +
 		"| `gpg.recipient`         | string   | *none*                    | GPG recipient                                       |\n" +
 		"| `gpg.symmetric`         | bool     | `false`                   | Use symmetric GPG encryption                        |\n" +
 		"| `keepassxc.args`        | []string | *none*                    | Extra args to KeePassXC CLI command                 |\n" +

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -183,6 +183,7 @@ The following configuration variables are available:
 | `follow`                | bool     | `false`                   | Follow symlinks                                     |
 | `genericSecret.command` | string   | *none*                    | Generic secret command                              |
 | `gopass.command`        | string   | `gopass`                  | gopass CLI command                                  |
+| `gpg.command`           | string   | `gpg`                     | GPG CLI command                                     |
 | `gpg.recipient`         | string   | *none*                    | GPG recipient                                       |
 | `gpg.symmetric`         | bool     | `false`                   | Use symmetric GPG encryption                        |
 | `keepassxc.args`        | []string | *none*                    | Extra args to KeePassXC CLI command                 |

--- a/internal/chezmoi/gpg.go
+++ b/internal/chezmoi/gpg.go
@@ -9,6 +9,7 @@ import (
 
 // GPG interfaces with gpg.
 type GPG struct {
+	Command   string
 	Recipient string
 	Symmetric bool
 }
@@ -28,8 +29,9 @@ func (g *GPG) Decrypt(filename string, ciphertext []byte) ([]byte, error) {
 		return nil, err
 	}
 
+	//nolint:gosec
 	cmd := exec.Command(
-		"gpg",
+		g.Command,
 		"--output", outputFilename,
 		"--quiet",
 		"--decrypt", inputFilename,
@@ -73,7 +75,9 @@ func (g *GPG) Encrypt(filename string, plaintext []byte) ([]byte, error) {
 		args = append(args, "--encrypt")
 	}
 	args = append(args, filename)
-	cmd := exec.Command("gpg", args...)
+
+	//nolint:gosec
+	cmd := exec.Command(g.Command, args...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
There are cases where we want to be able configure the gpg CLI command.

For example I am user of the QubesOS and I use a separate VM for the gpg (split GPG). That's why I need to use the `gpg-client-wrapper` when working with the keys.

Ref.:
- https://github.com/QubesOS/qubes-app-linux-split-gpg