### PR TITLE
 Read KeepassXC passwords from stdin rather than stdout

### DIFF
--- a/testdata/scripts/secretkeepassxc.txt
+++ b/testdata/scripts/secretkeepassxc.txt
@@ -1,0 +1,66 @@
+stdin $HOME/input
+chezmoi secret keepassxc -- show --show-protected secrets.kdbx example.com
+stdout examplelogin
+
+stdin $HOME/input
+chezmoi secret keepassxc -- show --attributes host-name --quiet --show-protected secrets.kdbx example.com
+stdout example.com
+
+stdin $HOME/input
+chezmoi apply
+cmp $HOME/.netrc golden/.netrc
+
+-- bin/keepass-test --
+#!/bin/sh
+
+case "$*" in
+"--version")
+    echo "2.5.4"
+    ;;
+"show --show-protected secrets.kdbx example.com")
+    cat <<EOF
+Title: example.com
+UserName: examplelogin
+Password: examplepassword
+URL: 
+Notes: 
+EOF
+    ;;
+"show --attributes host-name --quiet --show-protected secrets.kdbx example.com")
+    echo "example.com"
+    ;;
+*)
+    echo "keepass-test: invalid command: $*"
+    exit 1
+esac
+-- bin/keepass-test.cmd --
+@echo off
+IF "%*" == "--version" (
+    echo 2.5.4
+) ELSE IF "%*" == "show --show-protected secrets.kdbx example.com" (
+    echo.Title: example.com
+    echo.UserName: examplelogin
+    echo.Password: examplepassword
+    echo.URL: 
+    echo.Notes: 
+) ELSE IF "%*" == "show --attributes host-name --quiet --show-protected secrets.kdbx example.com" (
+    echo.example.com
+) ELSE (
+    echo keepass-test: invalid command: %*
+    echo "show --show-protected --attributes host-name secrets.kdbx example.com"
+    exit /b 1
+)
+-- home/user/input --
+fakepassword
+-- home/user/.config/chezmoi/chezmoi.toml --
+[keepassxc]
+    command = "keepass-test"
+    database = "secrets.kdbx"
+-- home/user/.local/share/chezmoi/private_dot_netrc.tmpl --
+machine {{ keepassxcAttribute "example.com" "host-name" }}
+login {{ (keepassxc "example.com").UserName }}
+password {{ (keepassxc "example.com").Password }}
+-- golden/.netrc --
+machine example.com
+login examplelogin
+password examplepassword


### PR DESCRIPTION
 * Fix a bug that tried to read KeepassXC passwords from stdout rather than stdin (Fixes #768)
 * Allow reading passwords from stdin even when it's not a terminal.
 * Add an integration test for KeepassXC features

<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://github.com/twpayne/chezmoi/blob/master/docs/CONTRIBUTING.md

-->