### PR TITLE
Use the first existing parent directory for a script's working directory

### DIFF
--- a/testdata/scripts/scriptsubdir_unix.txt
+++ b/testdata/scripts/scriptsubdir_unix.txt
@@ -14,10 +14,13 @@ exec tar -tzf archive.tar.gz
 cmp stdout golden/archive
 
 -- golden/apply --
+$HOME
 $HOME/dir
 -- golden/archive --
+otherdir/script
 dir/
 dir/script
+otherdir/
 -- golden/dump --
 {
   "dir": {
@@ -29,9 +32,23 @@ dir/script
     "type": "script",
     "name": "dir/script",
     "contents": "#!/bin/sh\n\necho $PWD\n"
+  },
+  "otherdir": {
+    "type": "dir",
+    "name": "otherdir",
+    "perm": 511
+  },
+  "otherdir/script": {
+    "type": "script",
+    "name": "otherdir/script",
+    "contents": "#!/bin/sh\n\necho $PWD\n"
   }
 }
 -- home/user/.local/share/chezmoi/dir/run_script --
+#!/bin/sh
+
+echo $PWD
+-- home/user/.local/share/chezmoi/otherdir/run_before_script --
 #!/bin/sh
 
 echo $PWD

--- a/testdata/scripts/scriptsubdir_windows.txt
+++ b/testdata/scripts/scriptsubdir_windows.txt
@@ -17,10 +17,13 @@ exec tar -tzf archive.tar.gz
 cmp stdout golden/archive
 
 -- golden/apply --
+$HOME
 $HOME\dir
 -- golden/archive --
+otherdir/script.cmd
 dir/
 dir/script.cmd
+otherdir/
 -- golden/dump --
 {
   "dir": {
@@ -32,7 +35,19 @@ dir/script.cmd
     "type": "script",
     "name": "dir/script.cmd",
     "contents": "@echo %cd%\n"
+  },
+  "otherdir": {
+    "type": "dir",
+    "name": "otherdir",
+    "perm": 511
+  },
+  "otherdir/script.cmd": {
+    "type": "script",
+    "name": "otherdir/script.cmd",
+    "contents": "@echo %cd%\n"
   }
 }
 -- home/user/.local/share/chezmoi/dir/run_script.cmd --
+@echo %cd%
+-- home/user/.local/share/chezmoi/otherdir/run_before_script.cmd --
 @echo %cd%


### PR DESCRIPTION
This allows putting `before_` scripts in subdirectories, which naturally won't exist during the `before` phase.

Fixes #1097.

<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://github.com/twpayne/chezmoi/blob/master/docs/CONTRIBUTING.md

-->
