### PR TITLE
Opt in to data caching provided by newer versions of 1password-cli

### DIFF
--- a/cmd/docs.gen.go
+++ b/cmd/docs.gen.go
@@ -2065,7 +2065,8 @@ func init() {
 		"| `lastpass`      | `command`    | string   | `lpass`                   | Lastpass CLI command                                |\n" +
 		"| `merge`         | `args`       | []string | *none*                    | Extra args to 3-way merge command                   |\n" +
 		"|                 | `command`    | string   | `vimdiff`                 | 3-way merge command                                 |\n" +
-		"| `onepassword`   | `command`    | string   | `op`                      | 1Password CLI command                               |\n" +
+		"| `onepassword`   | `cache`      | bool     | `true`                    | Enable optional caching provided by `op`            |\n" +
+		"|                 | `command`    | string   | `op`                      | 1Password CLI command                               |\n" +
 		"| `pass`          | `command`    | string   | `pass`                    | Pass CLI command                                    |\n" +
 		"| `sourceVCS`     | `autoCommit` | bool     | `false`                   | Commit changes to the source state after any change |\n" +
 		"|                 | `autoPush`   | bool     | `false`                   | Push changes to the source state after any change   |\n" +

--- a/cmd/secretonepassword.go
+++ b/cmd/secretonepassword.go
@@ -1,12 +1,14 @@
 package cmd
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
 	"strings"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/spf13/cobra"
 
 	"github.com/twpayne/chezmoi/internal/chezmoi"
@@ -21,12 +23,18 @@ var onepasswordCmd = &cobra.Command{
 
 type onepasswordCmdConfig struct {
 	Command string
+	Cache   bool
 }
 
-var onepasswordOutputCache = make(map[string][]byte)
+var (
+	onepasswordVersion         *semver.Version
+	onepasswordOutputCache     = make(map[string][]byte)
+	onepasswordCacheArgVersion = semver.Version{Major: 1, Minor: 8, Patch: 0}
+)
 
 func init() {
 	config.Onepassword.Command = "op"
+	config.Onepassword.Cache = true
 	config.addTemplateFunc("onepassword", config.onepasswordFunc)
 	config.addTemplateFunc("onepasswordDocument", config.onepasswordDocumentFunc)
 	config.addTemplateFunc("onepasswordDetailsFields", config.onepasswordDetailsFieldsFunc)
@@ -34,11 +42,33 @@ func init() {
 	secretCmd.AddCommand(onepasswordCmd)
 }
 
+func (c *Config) getOnepasswordVersion() *semver.Version {
+	if onepasswordVersion != nil {
+		return onepasswordVersion
+	}
+	name := c.Onepassword.Command
+	args := []string{"--version"}
+	cmd := exec.Command(name, args...)
+	output, err := c.mutator.IdempotentCmdOutput(cmd)
+	if err != nil {
+		panic(fmt.Errorf("%s %s: %w", name, chezmoi.ShellQuoteArgs(args), err))
+	}
+	onepasswordVersion, err = semver.NewVersion(string(bytes.TrimSpace(output)))
+	if err != nil {
+		panic(fmt.Errorf("cannot parse version %q: %w", output, err))
+	}
+	return onepasswordVersion
+}
+
 func (c *Config) runOnepasswordCmd(cmd *cobra.Command, args []string) error {
 	return c.run("", c.Onepassword.Command, args...)
 }
 
 func (c *Config) onepasswordOutput(args []string) []byte {
+	if c.Onepassword.Cache && c.getOnepasswordVersion().Compare(onepasswordCacheArgVersion) >= 0 {
+		args = append(args, "--cache")
+	}
+
 	key := strings.Join(args, "\x00")
 	if output, ok := onepasswordOutputCache[key]; ok {
 		return output

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -215,7 +215,8 @@ The following configuration variables are available:
 | `lastpass`      | `command`    | string   | `lpass`                   | Lastpass CLI command                                |
 | `merge`         | `args`       | []string | *none*                    | Extra args to 3-way merge command                   |
 |                 | `command`    | string   | `vimdiff`                 | 3-way merge command                                 |
-| `onepassword`   | `command`    | string   | `op`                      | 1Password CLI command                               |
+| `onepassword`   | `cache`      | bool     | `true`                    | Enable optional caching provided by `op`            |
+|                 | `command`    | string   | `op`                      | 1Password CLI command                               |
 | `pass`          | `command`    | string   | `pass`                    | Pass CLI command                                    |
 | `sourceVCS`     | `autoCommit` | bool     | `false`                   | Commit changes to the source state after any change |
 |                 | `autoPush`   | bool     | `false`                   | Push changes to the source state after any change   |


### PR DESCRIPTION
The new `--cache` option is provided on all platforms even though no actual caching is done on Windows (🤞 for the future). Also, the option is _not_ automatically added to commands run with `chezmoi secret onepassword` to keep it a pure pass-through.  If people need caching that way, they can simply specify the option themselves. 

<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://github.com/twpayne/chezmoi/blob/master/docs/CONTRIBUTING.md

-->
