### PR TITLE
docs(REFERENCE): clarify .chezmoiignore patterns

### DIFF
--- a/cmd/docs.gen.go
+++ b/cmd/docs.gen.go
@@ -2195,7 +2195,10 @@ func init() {
 		"\n" +
 		"    *.txt   # ignore *.txt in the target directory\n" +
 		"    */*.txt # ignore *.txt in subdirectories of the target directory\n" +
-		"    backups/** # ignore backups folder in chezmoi directory and all its contents\n" +
+		"            # but not in subdirectories of subdirectories;\n" +
+		"            # so a/b/c.txt would *not* be ignored\n" +
+		"    backups/** # ignore all contents of backups folder in chezmoi directory\n" +
+		"               # but not backups folder itself\n" +
 		"\n" +
 		"    {{- if ne .email \"john.smith@company.com\" }}\n" +
 		"    # Ignore .company-directory unless configured with a company email\n" +

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -332,7 +332,10 @@ ignored on different machines.
 
     *.txt   # ignore *.txt in the target directory
     */*.txt # ignore *.txt in subdirectories of the target directory
-    backups/** # ignore backups folder in chezmoi directory and all its contents
+            # but not in subdirectories of subdirectories;
+            # so a/b/c.txt would *not* be ignored
+    backups/** # ignore all contents of backups folder in chezmoi directory
+               # but not backups folder itself
 
     {{- if ne .email "john.smith@company.com" }}
     # Ignore .company-directory unless configured with a company email


### PR DESCRIPTION
Docs incorrectly state that the pattern

    backups/**

in a `.chezmoiignore` file would ignore `backups` and all its contents recursively; the pattern ignores all the contents of `backups` but not the directory itself. (As a consequence, `chezmoi add` would add `backups` with a `.keep` file in it, but not any of the files or folders in `backups` itself.)

This behavior comes from the `doublestar` library, which has [a test ensuring that `**` patterns work this way](https://github.com/bmatcuk/doublestar/blob/v1.3.4/doublestar_test.go#L87), so this is presumably the intended behavior.