### PR TITLE
Update rpm zsh completion directory to match recent Fedora versions.

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -149,7 +149,7 @@ nfpms:
       - src: completions/chezmoi.fish
         dst: /usr/share/fish/completions/chezmoi.fish
       - src: completions/chezmoi.zsh
-        dst: /usr/share/zsh/functions/_chezmoi
+        dst: /usr/share/zsh/site-functions/_chezmoi
 - id: apks
   builds:
   - chezmoi-cgo-musl


### PR DESCRIPTION
Looking at the source for zsh[1], it appears that the default directory for
extra functions like completions is `../site-functions` not `../functions`. This
matches the behavior on Fedora.

[1] https://github.com/zsh-users/zsh/blob/c1f932d66896753eb118003b7c1b1139bc6c8725/configure.ac#L308

<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://github.com/twpayne/chezmoi/blob/master/docs/CONTRIBUTING.md

-->
