### PR TITLE
Add include template function

### DIFF
--- a/cmd/docs.gen.go
+++ b/cmd/docs.gen.go
@@ -1661,6 +1661,7 @@ func init() {
 		"* [Template functions](#template-functions)\n" +
 		"  * [`bitwarden` [*args*]](#bitwarden-args)\n" +
 		"  * [`gopass` *gopass-name*](#gopass-gopass-name)\n" +
+		"  * [`include` *filename*](#include-filename)\n" +
 		"  * [`keepassxc` *entry*](#keepassxc-entry)\n" +
 		"  * [`keepassxcAttribute` *entry* *attribute*](#keepassxcattribute-entry-attribute)\n" +
 		"  * [`keyring` *service* *user*](#keyring-service-user)\n" +
@@ -2544,6 +2545,11 @@ func init() {
 		"#### `gopass` examples\n" +
 		"\n" +
 		"    {{ gopass \"<pass-name>\" }}\n" +
+		"\n" +
+		"### `include` *filename*\n" +
+		"\n" +
+		"`include` returns the literal contents of the file named `*filename*`, relative\n" +
+		"to the source directory.\n" +
 		"\n" +
 		"### `keepassxc` *entry*\n" +
 		"\n" +

--- a/cmd/templatefuncs.go
+++ b/cmd/templatefuncs.go
@@ -1,0 +1,15 @@
+package cmd
+
+import "path/filepath"
+
+func init() {
+	config.addTemplateFunc("include", config.includeFunc)
+}
+
+func (c *Config) includeFunc(filename string) string {
+	contents, err := c.fs.ReadFile(filepath.Join(c.SourceDir, filename))
+	if err != nil {
+		panic(err)
+	}
+	return string(contents)
+}

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -68,6 +68,7 @@ Manage your dotfiles securely across multiple machines.
 * [Template functions](#template-functions)
   * [`bitwarden` [*args*]](#bitwarden-args)
   * [`gopass` *gopass-name*](#gopass-gopass-name)
+  * [`include` *filename*](#include-filename)
   * [`keepassxc` *entry*](#keepassxc-entry)
   * [`keepassxcAttribute` *entry* *attribute*](#keepassxcattribute-entry-attribute)
   * [`keyring` *service* *user*](#keyring-service-user)
@@ -951,6 +952,11 @@ with the same *gopass-name* will only invoke `gopass` once.
 #### `gopass` examples
 
     {{ gopass "<pass-name>" }}
+
+### `include` *filename*
+
+`include` returns the literal contents of the file named `*filename*`, relative
+to the source directory.
 
 ### `keepassxc` *entry*
 


### PR DESCRIPTION
As [suggested by](https://github.com/twpayne/chezmoi/issues/787#issuecomment-646823638) @Legion2.

This adds a template function `include` that includes the contents of a file relative to the source directory.

Notes:
* The literal contents of the file are included, the file is not interpreted as a template.
* If you want to include a template, then you need to put the file in `.chezmoitemplates` and use the `template` function.

@Legion2 I'm not sure whether we should add this there are a number of downsides:
* The `include`d file has to be added to `.chezmoiignore` or start with a `.` to prevent chezmoi from creating a file in the target state of the same name.
* The `include`d file cannot be a template itself.

In short, `include` does not add anything that cannot already be achieved with `.chezmoitemplates`, with the exception of allowing the `include`d file to be outside the `.chezmoitemplates` directory.

What are your thoughts on this?
