### PR TITLE
Add diff.pager config option

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -66,6 +66,7 @@ type Config struct {
 	Merge             mergeConfig
 	Bitwarden         bitwardenCmdConfig
 	CD                cdCmdConfig
+	Diff              diffCmdConfig
 	GenericSecret     genericSecretCmdConfig
 	Gopass            gopassCmdConfig
 	KeePassXC         keePassXCCmdConfig

--- a/cmd/docs.gen.go
+++ b/cmd/docs.gen.go
@@ -487,6 +487,7 @@ func init() {
 		"* [Import archives](#import-archives)\n" +
 		"* [Export archives](#export-archives)\n" +
 		"* [Use a non-git version control system](#use-a-non-git-version-control-system)\n" +
+		"* [Use a custom pager for the `diff` command](#use-a-custom-pager-for-the-diff-command)\n" +
 		"* [Use a merge tool other than vimdiff](#use-a-merge-tool-other-than-vimdiff)\n" +
 		"* [Migrate from a dotfile manager that uses symlinks](#migrate-from-a-dotfile-manager-that-uses-symlinks)\n" +
 		"\n" +
@@ -1203,6 +1204,16 @@ func init() {
 		"you'd like to see your VCS better supported, please [open an issue on\n" +
 		"GitHub](https://github.com/twpayne/chezmoi/issues/new/choose).\n" +
 		"\n" +
+		"## Use a custom pager for the `diff` command\n" +
+		"\n" +
+		"By default, chezmoi uses a built-in diff command. You can pipe the output into a\n" +
+		"pager of your choice. In your config file, specify the pager to use. For\n" +
+		"example, to use [`diff-so-fancy`](https://github.com/so-fancy/diff-so-fancy)\n" +
+		"specify:\n" +
+		"\n" +
+		"    [diff]\n" +
+		"        pager = \"diff-so-fancy\"\n" +
+		"\n" +
 		"## Use a merge tool other than vimdiff\n" +
 		"\n" +
 		"By default, chezmoi uses vimdiff, but you can use any merge tool of your choice.\n" +
@@ -1582,6 +1593,7 @@ func init() {
 		"| `color`                 | string   | `auto`                    | Colorize diffs                                      |\n" +
 		"| `data`                  | any      | *none*                    | Template data                                       |\n" +
 		"| `destDir`               | string   | `~`                       | Destination directory                               |\n" +
+		"| `diff.pager`            | string   | *none*                    | Pager                                               |\n" +
 		"| `dryRun`                | bool     | `false`                   | Dry run mode                                        |\n" +
 		"| `follow`                | bool     | `false`                   | Follow symlinks                                     |\n" +
 		"| `genericSecret.command` | string   | *none*                    | Generic secret command                              |\n" +
@@ -1877,6 +1889,13 @@ func init() {
 		"destination directory match the target state. If no targets are specified, print\n" +
 		"the commands required for all targets. It is equivalent to `chezmoi apply\n" +
 		"--dry-run --verbose`.\n" +
+		"\n" +
+		"If `diff.pager` is set in the configuration file then the output will be piped\n" +
+		"into this command.\n" +
+		"\n" +
+		"#### `--no-pager`\n" +
+		"\n" +
+		"Do not use the pager.\n" +
 		"\n" +
 		"#### `diff` examples\n" +
 		"\n" +

--- a/cmd/helps.gen.go
+++ b/cmd/helps.gen.go
@@ -140,7 +140,14 @@ var helps = map[string]help{
 			"  Print the approximate shell commands required to ensure that *targets* in the\n" +
 			"  destination directory match the target state. If no targets are specified,\n" +
 			"  print the commands required for all targets. It is equivalent to `chezmoi\n" +
-			"  apply --dry-run --verbose`.",
+			"  apply --dry-run --verbose`.\n" +
+			"\n" +
+			"  If `diff.pager` is set in the configuration file then the output will be piped\n" +
+			"  into this command.\n" +
+			"\n" +
+			"  `--no-pager`\n" +
+			"\n" +
+			"  Do not use the pager.",
 		example: "" +
 			"  chezmoi diff\n" +
 			"  chezmoi diff ~/.bashrc",

--- a/completions/chezmoi-completion.bash
+++ b/completions/chezmoi-completion.bash
@@ -664,6 +664,7 @@ _chezmoi_diff()
     flags_with_completion=()
     flags_completion=()
 
+    flags+=("--no-pager")
     flags+=("--color=")
     two_word_flags+=("--color")
     flags+=("--config=")

--- a/completions/chezmoi.zsh
+++ b/completions/chezmoi.zsh
@@ -307,6 +307,7 @@ function _chezmoi_data {
 
 function _chezmoi_diff {
   _arguments \
+    '--no-pager[disable pager]' \
     '--color[colorize diffs]:' \
     '(-c --config)'{-c,--config}'[config file]:' \
     '--debug[write debug logs]' \

--- a/docs/HOWTO.md
+++ b/docs/HOWTO.md
@@ -29,6 +29,7 @@
 * [Import archives](#import-archives)
 * [Export archives](#export-archives)
 * [Use a non-git version control system](#use-a-non-git-version-control-system)
+* [Use a custom pager for the `diff` command](#use-a-custom-pager-for-the-diff-command)
 * [Use a merge tool other than vimdiff](#use-a-merge-tool-other-than-vimdiff)
 * [Migrate from a dotfile manager that uses symlinks](#migrate-from-a-dotfile-manager-that-uses-symlinks)
 
@@ -744,6 +745,16 @@ The source VCS command is used in the chezmoi commands `init`, `source`, and
 `update`, and support for VCSes other than git is limited but easy to add. If
 you'd like to see your VCS better supported, please [open an issue on
 GitHub](https://github.com/twpayne/chezmoi/issues/new/choose).
+
+## Use a custom pager for the `diff` command
+
+By default, chezmoi uses a built-in diff command. You can pipe the output into a
+pager of your choice. In your config file, specify the pager to use. For
+example, to use [`diff-so-fancy`](https://github.com/so-fancy/diff-so-fancy)
+specify:
+
+    [diff]
+        pager = "diff-so-fancy"
 
 ## Use a merge tool other than vimdiff
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -180,6 +180,7 @@ The following configuration variables are available:
 | `color`                 | string   | `auto`                    | Colorize diffs                                      |
 | `data`                  | any      | *none*                    | Template data                                       |
 | `destDir`               | string   | `~`                       | Destination directory                               |
+| `diff.pager`            | string   | *none*                    | Pager                                               |
 | `dryRun`                | bool     | `false`                   | Dry run mode                                        |
 | `follow`                | bool     | `false`                   | Follow symlinks                                     |
 | `genericSecret.command` | string   | *none*                    | Generic secret command                              |
@@ -475,6 +476,13 @@ Print the approximate shell commands required to ensure that *targets* in the
 destination directory match the target state. If no targets are specified, print
 the commands required for all targets. It is equivalent to `chezmoi apply
 --dry-run --verbose`.
+
+If `diff.pager` is set in the configuration file then the output will be piped
+into this command.
+
+#### `--no-pager`
+
+Do not use the pager.
 
 #### `diff` examples
 


### PR DESCRIPTION
Fixes #673. cc @Gerrit-K.

This is isn't quite ready to merge yet, as it only uses the pager for `chezmoi diff`, not for `chezmoi -v`.

@Gerrit-K is this what you had in mind? Are you able to test this?