### PR TITLE
Check if SourceDir begins with a home dir prefix

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -115,6 +115,15 @@ func init() {
 					"warning: to disable this warning, set sourceVCS.notGit = true in your config file\n",
 				)
 			}
+
+			if strings.HasPrefix(config.SourceDir, "~/") {
+				home, _ := os.UserHomeDir()
+				config.SourceDir = filepath.Join(home, config.SourceDir[2:])
+			} else if strings.HasPrefix(config.SourceDir, "~") {
+				home, _ := os.UserHomeDir()
+				config.SourceDir = filepath.Join(home, config.SourceDir[1:])
+			}
+
 		case os.IsNotExist(err):
 		default:
 			initErr = err

--- a/main_test.go
+++ b/main_test.go
@@ -288,7 +288,7 @@ func cmdUNIX2DOS(ts *testscript.TestScript, neg bool, args []string) {
 		dosData, err := unix2DOS(data)
 		ts.Check(err)
 		//nolint:gosec
-		if err := ioutil.WriteFile(filename, dosData, 0666); err != nil {
+		if err := ioutil.WriteFile(filename, dosData, 0o666); err != nil {
 			ts.Fatalf("%s: %v", filename, err)
 		}
 	}


### PR DESCRIPTION
Running `chezmoi {appy,doctor}` fails because chezmoi does not expand the home's tilde. This PR check if `SourceDir` has a prefix of `~/` or `~` and expands the home directory accordingly.

Example:

```toml
sourceDir: ~/dotfiles
data:
        ...
```

Before:
```
warning: version dev
     ok: runtime.GOOS darwin, runtime.GOARCH amd64
  ERROR: ~/dotfiles: (source directory, not found)
       : lstat ~/dotfiles: no such file or directory
....
```
After:
```
warning: version dev
     ok: runtime.GOOS darwin, runtime.GOARCH amd64
     ok: /Users/seds/dotfiles (source directory, perm 700)
     ok: /Users/seds (destination directory, perm 755)
```
