### PR TITLE
Update howto to use main instead of master

### DIFF
--- a/docs/HOWTO.md
+++ b/docs/HOWTO.md
@@ -52,7 +52,7 @@ example:
 
     chezmoi cd
     git remote add origin https://github.com/username/dotfiles.git
-    git push -u origin master
+    git push -u origin main
     exit
 
 On another machine you can checkout this repo:


### PR DESCRIPTION
Just a simple update to the howto docs to reference main as the branch rather than master since github and git are changing the default. This also aligns with your quickstart
