### PR TITLE
Fixing onepasswordDetailsFields typo in the HOWTO docs

### DIFF
--- a/cmd/docs.gen.go
+++ b/cmd/docs.gen.go
@@ -1217,7 +1217,7 @@ func init() {
 		"Login details fields can be retrieved with the `onepasswordDetailsFields`\n" +
 		"function, for example:\n" +
 		"\n" +
-		"    {{- (onepasswordDetailsField \"uuid\").password.value }}\n" +
+		"    {{- (onepasswordDetailsFields \"uuid\").password.value }}\n" +
 		"\n" +
 		"Documents can be retrieved with:\n" +
 		"\n" +

--- a/docs/HOWTO.md
+++ b/docs/HOWTO.md
@@ -608,7 +608,7 @@ Then you can access `details.password` with the syntax:
 Login details fields can be retrieved with the `onepasswordDetailsFields`
 function, for example:
 
-    {{- (onepasswordDetailsField "uuid").password.value }}
+    {{- (onepasswordDetailsFields "uuid").password.value }}
 
 Documents can be retrieved with:
 


### PR DESCRIPTION
Insignificant change in the documentation that caused me some time and reading the code to find the missing (s), which was in the previous line. Might save someone else the time.
