### PR TITLE
docs(TEMPLATING): trivial spelling fix

### DIFF
--- a/docs/TEMPLATING.md
+++ b/docs/TEMPLATING.md
@@ -161,7 +161,7 @@ chezmoi will output the current OS and architecture to stdout.
 
 You can also feed the contents of a file to this command by typing:
 
-	cat foo.txt | chezmoi exectute-template
+	cat foo.txt | chezmoi execute-template
 
 ## Simple logic
 


### PR DESCRIPTION
One letter spelling fix I spotted while reading the docs -- `exectute-template` should be `execute-template`. 
