### PR TITLE
added example for detecting WSL 2

### DIFF
--- a/cmd/docs.gen.go
+++ b/cmd/docs.gen.go
@@ -1425,8 +1425,23 @@ func init() {
 		"`/proc/kernel/osrelease`, which is available in the template variable\n" +
 		"`.chezmoi.kernel.osrelease`, for example:\n" +
 		"\n" +
+		"WSL 1:\n" +
 		"```\n" +
 		"{{ if (contains \"Microsoft\" .chezmoi.kernel.osrelease) }}\n" +
+		"# WSL-specific code\n" +
+		"{{ end }}\n" +
+		"```\n" +
+		"\n" +
+		"WSL 2:\n" +
+		"```\n" +
+		"{{ if (contains \"microsoft\" .chezmoi.kernel.osrelease) }}\n" +
+		"# WSL-specific code\n" +
+		"{{ end }}\n" +
+		"```\n" +
+		"\n" +
+		"WSL 2 since version 4.19.112:\n" +
+		"```\n" +
+		"{{ if (contains \"microsoft-WSL2\" .chezmoi.kernel.osrelease) }}\n" +
 		"# WSL-specific code\n" +
 		"{{ end }}\n" +
 		"```\n" +

--- a/docs/HOWTO.md
+++ b/docs/HOWTO.md
@@ -842,8 +842,23 @@ WSL can be detected by looking for the string `Microsoft` in
 `/proc/kernel/osrelease`, which is available in the template variable
 `.chezmoi.kernel.osrelease`, for example:
 
+WSL 1:
 ```
 {{ if (contains "Microsoft" .chezmoi.kernel.osrelease) }}
+# WSL-specific code
+{{ end }}
+```
+
+WSL 2:
+```
+{{ if (contains "microsoft" .chezmoi.kernel.osrelease) }}
+# WSL-specific code
+{{ end }}
+```
+
+WSL 2 since version 4.19.112:
+```
+{{ if (contains "microsoft-WSL2" .chezmoi.kernel.osrelease) }}
 # WSL-specific code
 {{ end }}
 ```


### PR DESCRIPTION
Updated the documentation for detecting WSL according to https://github.com/Microsoft/WSL/issues/423#issuecomment-611086412. In WSL 2 the string `microsoft` is lowercase and in newer versions there is also `-WSL2` in the string to unambiguously identify it.