### PR TITLE
Fix GOLANGCI missing version patch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GOLANGCI_LINT_VERSION=1.33
+GOLANGCI_LINT_VERSION=1.33.0
 
 .PHONY: default
 default: generate run test lint format


### PR DESCRIPTION
When running `make lint`, it fails locally with the following message:

```
golangci/golangci-lint info checking GitHub for tag 'v1.33'
golangci/golangci-lint crit unable to find 'v1.33' - use 'latest' or see https://github.com/golangci/golangci-lint/releases for details
```

This PR fixes this issue. 