### PR TITLE
Correct `and` template example in How To guide

### DIFF
--- a/docs/HOWTO.md
+++ b/docs/HOWTO.md
@@ -996,7 +996,7 @@ needed. For example, to install `vim-gtk` on Linux but not in Codespaces, your
 `run_once_install-packages.sh.tmpl` might contain:
 
 ```
-{{- if (and (eq .chezmoi.os "linux")) (not .codespaces))) -}}
+{{- if (and (eq .chezmoi.os "linux") (not .codespaces)) -}}
 #!/bin/sh
 sudo apt install -y vim-gtk
 {{- end -}}


### PR DESCRIPTION
I'm new to Go's templates, but based on [the docs](https://golang.org/pkg/text/template/#hdr-Functions), it looks like there were two erroneous `)` in the example here.