### PR TITLE
Fix issue in example for trying to use existing boolean vars first in…

### DIFF
--- a/docs/HOWTO.md
+++ b/docs/HOWTO.md
@@ -480,7 +480,7 @@ For boolean variables you can use:
 
     {{- $var := false -}}
     {{- if (hasKey . "var") -}}
-    {{-   $var = get "." "var" -}}
+    {{-   $var = get . "var" -}}
     {{- end -}}
 
     [data]


### PR DESCRIPTION
… How To section: First arg of get doesn't have to be in quotes.
http://masterminds.github.io/sprig/dicts.html