### PR TITLE
Fix the install.ps1 script to better support Powershell v5

### DIFF
--- a/chezmoi2/cmd/docs.gen.go
+++ b/chezmoi2/cmd/docs.gen.go
@@ -1731,7 +1731,14 @@ func init() {
 		"\n" +
 		"Or on systems with Powershell, you can use this command:\n" +
 		"\n" +
+		"    # To install in ./bin\n" +
 		"    (iwr https://git.io/chezmoi.ps1).Content | powershell -c -\n" +
+		"\n" +
+		"    # To install in another location\n" +
+		"    '$params = \"-BinDir ~/other\"', (iwr https://git.io/chezmoi.ps1).Content | powershell -c -\n" +
+		"\n" +
+		"    # For information about other options, try this:\n" +
+		"    '$params = \"-?\"', (iwr https://git.io/chezmoi.ps1).Content | powershell -c -\n" +
 		"\n" +
 		"## One-line package install\n" +
 		"\n" +

--- a/cmd/docs.gen.go
+++ b/cmd/docs.gen.go
@@ -1731,7 +1731,14 @@ func init() {
 		"\n" +
 		"Or on systems with Powershell, you can use this command:\n" +
 		"\n" +
+		"    # To install in ./bin\n" +
 		"    (iwr https://git.io/chezmoi.ps1).Content | powershell -c -\n" +
+		"\n" +
+		"    # To install in another location\n" +
+		"    '$params = \"-BinDir ~/other\"', (iwr https://git.io/chezmoi.ps1).Content | powershell -c -\n" +
+		"\n" +
+		"    # For information about other options, try this:\n" +
+		"    '$params = \"-?\"', (iwr https://git.io/chezmoi.ps1).Content | powershell -c -\n" +
 		"\n" +
 		"## One-line package install\n" +
 		"\n" +

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -18,7 +18,14 @@ with a single command.
 
 Or on systems with Powershell, you can use this command:
 
+    # To install in ./bin
     (iwr https://git.io/chezmoi.ps1).Content | powershell -c -
+
+    # To install in another location
+    '$params = "-BinDir ~/other"', (iwr https://git.io/chezmoi.ps1).Content | powershell -c -
+
+    # For information about other options, try this:
+    '$params = "-?"', (iwr https://git.io/chezmoi.ps1).Content | powershell -c -
 
 ## One-line package install
 


### PR DESCRIPTION
  * Fix architecture detection
  * Use built-in Expand-Archive to unzip packages.

Document some examples of how to run the install script

Fixes #1006 

<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://github.com/twpayne/chezmoi/blob/master/docs/CONTRIBUTING.md

-->
