### PR TITLE
Strip encrypted suffix when editing transparently decrypted files

### DIFF
--- a/internal/cmd/editcmd.go
+++ b/internal/cmd/editcmd.go
@@ -75,7 +75,7 @@ func (c *Config) runEditCmd(cmd *cobra.Command, args []string, sourceState *chez
 	var transparentlyDecryptedFiles []transparentlyDecryptedFile
 	for _, targetRelPath := range targetRelPaths {
 		sourceStateEntry := sourceState.MustEntry(targetRelPath)
-		sourceRelPath := sourceStateEntry.SourceRelPath().RelPath()
+		sourceRelPath := sourceStateEntry.SourceRelPath()
 		var editorArg string
 		if sourceStateFile, ok := sourceStateEntry.(*chezmoi.SourceStateFile); ok && sourceStateFile.Attr.Encrypted {
 			if decryptedDirAbsPath == "" {
@@ -94,7 +94,7 @@ func (c *Config) runEditCmd(cmd *cobra.Command, args []string, sourceState *chez
 				}
 			}
 			// FIXME use RawContents and DecryptFile
-			decryptedAbsPath := decryptedDirAbsPath.Join(sourceRelPath)
+			decryptedAbsPath := decryptedDirAbsPath.Join(sourceRelPath.TargetRelPath(c.encryption.EncryptedSuffix()))
 			contents, err := sourceStateFile.Contents()
 			if err != nil {
 				return err
@@ -106,13 +106,13 @@ func (c *Config) runEditCmd(cmd *cobra.Command, args []string, sourceState *chez
 				return err
 			}
 			transparentlyDecryptedFile := transparentlyDecryptedFile{
-				sourceAbsPath:    c.SourceDirAbsPath.Join(sourceRelPath),
+				sourceAbsPath:    c.SourceDirAbsPath.Join(sourceRelPath.RelPath()),
 				decryptedAbsPath: decryptedAbsPath,
 			}
 			transparentlyDecryptedFiles = append(transparentlyDecryptedFiles, transparentlyDecryptedFile)
 			editorArg = string(decryptedAbsPath)
 		} else {
-			sourceAbsPath := c.SourceDirAbsPath.Join(sourceRelPath)
+			sourceAbsPath := c.SourceDirAbsPath.Join(sourceRelPath.RelPath())
 			editorArg = string(sourceAbsPath)
 		}
 		editorArgs = append(editorArgs, editorArg)

--- a/internal/cmd/testdata/scripts/gpgencryption.txt
+++ b/internal/cmd/testdata/scripts/gpgencryption.txt
@@ -39,5 +39,18 @@ chezmoi add --encrypt $HOME${/}.dir${/}.encrypted
 chezmoi edit --apply $HOME${/}.dir${/}.encrypted
 grep '# edited' $HOME/.dir/.encrypted
 
+# test that chezmoi edit strips the encrypted suffix
+[!windows] env EDITOR=echo
+[windows] env EDITOR=printargs
+chezmoi edit $HOME${/}.dir${/}.encrypted
+stdout '\.dir/\.encrypted\r?$'
+
+-- bin/printargs.cmd --
+@echo off
+setlocal
+set out=%*
+set out=%out:\=%
+echo %out%
+endlocal
 -- golden/.encrypted --
 plaintext


### PR DESCRIPTION
Fixes #1319.