### PR TITLE
Fix commit editing snafu in feature chart

### DIFF
--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -44,7 +44,7 @@
 | Run once scripts                       | ✅            | ❌                | ❌                | ❌                | ✅                       | ❌            | ❌         |
 | Machine-to-machine symlink differences | ✅            | ❌                | ❌                | ❌                | Manual                   | ✅            | Manual     |
 | Shell completion                       | ✅            | ❌                | ❌                | ❌                | ✅                       | ✅            | ✅         |
-| Archive import                         | ✅            | ❌                | ❌                | ❌                | ❌                       | ❌            | ❌         |
+| Archive import                         | ✅            | ❌                | ❌                | ❌                | ✅                       | ❌            | ✅         |
 | Archive export                         | ✅            | ❌                | ❌                | ❌                | ✅                       | ❌            | ✅         |
 | Implementation language                | Go            | Python            | Perl              | Ruby              | POSIX                    | Bash          | C          |
 


### PR DESCRIPTION
Thanks for merging #1314. Unfortunately it seems I made a mistake while revising commits that left two incorrect values that I intended to fix.

I actually fixed this in dde40d0 and included in in the commit message, then I botched some rebase work where I was trying to same formatting cleanup separately from content changes and obliterated the fix.
