### PR TITLE
Fix hostname condition in how-to page

### DIFF
--- a/docs/HOWTO.md
+++ b/docs/HOWTO.md
@@ -216,7 +216,7 @@ that chezmoi should ignore, and are interpreted as templates. An example
 `.chezmoiignore` file might look like:
 
     README.md
-    {{- if ne .chezmoi.hostname "work-laptop" }}
+    {{- if eq .chezmoi.hostname "work-laptop" }}
     .work # only manage .work on work-laptop
     {{- end }}
 


### PR DESCRIPTION
On line 219, we can read the following:

```
{{- if ne .chezmoi.hostname "work-laptop" }}
    .work # only manage .work on work-laptop
{{- end }}
```
The comment in the condition hints at the body of the condition will be evaluated if this is the hostname is `work-laptop`. However, the condition uses negation instead of equality.

I suggest to update it to:

```
{{- if eq .chezmoi.hostname "work-laptop" }}
```
so the condition reflects the intention and also matches the same condition on line 176.

<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://github.com/twpayne/chezmoi/blob/master/docs/CONTRIBUTING.md

-->