### PR TITLE
Preserve homedir template variable until v2.1

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -492,6 +492,7 @@ func (c *Config) defaultTemplateData() map[string]interface{} {
 	data := map[string]interface{}{
 		"arch":      runtime.GOARCH,
 		"homeDir":   c.homeDir,
+		"homedir":   c.homeDir, // TODO Remove in version 2.1.
 		"os":        runtime.GOOS,
 		"sourceDir": c.sourceDirAbsPath,
 		"version": map[string]interface{}{

--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -104,7 +104,8 @@ the new functionality and for consistency:
 * The gpg recipient is configured with the `gpg.recipient` configuration
   variable, `gpgRecipient` is no longer used.
 * The structure of data output by `chezmoi dump` has changed.
-* The `.chezmoi.homedir` template variable has been renamed to
-  `.chezmoi.homeDir`.
+* The `.chezmoi.homedir` template variable has been replaced with
+  `.chezmoi.homeDir`. For compatibility, `.chezmoi.homedir` will continue to be
+  supported until version 2.1.
 * The `.chezmoi.fullHostname` template variable has been removed, as it did not
   contain the full hostname,

--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -91,7 +91,7 @@ the new functionality and for consistency:
   ignored.
 * Diffs include the contents of scripts that would be run.
 * Mercurial support has been removed.
-* The `chezmoi source` command has been removed, used `chezmoi git` instead.
+* The `chezmoi source` command has been removed, use `chezmoi git` instead.
 * The `sourceVCS` configuration group has been renamed to `git`.
 * The order of files for a three-way merge passed to `merge.command` is now
   actual file, target state, source state.
@@ -108,4 +108,4 @@ the new functionality and for consistency:
   `.chezmoi.homeDir`. For compatibility, `.chezmoi.homedir` will continue to be
   supported until version 2.1.
 * The `.chezmoi.fullHostname` template variable has been removed, as it did not
-  contain the full hostname,
+  contain the full hostname. Use `.chezmoi.fqdnHostname` (UNIX only) instead.


### PR DESCRIPTION
The `.chezmoi.homedir` template variable has been replaced with `chezmoi.homeDir` for consistency, but let's keep the old template variable around for a version to help people transition to v2.