### PR TITLE
Fix installation path of gofumports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ ensure-tools: ensure-gofumports ensure-golangci-lint
 ensure-gofumports:
 	if [ ! -x bin/gofumports ] ; then \
 		mkdir -p bin ; \
-		( cd $$(mktemp -d) && go mod init tmp && GOBIN=${PWD}/bin go get mvdan.cc/gofumpt/gofumports ) ; \
+		( cd $$(mktemp -d) && go mod init tmp && GOBIN=$(shell pwd)/bin go get mvdan.cc/gofumpt/gofumports ) ; \
 	fi
 
 .PHONY: ensure-golangci-lint


### PR DESCRIPTION
${PWD} is empty unless that environmental variable is set. Instead we
run `pwd` in a shell to get our current directory.

`make test` was failing for me due to gofumports missing (due to it
being installed in /bin instead of ./bin). This fixes that.

Error I got before: 
```
[...]
golangci/golangci-lint info installed ./bin/golangci-lint
./bin/golangci-lint run
if [ ! -x bin/gofumports ] ; then \
        mkdir -p bin ; \
        ( cd $(mktemp -d) && go mod init tmp && GOBIN=/bin go get mvdan.cc/gofumpt/gofumports ) ; \
fi
go: creating new go.mod: module tmp
go: downloading mvdan.cc/gofumpt v0.0.0-20200802201014-ab5a8192947d
go: found mvdan.cc/gofumpt/gofumports in mvdan.cc/gofumpt v0.0.0-20200802201014-ab5a8192947d
go: downloading golang.org/x/tools v0.0.0-20200731060945-b5fad4ed8dd6
go: downloading github.com/google/go-cmp v0.5.1
go: downloading golang.org/x/mod v0.3.0
go: downloading golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
find . -name \*.go | xargs ./bin/gofumports -local github.com/twpayne/chezmoi -w
xargs: ./bin/gofumports: No such file or directory
make: *** [Makefile:24: format] Error 127
```

<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://github.com/twpayne/chezmoi/blob/master/docs/CONTRIBUTING.md

-->