### PR TITLE
Update WSL2 section of HOWTO with new kernel string

### DIFF
--- a/docs/HOWTO.md
+++ b/docs/HOWTO.md
@@ -1047,6 +1047,15 @@ WSL 2 since version 4.19.112:
 {{ end }}
 ```
 
+WSL 2 since version 5.4.72:
+```
+{{ if (eq .chezmoi.os "linux") }}
+{{   if (contains "microsoft-standard-WSL2" .chezmoi.kernel.osrelease) }}
+# WSL-specific code
+{{   end }}
+{{ end }}
+```
+
 ### Run a PowerShell script as admin on Windows
 
 Put the following at the top of your script:


### PR DESCRIPTION
Looks like Microsoft has changed this yet again based on what I'm getting back in my `osrelease`. Perhaps `hasSuffix .chezmoi.kernel.osrelease "-WSL2"` might be better?

```
$ chezmoi data | jq .chezmoi.kernel
{
  "osrelease": "5.4.72-microsoft-standard-WSL2",
  "ostype": "Linux",
  "version": "#1 SMP Wed Oct 28 23:40:43 UTC 2020"
}
```

<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://github.com/twpayne/chezmoi/blob/master/docs/CONTRIBUTING.md

-->
