### PR TITLE
Add BitwardenAttachment template support

### DIFF
--- a/cmd/docs.gen.go
+++ b/cmd/docs.gen.go
@@ -2009,6 +2009,7 @@ func init() {
 		"* [Template functions](#template-functions)\n" +
 		"  * [`bitwarden` [*args*]](#bitwarden-args)\n" +
 		"  * [`bitwardenFields` [*args*]](#bitwardenfields-args)\n" +
+		"  * [`bitwardenAttachment` [*args*]](#bitwardenattachment-args)\n" +
 		"  * [`gopass` *gopass-name*](#gopass-gopass-name)\n" +
 		"  * [`include` *filename*](#include-filename)\n" +
 		"  * [`ioreg`](#ioreg)\n" +
@@ -3010,6 +3011,22 @@ func init() {
 		"#### `bitwardenFields` examples\n" +
 		"\n" +
 		"    {{ (bitwardenFields \"item\" \"example.com\").token.value }}\n" +
+		"\n" +
+		"### `bitwardenAttachment` _filename_ _itemid_\n" +
+		"\n" +
+		"`bitwardenAttachment` returns a document from [Bitwarden](https://bitwarden.com/)\n" +
+		"using the [Bitwarden CLI](https://bitwarden.com/help/article/cli/) (`bw`). _filename_\n" +
+		"and _itemid_ is passed to `bw get attachment <filename> --itemid <itemid>`\n" +
+		"and the output from `bw` is returned. The output from `bw` is cached so calling\n" +
+		"`bitwardenAttachment` multiple times with the same _filename_ and _itemid_ will only\n" +
+		"invoke `bw` once. _Beware_ that using the `id` instead of a filename, will expose your\n" +
+		"file publicly, as the `id` + `itemid` is built into the following URL in Bitwarden:\n" +
+		"`\"https://cdn.bitwarden.net/attachments/<id>/<itemid>\"`, which allows anyone to download\n" +
+		"your files.\n" +
+		"\n" +
+		"#### `bitwardenAttachment` examples\n" +
+		"\n" +
+		"    {{- (bitwardenAttachment \"<filename>\" \"<itemid>\") -}}\n" +
 		"\n" +
 		"### `gopass` *gopass-name*\n" +
 		"\n" +

--- a/cmd/docs.gen.go
+++ b/cmd/docs.gen.go
@@ -3019,10 +3019,7 @@ func init() {
 		"and _itemid_ is passed to `bw get attachment <filename> --itemid <itemid>`\n" +
 		"and the output from `bw` is returned. The output from `bw` is cached so calling\n" +
 		"`bitwardenAttachment` multiple times with the same _filename_ and _itemid_ will only\n" +
-		"invoke `bw` once. _Beware_ that using the `id` instead of a filename, will expose your\n" +
-		"file publicly, as the `id` + `itemid` is built into the following URL in Bitwarden:\n" +
-		"`\"https://cdn.bitwarden.net/attachments/<id>/<itemid>\"`, which allows anyone to download\n" +
-		"your files.\n" +
+		"invoke `bw` once.\n" +
 		"\n" +
 		"#### `bitwardenAttachment` examples\n" +
 		"\n" +

--- a/cmd/secretbitwarden.go
+++ b/cmd/secretbitwarden.go
@@ -29,6 +29,7 @@ func init() {
 	config.Bitwarden.Command = "bw"
 	config.addTemplateFunc("bitwarden", config.bitwardenFunc)
 	config.addTemplateFunc("bitwardenFields", config.bitwardenFieldsFunc)
+	config.addTemplateFunc("bitwardenAttachment", config.bitwardenAttachmentFunc)
 
 	secretCmd.AddCommand(bitwardenCmd)
 }
@@ -80,4 +81,8 @@ func (c *Config) bitwardenFieldsFunc(args ...string) map[string]interface{} {
 		}
 	}
 	return result
+}
+
+func (c *Config) bitwardenAttachmentFunc(name, itemID string) string {
+	return string(c.bitwardenOutput([]string{"get", "attachment", name, "--itemid", itemID, "--raw"}))
 }

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -1079,10 +1079,7 @@ using the [Bitwarden CLI](https://bitwarden.com/help/article/cli/) (`bw`). _file
 and _itemid_ is passed to `bw get attachment <filename> --itemid <itemid>`
 and the output from `bw` is returned. The output from `bw` is cached so calling
 `bitwardenAttachment` multiple times with the same _filename_ and _itemid_ will only
-invoke `bw` once. _Beware_ that using the `id` instead of a filename, will expose your
-file publicly, as the `id` + `itemid` is built into the following URL in Bitwarden:
-`"https://cdn.bitwarden.net/attachments/<id>/<itemid>"`, which allows anyone to download
-your files.
+invoke `bw` once.
 
 #### `bitwardenAttachment` examples
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -69,6 +69,7 @@ Manage your dotfiles securely across multiple machines.
 * [Template functions](#template-functions)
   * [`bitwarden` [*args*]](#bitwarden-args)
   * [`bitwardenFields` [*args*]](#bitwardenfields-args)
+  * [`bitwardenAttachment` [*args*]](#bitwardenattachment-args)
   * [`gopass` *gopass-name*](#gopass-gopass-name)
   * [`include` *filename*](#include-filename)
   * [`ioreg`](#ioreg)
@@ -1070,6 +1071,22 @@ same arguments will only invoke `bw` once.
 #### `bitwardenFields` examples
 
     {{ (bitwardenFields "item" "example.com").token.value }}
+
+### `bitwardenAttachment` _filename_ _itemid_
+
+`bitwardenAttachment` returns a document from [Bitwarden](https://bitwarden.com/)
+using the [Bitwarden CLI](https://bitwarden.com/help/article/cli/) (`bw`). _filename_
+and _itemid_ is passed to `bw get attachment <filename> --itemid <itemid>`
+and the output from `bw` is returned. The output from `bw` is cached so calling
+`bitwardenAttachment` multiple times with the same _filename_ and _itemid_ will only
+invoke `bw` once. _Beware_ that using the `id` instead of a filename, will expose your
+file publicly, as the `id` + `itemid` is built into the following URL in Bitwarden:
+`"https://cdn.bitwarden.net/attachments/<id>/<itemid>"`, which allows anyone to download
+your files.
+
+#### `bitwardenAttachment` examples
+
+    {{- (bitwardenAttachment "<filename>" "<itemid>") -}}
 
 ### `gopass` *gopass-name*
 

--- a/testdata/scripts/bitwarden.txt
+++ b/testdata/scripts/bitwarden.txt
@@ -9,6 +9,11 @@ stdout password-value
 chezmoi execute-template '{{ (bitwardenFields "item" "example.com").Hidden.value }}'
 stdout hidden-value
 
+[short] stop
+
+chezmoi execute-template '{{ (bitwardenAttachment "filename" "item-id") }}'
+stdout hidden-file-value
+
 -- bin/bw --
 #!/bin/sh
 
@@ -45,6 +50,11 @@ case "$*" in
   "collectionIds": [],
   "revisionDate": "2020-10-28T00:21:02.690Z"
 }
+EOF
+   ;;
+"get attachment filename --itemid item-id --raw")
+    cat <<EOF
+hidden-file-value
 EOF
     ;;
 *)
@@ -85,6 +95,8 @@ IF "%*" == "get item example.com" (
     echo.  "collectionIds": [],
     echo.  "revisionDate": "2020-10-28T00:21:02.690Z"
     echo.}
+) ELSE IF "%*" == "get attachment filename --itemid item-id --raw" (
+    echo. hidden-file-value
 ) ELSE (
     echo Invalid command: $*
     echo "See --help for a list of available commands."


### PR DESCRIPTION
This "mimics" `onepasswordDocument` for Bitwarden. I found an "issue" with Bitwarden while implementing this feature. Basically Bitwarden's file URL is build upon the `ID` + `itemid`, which makes anyone who exposes both `ids` to expose their files. 

Here is an example of the payload (with dummy values), pay attention to `id` and `id` in `attachments`, then the `url`:

```
[
  ...
  {
    "object": "item",
    "id": "98ebec3b-3a9f-4220-9ae2-",
    "organizationId": null,
    "folderId": "C6BE41BF-A86F-455D-B9EB-E36F6E2D37E2",
    "type": 2,
    "name": ".ssh/id_rsa.pub",
    "notes": null,
    "favorite": false,
    "secureNote": {
      "type": 0
    },
    "collectionIds": [],
    "attachments": [
      {
        "id": "arandom-id",
        "fileName": "id_rsa.pub",
        "size": "625",
        "sizeName": "625 Bytes",
        "url": "https://cdn.bitwarden.net/attachments/C6BE41BF-A86F-455D-B9EB-E36F6E2D37E2/arandomid"
      }
    ],
    "revisionDate": "2021-02-02T15:28:04.683Z"
  }
]
```

This can be avoided **IF** the user actually reads the docs... But I am still a bit afraid someone uses something like the following:

```
    {{- (bitwardenAttachment "C6BE41BF-A86F-455D-B9EB-E36F6E2D37E2" "random-id") -}}
```
Which exposes the file. We would for example, check whether the user is using two ids instead of a `filename` and return an error/warning. But I would like to review any other options. 

I've commited the docs and the code altogether, which is easier when reverting, but I could separate them if required.

Regarding `chezmoi2`, I was unsure whether I should move this to `chezmoi2` or wait a bit more. 