### PR TITLE
Make PowerShell install script replace previous chezmoi.exe if script is used to update previous installation.

### DIFF
--- a/assets/scripts/install.ps1
+++ b/assets/scripts/install.ps1
@@ -291,7 +291,7 @@ function Install-Chezmoi {
     $binary = "chezmoi$($binsuffix)";
     $tmp_binary = (Join-Path $tempdir $binary);
 
-    Move-Item -Path $tmp_binary -Destination $BinDir
+    Move-Item -Force -Path $tmp_binary -Destination $BinDir
 
     log-info "Installed $($BinDir)/$($binary)"
 


### PR DESCRIPTION
If using the install.ps1 script to update an existing installation it will fail with an error like this:
"An error occurred while installing: Cannot create a file when that file already exists."

Adding -Force to the script makes the script replace the existing chezmoi.exe.
