### PR TITLE
Add Chocolatey to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ before you can use your system.
 chezmoi is distributed as a single stand-alone statically-linked binary with no
 dependencies that you can simply copy onto your machine and run. chezmoi
 provides one-line installs, pre-built binaries, packages for Linux and BSD
-distributions, Homebrew formulae, Scoop support on Windows, and a initial config
+distributions, Homebrew formulae, Scoop and Chocolatey support on Windows, and a initial config
 file generation mechanism to make installing your dotfiles on a new machine as
 painless as possible.
 

--- a/chezmoi.io/content/_index.md
+++ b/chezmoi.io/content/_index.md
@@ -153,7 +153,7 @@ before you can use your system.
 chezmoi is distributed as a single stand-alone statically-linked binary with no
 dependencies that you can simply copy onto your machine and run. chezmoi
 provides one-line installs, pre-built binaries, packages for Linux and BSD
-distributions, Homebrew formulae, Scoop support on Windows, and a initial config
+distributions, Homebrew formulae, Scoop and Chocolatey support on Windows, and a initial config
 file generation mechanism to make installing your dotfiles on a new machine as
 painless as possible.
 

--- a/cmd/docs.gen.go
+++ b/cmd/docs.gen.go
@@ -1355,6 +1355,7 @@ func init() {
 		"| NixOS Linux  | nix-env    | `nix-env -i chezmoi`                                                                        |\n" +
 		"| macOS        | Homebrew   | `brew install chezmoi`                                                                      |\n" +
 		"| Windows      | Scoop      | `scoop bucket add twpayne https://github.com/twpayne/scoop-bucket && scoop install chezmoi` |\n" +
+		"| Windows      | Chocolatey | `choco install chezmoi`                                                                     |\n" +
 		"\n" +
 		"## Pre-built Linux packages\n" +
 		"\n" +

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -29,7 +29,7 @@ Install chezmoi with a single command.
 | NixOS Linux  | nix-env    | `nix-env -i chezmoi`                                                                        |
 | macOS        | Homebrew   | `brew install chezmoi`                                                                      |
 | Windows      | Scoop      | `scoop bucket add twpayne https://github.com/twpayne/scoop-bucket && scoop install chezmoi` |
-| Windows      | Chocolatey | `choco install chezmoi` |
+| Windows      | Chocolatey | `choco install chezmoi`                                                                     |
 
 ## Pre-built Linux packages
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -29,6 +29,7 @@ Install chezmoi with a single command.
 | NixOS Linux  | nix-env    | `nix-env -i chezmoi`                                                                        |
 | macOS        | Homebrew   | `brew install chezmoi`                                                                      |
 | Windows      | Scoop      | `scoop bucket add twpayne https://github.com/twpayne/scoop-bucket && scoop install chezmoi` |
+| Windows      | Chocolatey | `choco install chezmoi` |
 
 ## Pre-built Linux packages
 


### PR DESCRIPTION
As someone who heavily relies on [Chocolatey ](https://chocolatey.org/) instead of Scoop for installing most software, I took the liberty to create a [package](https://chocolatey.org/packages/chezmoi) ([package source](https://github.com/rasmuskriest/Chocolatey-Packages/tree/master/chezmoi)) that updates automatically based on the GitHub releases.

This PR updates all documentation to include the Chocolatey package after/below Scoop.