### PR TITLE
Fix typo in error check

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -366,7 +366,7 @@ func (c *Config) getDefaultData() (map[string]interface{}, error) {
 	// If the current user could be determined, then attempt to lookup the group
 	// id. There is no fallback.
 	if currentUser != nil {
-		if group, err := user.LookupGroupId(currentUser.Gid); err != nil {
+		if group, err := user.LookupGroupId(currentUser.Gid); err == nil {
 			data["group"] = group.Name
 		}
 	}


### PR DESCRIPTION
This prevents a nil pointer deref when there actually was an error looking up the group (which is nearly always the case on WIndows).  I expect that `group` wasn't actually getting added to `data` on non-Windows platforms either, which this should also fix.  I haven't actually verified this myself though.

<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://github.com/twpayne/chezmoi/blob/master/docs/CONTRIBUTING.md

-->
