### PR TITLE
Change pass unlock command

### DIFF
--- a/cmd/secretpass.go
+++ b/cmd/secretpass.go
@@ -41,7 +41,7 @@ func (c *Config) passFunc(id string) string {
 	}
 	name := c.Pass.Command
 	if !c.Pass.unlocked {
-		args := []string{"grep", "^$"}
+		args := []string{"grep", "$^"}
 		cmd := exec.Command(name, args...)
 		cmd.Stdin = c.Stdin
 		cmd.Stdout = c.Stdout

--- a/testdata/scripts/secretpass.txt
+++ b/testdata/scripts/secretpass.txt
@@ -8,7 +8,7 @@ cmp $HOME/.netrc golden/.netrc
 #!/bin/sh
 
 case "$*" in
-"grep ^$")
+"grep $^")
     ;;
 "show misc/example.com")
     echo "examplepassword"
@@ -19,8 +19,9 @@ case "$*" in
 esac
 -- bin/pass.cmd --
 @echo off
-REM Windows drops the leading ^ from the ^$ argument that chezmoi passes to "pass grep" so match on $ only.
-REM For background information, read http://daviddeley.com/autohotkey/parameters/parameters.htm#WIN.
+REM Matching "grep $^" seems more or less impossible on windows as it
+REM is an escape character in the cmd.exe shell. See
+REM https://github.com/twpayne/chezmoi/pull/839#issuecomment-670800462
 IF "%*" == "grep $" (
     exit /b 0
 ) ELSE IF "%*" == "show misc/example.com" (


### PR DESCRIPTION
Hi,

This changes the unlock command for pass from `^$` to `$^`. `^$` matches empty lines, causing the unlock step to print some grep matches if empty lines occur in the pass secrets. `$^` on the other hand (end of line followed by beginning of line) should never match anything. 

Note that `$^` was what @m-rey suggested from the beginning in https://github.com/twpayne/chezmoi/issues/784. 

Both `make test` and `make lint` succeed without error. I do not have access to a windows box though so I am not sure if the test on windows is correct. Based on the comment it seems that only leading ^'s are dropped, so that we can match `grep $^`, but I have not been able to verify this (we'll see when the CI runs I guess).