### PR TITLE
Update PowerShell install script to use checksums.txt

### DIFF
--- a/assets/scripts/install.ps1
+++ b/assets/scripts/install.ps1
@@ -270,7 +270,7 @@ function Install-Chezmoi {
     Fetch-FileFromWeb $tarball_url $tmp_tarball
 
     # download checksums
-    $checksums = "chezmoi_$($version)_checksums.txt"
+    $checksums = "checksums.txt"
     $checksums_url = "$($github_download)/$($real_tag)/$($checksums)"
 
     $tmp_checksums = (Join-Path $tempdir $checksums)


### PR DESCRIPTION
Fixed checksums.txt filename to match the new naming in sh script.
Current version fails with 404 error when trying to download checksums file as the name changed for release 2.0.7.

<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://github.com/twpayne/chezmoi/blob/master/docs/CONTRIBUTING.md

-->
