### PR TITLE
CI: Add artifact capture "nightlies" to Github Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,12 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: chezmoi2-${{ matrix.os }}
-        path: dist/chezmoi*
+        path: dist/chezmoi2
+    - name: Artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: chezmoi-${{ matrix.os }}
+        path: dist/chezmoi
   test-release:
     runs-on: ubuntu-18.04
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,12 +49,16 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: chezmoi2-${{ matrix.os }}
-        path: dist/chezmoi2
+        path: |
+          dist/chezmoi2
+          dist/chezmoi2.exe
     - name: Artifact
       uses: actions/upload-artifact@v2
       with:
         name: chezmoi-${{ matrix.os }}
-        path: dist/chezmoi
+        path: |
+          dist/chezmoi
+          dist/chezmoi.exe
   test-release:
     runs-on: ubuntu-18.04
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,20 +45,6 @@ jobs:
         go run ./chezmoi2 --version
     - name: Test
       run: go test -race ./...
-    - name: Artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: chezmoi2-${{ matrix.os }}
-        path: |
-          dist/chezmoi2
-          dist/chezmoi2.exe
-    - name: Artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: chezmoi-${{ matrix.os }}
-        path: |
-          dist/chezmoi
-          dist/chezmoi.exe
   test-release:
     runs-on: ubuntu-18.04
     steps:
@@ -92,6 +78,41 @@ jobs:
         ./dist/chezmoi-cgo-glibc_linux_amd64/chezmoi --version | tee /dev/stderr | grep -q "chezmoi version v"
         ./dist/chezmoi-cgo-musl_linux_amd64/chezmoi --version | tee /dev/stderr | grep -q "chezmoi version v"
         ./dist/chezmoi-nocgo_linux_386/chezmoi --version | tee /dev/stderr | grep -q "chezmoi version v"
+
+    - name: Artifact chezmoi2-windows-amd64
+      uses: actions/upload-artifact@v2
+      with:
+        name: chezmoi2-windows-amd64
+        path: dist/chezmoi2-nocgo_windows_amd64/chezmoi.exe
+
+    - name: Artifact chezmoi-windows-amd64
+      uses: actions/upload-artifact@v2
+      with:
+        name: chezmoi-windows-amd64
+        path: dist/chezmoi-nocgo_windows_amd64/chezmoi.exe
+
+    - name: Artifact chezmoi2-linux-amd64
+      uses: actions/upload-artifact@v2
+      with:
+        name: chezmoi2-linux-amd64
+        path: dist/chezmoi2-nocgo_linux_amd64/chezmoi
+
+    - name: Artifact chezmoi-linux-amd64
+      uses: actions/upload-artifact@v2
+      with:
+        name: chezmoi-linux-amd64
+        path: dist/chezmoi-nocgo_linux_amd64/chezmoi
+
+    - name: Artifact chezmoi2-macos-amd64
+      uses: actions/upload-artifact@v2
+      with:
+        name: chezmoi2-macos-amd64
+        path: dist/chezmoi2-nocgo_darwin_amd64/chezmoi
+    - name: Artifact chezmoi-windows-amd64
+      uses: actions/upload-artifact@v2
+      with:
+        name: chezmoi-windows-amd64
+        path: dist/chezmoi-nocgo_darwin_amd64/chezmoi
   generate:
     runs-on: ubuntu-18.04
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,23 +95,36 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: chezmoi2-linux-amd64
-        path: dist/chezmoi2-nocgo_linux_amd64/chezmoi
+        path: dist/chezmoi2-cgo-glibc_linux_amd64/chezmoi
 
     - name: Artifact chezmoi-linux-amd64
       uses: actions/upload-artifact@v2
       with:
         name: chezmoi-linux-amd64
-        path: dist/chezmoi-nocgo_linux_amd64/chezmoi
+        path: dist/chezmoi-cgo-glibc_linux_amd64/chezmoi
+
+    - name: Artifact chezmoi2-linux-musl-amd64
+      uses: actions/upload-artifact@v2
+      with:
+        name: chezmoi2-linux-musl-amd64
+        path: dist/chezmoi2-cgo-musl_linux_amd64/chezmoi
+
+    - name: Artifact chezmoi-linux-musl-amd64
+      uses: actions/upload-artifact@v2
+      with:
+        name: chezmoi-linux-musl-amd64
+        path: dist/chezmoi-cgo-musl_linux_amd64/chezmoi
 
     - name: Artifact chezmoi2-macos-amd64
       uses: actions/upload-artifact@v2
       with:
         name: chezmoi2-macos-amd64
         path: dist/chezmoi2-nocgo_darwin_amd64/chezmoi
-    - name: Artifact chezmoi-windows-amd64
+
+    - name: Artifact chezmoi-macos-amd64
       uses: actions/upload-artifact@v2
       with:
-        name: chezmoi-windows-amd64
+        name: chezmoi-macos-amd64
         path: dist/chezmoi-nocgo_darwin_amd64/chezmoi
   generate:
     runs-on: ubuntu-18.04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,13 +36,20 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Build
-      run: go build ./...
+      run: |
+        mkdir dist
+        go build -o dist ./...
     - name: Run
       run: |
         go run . --version
         go run ./chezmoi2 --version
     - name: Test
       run: go test -race ./...
+    - name: Artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: chezmoi2-${{ matrix.os }}
+        path: dist/chezmoi*
   test-release:
     runs-on: ubuntu-18.04
     steps:


### PR DESCRIPTION
This PR will capture the binaries to artifacts so that every commit has an available downloadable build to test, allowing rapid testing of new features without needing a development environment.

Currently capturing both Chezmoi1 and Chezmoi2

https://github.com/twpayne/chezmoi/pull/1009/checks?check_run_id=1756221264#step:9:15
![image](https://user-images.githubusercontent.com/15258962/105623133-304d0e80-5dcc-11eb-8ba2-83f18235ca32.png)

<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://github.com/twpayne/chezmoi/blob/master/docs/CONTRIBUTING.md

-->
