### PR TITLE
fix: gpg symmetric passing wrong arguments

### DIFF
--- a/internal/chezmoi/gpgencryption.go
+++ b/internal/chezmoi/gpgencryption.go
@@ -76,13 +76,14 @@ func (e *GPGEncryption) EncryptedSuffix() string {
 func (e *GPGEncryption) encryptArgs() []string {
 	args := []string{
 		"--armor",
-		"--encrypt",
-	}
-	if e.Recipient != "" {
-		args = append(args, "--recipient", e.Recipient)
 	}
 	if e.Symmetric {
 		args = append(args, "--symmetric")
+	} else {
+		args = append(args, "--encrypt")
+		if e.Recipient != "" {
+			args = append(args, "--recipient", e.Recipient)
+		}
 	}
 	return args
 }


### PR DESCRIPTION
<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://github.com/twpayne/chezmoi/blob/master/docs/CONTRIBUTING.md

-->
Current behavior if set encrypt with gpg symmetric (log by --debug flag)
```
2021-04-01T11:41:15+08:00 DBG Stat name=.../.config/chezmoi/chezmoistate.boltdb
2021-04-01T11:41:15+08:00 DBG Mkdir error="mkdir .../.local/share/chezmoi: file exists" name=.../.local/share/chezmoi perm=511
2021-04-01T11:41:15+08:00 DBG Stat name=.../.local/share/chezmoi
2021-04-01T11:41:15+08:00 DBG Lstat name=.../.local/share/chezmoi
2021-04-01T11:41:15+08:00 DBG ReadFile data="..." filename=.../.profile
You did not specify a user ID. (you may use "-r")

Current recipients:

Enter the user ID.  End with an empty line: 
gpg: no valid addressees
gpg: [stdin]: encryption failed: No user ID
2021-04-01T11:41:37+08:00 ERR Output error="exit status 2" args=["gpg","--armor","--encrypt","--symmetric"] exitCode=2 output= path=/usr/bin/gpg userTime=99.948

(deleted some private data)
```

An extra --encrypt argument has been passed.
