### PR TITLE
Fix: State Version Check Fails with Artifacts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,7 +68,7 @@ jobs:
       uses: goreleaser/goreleaser-action@v2
       with:
         version: latest
-        args: release --skip-publish --snapshot
+        args: release --skip-publish
     - name: Test release
       run: |
         # verify that version information is embedded correctly


### PR DESCRIPTION
Current snapshot artifacts fail with:
`chezmoi: source state requires version 0.0.0 or later, chezmoi is version 0.0.0-SNAPSHOT-3bc8688`

Removing -snapshot will generate normal versions.

<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://github.com/twpayne/chezmoi/blob/master/docs/CONTRIBUTING.md

-->
