### PR TITLE
Make modify scripts always overwrite the target without prompting

### DIFF
--- a/internal/chezmoi/entrystate.go
+++ b/internal/chezmoi/entrystate.go
@@ -25,6 +25,7 @@ type EntryState struct {
 	Mode           fs.FileMode    `json:"mode,omitempty" toml:"mode,omitempty" yaml:"mode,omitempty"`
 	ContentsSHA256 HexBytes       `json:"contentsSHA256,omitempty" toml:"contentsSHA256,omitempty" yaml:"contentsSHA256,omitempty"` //nolint:tagliatelle
 	contents       []byte
+	overwrite      bool
 }
 
 // Contents returns s's contents, if available.
@@ -53,4 +54,9 @@ func (s *EntryState) Equivalent(other *EntryState) bool {
 	default:
 		return s.Equal(other)
 	}
+}
+
+// Overwrite returns true if s should be overwritten by default.
+func (s *EntryState) Overwrite() bool {
+	return s.overwrite
 }

--- a/internal/chezmoi/sourcestate.go
+++ b/internal/chezmoi/sourcestate.go
@@ -1028,6 +1028,7 @@ func (s *SourceState) newModifyTargetStateEntryFunc(sourceRelPath SourceRelPath,
 		}
 		return &TargetStateFile{
 			lazyContents: newLazyContentsFunc(contentsFunc),
+			overwrite:    true,
 			perm:         fileAttr.perm() &^ s.umask,
 		}, nil
 	}

--- a/internal/chezmoi/targetstateentry.go
+++ b/internal/chezmoi/targetstateentry.go
@@ -24,8 +24,9 @@ type TargetStateDir struct {
 // A TargetStateFile represents the state of a file in the target state.
 type TargetStateFile struct {
 	*lazyContents
-	empty bool
-	perm  fs.FileMode
+	empty     bool
+	overwrite bool
+	perm      fs.FileMode
 }
 
 // A TargetStateRemove represents the absence of an entry in the target state.
@@ -145,6 +146,7 @@ func (t *TargetStateFile) EntryState(umask fs.FileMode) (*EntryState, error) {
 		Mode:           t.perm &^ umask,
 		ContentsSHA256: HexBytes(contentsSHA256),
 		contents:       contents,
+		overwrite:      t.overwrite,
 	}, nil
 }
 

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -542,6 +542,8 @@ func (c *Config) defaultConfigFile(fileSystem vfs.Stater, bds *xdg.BaseDirectory
 
 func (c *Config) defaultPreApplyFunc(targetRelPath chezmoi.RelPath, targetEntryState, lastWrittenEntryState, actualEntryState *chezmoi.EntryState) error {
 	switch {
+	case targetEntryState.Overwrite():
+		return nil
 	case targetEntryState.Type == chezmoi.EntryStateTypeScript:
 		return nil
 	case c.force:

--- a/internal/cmd/testdata/scripts/modify_unix.txt
+++ b/internal/cmd/testdata/scripts/modify_unix.txt
@@ -39,6 +39,22 @@ cmpmod 666 $HOME/.file
 chezmoi apply $HOME${/}.file
 cmpmod 700 $HOME/.file
 
+chhome home3/user
+
+# test that chezmoi apply always overwrites modified files without --force
+chezmoi add $HOME${/}.modify
+chezmoi apply
+edit $HOME${/}.modify
+rm $CHEZMOISOURCEDIR/dot_modify
+cp home/user/.local/share/chezmoi/modify_dot_modify $CHEZMOISOURCEDIR
+chezmoi apply
+cmp $HOME${/}.modify golden/.edited-and-modified
+
+-- golden/.edited-and-modified --
+beginning
+modified-middle
+end
+# edited
 -- golden/.modified --
 beginning
 modified-middle
@@ -76,3 +92,7 @@ exit 1
 #!/bin/sh
 
 cat
+-- home3/user/.modify --
+beginning
+middle
+end


### PR DESCRIPTION
As [identified by @lcrockett](https://github.com/twpayne/chezmoi/issues/1046#issuecomment-864343405) in #1046.

Before this change, chezmoi would always warn if the target of a modify script had changed since chezmoi last wrote it, but this is counter to the concept of a modify script: we expect the target of modify scripts to have changed since chezmoi last wrote it.

This PR changes the behavior of chezmoi to always overwrite the target of modify scripts, even if `--force` is not specified.

@lcrockett would you be able to test this? No worries if not :)