### PR TITLE
chezmoi2: Restore secret keyring command

### DIFF
--- a/chezmoi2/cmd/config.go
+++ b/chezmoi2/cmd/config.go
@@ -111,6 +111,7 @@ type Config struct {
 	init            initCmdConfig
 	managed         managedCmdConfig
 	purge           purgeCmdConfig
+	secretKeyring   secretKeyringCmdConfig
 	status          statusCmdConfig
 	update          updateCmdConfig
 	verify          verifyCmdConfig
@@ -784,6 +785,7 @@ func (c *Config) newRootCmd() (*cobra.Command, error) {
 		c.newMergeCmd,
 		c.newPurgeCmd,
 		c.newRemoveCmd,
+		c.newSecretCmd,
 		c.newSourcePathCmd,
 		c.newStateCmd,
 		c.newStatusCmd,

--- a/chezmoi2/cmd/secretcmd.go
+++ b/chezmoi2/cmd/secretcmd.go
@@ -1,0 +1,17 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+func (c *Config) newSecretCmd() *cobra.Command {
+	secretCmd := &cobra.Command{
+		Use:     "secret",
+		Args:    cobra.NoArgs,
+		Short:   "Interact with a secret manager",
+		Long:    mustLongHelp("secret"),
+		Example: example("secret"),
+	}
+
+	secretCmd.AddCommand(c.newSecretKeyringCmd())
+
+	return secretCmd
+}

--- a/chezmoi2/cmd/secretkeyringcmd.go
+++ b/chezmoi2/cmd/secretkeyringcmd.go
@@ -22,6 +22,17 @@ func (c *Config) newSecretKeyringCmd() *cobra.Command {
 		Short: "Interact with keyring",
 	}
 
+	persistentFlags := keyringCmd.PersistentFlags()
+	persistentFlags.StringVar(&c.secretKeyring.service, "service", "", "service")
+	if err := keyringCmd.MarkPersistentFlagRequired("service"); err != nil {
+		panic(err)
+	}
+
+	persistentFlags.StringVar(&c.secretKeyring.user, "user", "", "user")
+	if err := keyringCmd.MarkPersistentFlagRequired("user"); err != nil {
+		panic(err)
+	}
+
 	keyringGetCmd := &cobra.Command{
 		Use:   "get",
 		Args:  cobra.NoArgs,

--- a/chezmoi2/cmd/secretkeyringcmd.go
+++ b/chezmoi2/cmd/secretkeyringcmd.go
@@ -1,0 +1,63 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/zalando/go-keyring"
+	"golang.org/x/term"
+)
+
+type secretKeyringCmdConfig struct {
+	service string
+	user    string
+	value   string
+}
+
+func (c *Config) newSecretKeyringCmd() *cobra.Command {
+	keyringCmd := &cobra.Command{
+		Use:   "keyring",
+		Args:  cobra.NoArgs,
+		Short: "Interact with keyring",
+	}
+
+	keyringGetCmd := &cobra.Command{
+		Use:   "get",
+		Args:  cobra.NoArgs,
+		Short: "Get a value from keyring",
+		RunE:  c.runKeyringGetCmdE,
+	}
+	keyringCmd.AddCommand(keyringGetCmd)
+
+	keyringSetCmd := &cobra.Command{
+		Use:   "set",
+		Args:  cobra.NoArgs,
+		Short: "Set a value in keyring",
+		RunE:  c.runKeyringSetCmdE,
+	}
+	keyringCmd.AddCommand(keyringSetCmd)
+
+	return keyringCmd
+}
+
+func (c *Config) runKeyringGetCmdE(cmd *cobra.Command, args []string) error {
+	value, err := keyring.Get(c.secretKeyring.service, c.secretKeyring.user)
+	if err != nil {
+		return err
+	}
+	return c.writeOutputString(value)
+}
+
+func (c *Config) runKeyringSetCmdE(cmd *cobra.Command, args []string) error {
+	valueStr := c.secretKeyring.value
+	if valueStr == "" {
+		fmt.Print("Value: ")
+		value, err := term.ReadPassword(int(os.Stdin.Fd()))
+		if err != nil {
+			return err
+		}
+		valueStr = string(value)
+	}
+	return keyring.Set(c.secretKeyring.service, c.secretKeyring.user, valueStr)
+}


### PR DESCRIPTION
Refs #987.

As [reported by](https://github.com/twpayne/chezmoi/issues/987#issuecomment-761884922) @zb140.

> Is the `chezmoi secret` subcommand permanently gone?

No :) I just didn't realize that it was actively used. This PR restores it for `secret keyring`. For other password managers, I think that the password manager's CLI should be a better option than using `chezmoi secret` but let's see what users report.

> I've been using it as part of my secret caching scheme to work around the perf issues in 1password. Specifically, I'm caching secrets in keepass and storing the keepass db password in the OS keyring (which gets unlocked when I sign into the computer). Then I use a shell alias to do `chezmoi secret keyring get --service secret_cache_pw --user zb | chezmoi apply` to apply dotfile changes. I'm sure I can find a workaround if needed.

This PR should fix this, but there's a deeper issue here that this PR doesn't address. chezmoi2 tries to read passwords from a TTY, and will get one if necessary. It so happens that I don't know how to do this on Windows yet (see https://github.com/twpayne/chezmoi/blob/master/chezmoi2/cmd/config.go#L634-L651) so on Windows chezmoi2 will happily read a password from stdin. The long term fix is probably to (a) read passwords from a TTY on Windows and (b) add a flag to allow passwords to be read from stdin if needed.

@zb140 would you mind testing this PR? Please do merge it or push fixes to this branch if needed.