### PR TITLE
Use temporary files, instead of stdin/stdout, when calling gpg

### DIFF
--- a/internal/chezmoi/gpgencryption.go
+++ b/internal/chezmoi/gpgencryption.go
@@ -1,9 +1,10 @@
 package chezmoi
 
 import (
-	"bytes"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 
 	"github.com/rs/zerolog/log"
 
@@ -21,51 +22,82 @@ type GPGEncryption struct {
 
 // Decrypt implements Encyrption.Decrypt.
 func (e *GPGEncryption) Decrypt(ciphertext []byte) ([]byte, error) {
-	args := append([]string{"--decrypt"}, e.Args...)
-	//nolint:gosec
-	cmd := exec.Command(e.Command, args...)
-	cmd.Stdin = bytes.NewReader(ciphertext)
-	cmd.Stderr = os.Stderr
-	return chezmoilog.LogCmdOutput(log.Logger, cmd)
+	var plaintext []byte
+	if err := withPrivateTempDir(func(tempDir string) error {
+		ciphertextFilename := filepath.Join(tempDir, "ciphertext"+e.EncryptedSuffix())
+		if err := os.WriteFile(ciphertextFilename, ciphertext, 0o600); err != nil {
+			return err
+		}
+		plaintextFilename := filepath.Join(tempDir, "plaintext")
+
+		args := e.decryptArgs(plaintextFilename, ciphertextFilename)
+		if err := e.run(args); err != nil {
+			return err
+		}
+
+		var err error
+		plaintext, err = os.ReadFile(plaintextFilename)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+	return plaintext, nil
 }
 
 // DecryptToFile implements Encryption.DecryptToFile.
 func (e *GPGEncryption) DecryptToFile(plaintextFilename string, ciphertext []byte) error {
-	args := append([]string{
-		"--decrypt",
-		"--output", plaintextFilename,
-		"--yes",
-	}, e.Args...)
-	//nolint:gosec
-	cmd := exec.Command(e.Command, args...)
-	cmd.Stdin = bytes.NewReader(ciphertext)
-	cmd.Stderr = os.Stderr
-	return chezmoilog.LogCmdRun(log.Logger, cmd)
+	return withPrivateTempDir(func(tempDir string) error {
+		ciphertextFilename := filepath.Join(tempDir, "ciphertext"+e.EncryptedSuffix())
+		if err := os.WriteFile(ciphertextFilename, ciphertext, 0o600); err != nil {
+			return err
+		}
+		args := e.decryptArgs(plaintextFilename, ciphertextFilename)
+		return e.run(args)
+	})
 }
 
 // Encrypt implements Encryption.Encrypt.
 func (e *GPGEncryption) Encrypt(plaintext []byte) ([]byte, error) {
-	args := append(e.encryptArgs(), e.Args...)
-	//nolint:gosec
-	cmd := exec.Command(e.Command, args...)
-	cmd.Stdin = bytes.NewReader(plaintext)
-	cmd.Stderr = os.Stderr
-	return chezmoilog.LogCmdOutput(log.Logger, cmd)
+	var ciphertext []byte
+	if err := withPrivateTempDir(func(tempDir string) error {
+		plaintextFilename := filepath.Join(tempDir, "plaintext")
+		if err := os.WriteFile(plaintextFilename, plaintext, 0o600); err != nil {
+			return err
+		}
+		ciphertextFilename := filepath.Join(tempDir, "ciphertext"+e.EncryptedSuffix())
+
+		args := e.encryptArgs(plaintextFilename, ciphertextFilename)
+		if err := e.run(args); err != nil {
+			return err
+		}
+
+		var err error
+		ciphertext, err = os.ReadFile(ciphertextFilename)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+	return ciphertext, nil
 }
 
 // EncryptFile implements Encryption.EncryptFile.
-func (e *GPGEncryption) EncryptFile(plaintextFilename string) (ciphertext []byte, err error) {
-	f, err := os.Open(plaintextFilename)
-	if err != nil {
+func (e *GPGEncryption) EncryptFile(plaintextFilename string) ([]byte, error) {
+	var ciphertext []byte
+	if err := withPrivateTempDir(func(tempDir string) error {
+		ciphertextFilename := filepath.Join(tempDir, "ciphertext"+e.EncryptedSuffix())
+
+		args := e.encryptArgs(plaintextFilename, ciphertextFilename)
+		if err := e.run(args); err != nil {
+			return err
+		}
+
+		var err error
+		ciphertext, err = os.ReadFile(ciphertextFilename)
+		return err
+	}); err != nil {
 		return nil, err
 	}
-	defer f.Close()
-	args := append(e.encryptArgs(), e.Args...)
-	//nolint:gosec
-	cmd := exec.Command(e.Command, args...)
-	cmd.Stdin = f
-	cmd.Stderr = os.Stderr
-	return chezmoilog.LogCmdOutput(log.Logger, cmd)
+	return ciphertext, nil
 }
 
 // EncryptedSuffix implements Encryption.EncryptedSuffix.
@@ -73,17 +105,52 @@ func (e *GPGEncryption) EncryptedSuffix() string {
 	return e.Suffix
 }
 
-func (e *GPGEncryption) encryptArgs() []string {
+func (e *GPGEncryption) decryptArgs(plaintextFilename, ciphertextFilename string) []string {
+	args := []string{"--output", plaintextFilename}
+	args = append(args, e.Args...)
+	args = append(args, "--decrypt", ciphertextFilename)
+	return args
+}
+
+func (e *GPGEncryption) encryptArgs(plaintextFilename, ciphertextFilename string) []string {
 	args := []string{
 		"--armor",
+		"--output", ciphertextFilename,
 	}
 	if e.Symmetric {
 		args = append(args, "--symmetric")
-	} else {
+	} else if e.Recipient != "" {
+		args = append(args, "--recipient", e.Recipient)
+	}
+	args = append(args, e.Args...)
+	if !e.Symmetric {
 		args = append(args, "--encrypt")
-		if e.Recipient != "" {
-			args = append(args, "--recipient", e.Recipient)
+	}
+	args = append(args, plaintextFilename)
+	return args
+}
+
+func (e *GPGEncryption) run(args []string) error {
+	//nolint:gosec
+	cmd := exec.Command(e.Command, args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return chezmoilog.LogCmdRun(log.Logger, cmd)
+}
+
+// withPrivateTempDir creates a private temporary and calls f.
+func withPrivateTempDir(f func(tempDir string) error) error {
+	tempDir, err := os.MkdirTemp("", "chezmoi-encryption")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tempDir)
+	if runtime.GOOS != "windows" {
+		if err := os.Chmod(tempDir, 0o700); err != nil {
+			return err
 		}
 	}
-	return args
+
+	return f(tempDir)
 }


### PR DESCRIPTION
Refs #1074.

@3v1n0 would you be able to test if this PR fixes the problems you reported in #1074?

It changes the way that chezmoi reads and writes data from gpg back to how it was done prior to chezmoi v2, i.e it reverts back to using temporary files rather than gpg's standard input and output.