### PR TITLE
Fix umask on Windows so new files are not created read-only by default.

### DIFF
--- a/internal/chezmoi/chezmoi_windows.go
+++ b/internal/chezmoi/chezmoi_windows.go
@@ -4,7 +4,7 @@ import "os"
 
 // GetUmask returns the umask.
 func GetUmask() os.FileMode {
-	return os.ModePerm
+	return os.FileMode(0)
 }
 
 // SetUmask sets the umask.


### PR DESCRIPTION
<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://github.com/twpayne/chezmoi/blob/master/docs/CONTRIBUTING.md

-->

This commit (https://github.com/twpayne/chezmoi/commit/592a363977a83945308018a6b1748647403bed6c) inadvertently made it so that whenever `chezmoi` updates one of my files (on Windows), it's set to "read only".  So if I make some changes to a file, apply it, then make some more changes, the second apply will fail because it can't overwrite the read-only file.

Going back to using `0` for the umask on Windows fixes the issue, but I'm not sure if this change was intentional.  Let me know if you foresee any problems with this and I can look for a different solution.