### PR TITLE
Allow getting pass pw from pinentry instead of 'unlocking' pass

### DIFF
--- a/cmd/secretpass.go
+++ b/cmd/secretpass.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"os/exec"
 
 	"github.com/spf13/cobra"
@@ -41,6 +42,8 @@ func (c *Config) passFunc(id string) string {
 	name := c.Pass.Command
 	args := []string{"show", id}
 	cmd := exec.Command(name, args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stderr = os.Stderr
 	output, err := c.mutator.IdempotentCmdOutput(cmd)
 	if err != nil {
 		panic(fmt.Errorf("%s %s: %w", name, chezmoi.ShellQuoteArgs(args), err))

--- a/cmd/secretpass.go
+++ b/cmd/secretpass.go
@@ -18,8 +18,7 @@ var passCmd = &cobra.Command{
 }
 
 type passCmdConfig struct {
-	Command  string
-	unlocked bool
+	Command string
 }
 
 var passCache = make(map[string]string)
@@ -40,17 +39,6 @@ func (c *Config) passFunc(id string) string {
 		return s
 	}
 	name := c.Pass.Command
-	if !c.Pass.unlocked {
-		args := []string{"grep", "^$"}
-		cmd := exec.Command(name, args...)
-		cmd.Stdin = c.Stdin
-		cmd.Stdout = c.Stdout
-		cmd.Stderr = c.Stderr
-		if err := cmd.Run(); err != nil {
-			panic(fmt.Errorf("%s %s: %w", name, chezmoi.ShellQuoteArgs(args), err))
-		}
-		c.Pass.unlocked = true
-	}
 	args := []string{"show", id}
 	cmd := exec.Command(name, args...)
 	output, err := c.mutator.IdempotentCmdOutput(cmd)

--- a/cmd/secretpass.go
+++ b/cmd/secretpass.go
@@ -41,7 +41,7 @@ func (c *Config) passFunc(id string) string {
 	}
 	name := c.Pass.Command
 	if !c.Pass.unlocked {
-		args := []string{"grep", "$^"}
+		args := []string{"grep", "^$"}
 		cmd := exec.Command(name, args...)
 		cmd.Stdin = c.Stdin
 		cmd.Stdout = c.Stdout

--- a/testdata/scripts/secretpass.txt
+++ b/testdata/scripts/secretpass.txt
@@ -8,8 +8,6 @@ cmp $HOME/.netrc golden/.netrc
 #!/bin/sh
 
 case "$*" in
-"grep ^$")
-    ;;
 "show misc/example.com")
     echo "examplepassword"
     ;;
@@ -19,11 +17,7 @@ case "$*" in
 esac
 -- bin/pass.cmd --
 @echo off
-REM Windows drops the leading ^ from the ^$ argument that chezmoi passes to "pass grep" so match on $ only.
-REM For background information, read http://daviddeley.com/autohotkey/parameters/parameters.htm#WIN.
-IF "%*" == "grep $" (
-    exit /b 0
-) ELSE IF "%*" == "show misc/example.com" (
+IF "%*" == "show misc/example.com" (
     echo | set /p=examplepassword
     exit /b 0
 ) ELSE (

--- a/testdata/scripts/secretpass.txt
+++ b/testdata/scripts/secretpass.txt
@@ -8,7 +8,7 @@ cmp $HOME/.netrc golden/.netrc
 #!/bin/sh
 
 case "$*" in
-"grep $^")
+"grep ^$")
     ;;
 "show misc/example.com")
     echo "examplepassword"
@@ -19,9 +19,8 @@ case "$*" in
 esac
 -- bin/pass.cmd --
 @echo off
-REM Matching "grep $^" seems more or less impossible on windows as it
-REM is an escape character in the cmd.exe shell. See
-REM https://github.com/twpayne/chezmoi/pull/839#issuecomment-670800462
+REM Windows drops the leading ^ from the ^$ argument that chezmoi passes to "pass grep" so match on $ only.
+REM For background information, read http://daviddeley.com/autohotkey/parameters/parameters.htm#WIN.
 IF "%*" == "grep $" (
     exit /b 0
 ) ELSE IF "%*" == "show misc/example.com" (


### PR DESCRIPTION
Tested for a week on archlinux without any observed side effects.

Here's a gif showing that a password prompt is opened both in a desktop environment and in a terminal without x:
![chezmoi](https://user-images.githubusercontent.com/18900601/90342732-c48b9c00-e00a-11ea-92a5-5541b8f42672.gif)

Saves quite a lot of time when `chezmoi apply`ing or `chezmoi diff`ing. 

I have not tested this on mac or windows.