### PR TITLE
Improve reliability of Powershell installer

### DIFF
--- a/assets/scripts/install.ps1
+++ b/assets/scripts/install.ps1
@@ -127,9 +127,9 @@ function get_goarch {
     if (-not $arch) {
         if (Get-Command "Get-WmiObject" -ErrorAction SilentlyContinue) {
             $wmi_arch = (Get-WmiObject -Class Win32_OperatingSystem | Select-Object *).OSArchitecture
-            if ($wmi_arch -eq "64-bit") {
+            if ($wmi_arch.StartsWith("64")) {
                 $arch = "X64";
-            } elseif ($wmi_arch -eq "32-bit") {
+            } elseif ($wmi_arch.StartsWith("32")) {
                 $arch = "X86";
             }
         }
@@ -311,4 +311,3 @@ try {
         Remove-Item -LiteralPath $tempdir -Recurse -Force
     }
 }
-

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -28,7 +28,7 @@ your dotfiles with the single command:
 Or on systems with Powershell, you can use this command:
 
     # To install in ./bin
-    (iwr https://git.io/chezmoi.ps1).Content | powershell -c -
+    (iwr -UseBasicParsing https://git.io/chezmoi.ps1).Content | powershell -c -
 
     # To install in another location
     '$params = "-BinDir ~/other"', (iwr https://git.io/chezmoi.ps1).Content | powershell -c -


### PR DESCRIPTION
This PR fixes couple of issues that I've encountered while installing `chezmoi` on Windows 10 with non `en-US` locale.

First, `.OSArchitecture` returns localized value and even changing `CurrentCulture` doesn't help.

```
PS C:\Users\username> (iwr -UseBasicParsing https://git.io/chezmoi.ps1).Content | powershell -c -
WARNING: PowerShell requires an execution policy in [Unrestricted, RemoteSigned, Bypass] to run this install script.
WARNING: For example, to set the execution policy to 'RemoteSigned' please run :
WARNING: 'Set-ExecutionPolicy RemoteSigned -scope CurrentUser'
Unsupported architecture:  (wmi: 64-разрядная)
An error occurred while installing: unsupported architecture
```

```
PS C:\Users\username\Downloads> (Get-WmiObject -Class Win32_OperatingSystem | Select-Object *).OSArchitecture
64-разрядная
```

I suggest to match beginning of the string as a workaround.

Second, the script returns the following error if IE is not present in the system

```
 PS C:\Users\username> (iwr https://git.io/chezmoi.ps1).Content | powershell -c -
iwr : The response content cannot be parsed because the Internet Explorer engine is not available, or Internet
Explorer's first-launch configuration is not complete. Specify the UseBasicParsing parameter and try again.
At line:1 char:2
+ (iwr https://git.io/chezmoi.ps1).Content | powershell -c -
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotImplemented: (:) [Invoke-WebRequest], NotSupportedException
    + FullyQualifiedErrorId : WebCmdletIEDomNotSupportedException,Microsoft.PowerShell.Commands.InvokeWebRequestComman
   d
```

Using `-UseBasicParsing` option resolves this.
