### PR TITLE
Allow install of chezmoi from a powershell where StrictMode is on

### DIFF
--- a/assets/scripts/install.ps1
+++ b/assets/scripts/install.ps1
@@ -247,6 +247,10 @@ function Install-Chezmoi {
         [string[]]$ExecArgs
     )
 
+    # some sub-functions (ie, get_goarch, likely others) require fetching of
+    # non-existent properites to not error
+    Set-StrictMode -off
+
     # $BinDir = Resolve-Path $BinDir
 
     $os = get_goos


### PR DESCRIPTION
Currently, if, ie, the currently running context has called:

```
Set-StrictMode -version latest
```

...then `install.ps1` will error when, ie,

`[Runtime.InteropServices.RuntimeInformation]::OSArchitecture`
 in `get_goarch` is fetched from .NET 4.0.

This change won't affect the calling context.

