### PR TITLE
Follow Systemd FHS spec

### DIFF
--- a/assets/scripts/install.sh
+++ b/assets/scripts/install.sh
@@ -7,7 +7,7 @@
 
 set -e
 
-BINDIR=${BINDIR:-./bin}
+BINDIR=${BINDIR:-./.local/bin}
 TAGARG=latest
 LOG_LEVEL=2
 EXECARGS=

--- a/internal/cmd/generate-install.sh/install.sh.tmpl
+++ b/internal/cmd/generate-install.sh/install.sh.tmpl
@@ -7,7 +7,7 @@
 
 set -e
 
-BINDIR=${BINDIR:-./bin}
+BINDIR=${BINDIR:-./.local/bin}
 TAGARG=latest
 LOG_LEVEL=2
 EXECARGS=


### PR DESCRIPTION
The directory `~/bin` is an antiquated 20 year old social convention that came out of need and a failure on the part of the Linux Filesystem Hierarchy Standard (FHS) to state anything on the matter. The new replacement for that is standardized by the Systemd File Hierarchy Specification; see `man file-hierarchy` for more information. It states `~/.local/bin/` is the right place for user-installed binary files.

<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://github.com/twpayne/chezmoi/blob/master/docs/CONTRIBUTING.md

-->
