### PR TITLE
Add .chezmoi.rawHomeDir template variable using raw OS path to home dir

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -1426,12 +1426,13 @@ chezmoi provides the following automatically-populated variables:
 | `.chezmoi.arch`         | Architecture, e.g. `amd64`, `arm`, etc. as returned by [runtime.GOARCH](https://pkg.go.dev/runtime?tab=doc#pkg-constants).      |
 | `.chezmoi.fqdnHostname` | The fully-qualified domain name hostname of the machine chezmoi is running on.                                                  |
 | `.chezmoi.group`        | The group of the user running chezmoi.                                                                                          |
-| `.chezmoi.homeDir`      | The home directory of the user running chezmoi.                                                                                 |
+| `.chezmoi.homeDir`      | The normalized home directory of the user running chezmoi.                                                                      |
 | `.chezmoi.hostname`     | The hostname of the machine chezmoi is running on, up to the first `.`.                                                         |
 | `.chezmoi.kernel`       | Contains information from `/proc/sys/kernel`. Linux only, useful for detecting specific kernels (i.e. Microsoft's WSL kernel).  |
 | `.chezmoi.os`           | Operating system, e.g. `darwin`, `linux`, etc. as returned by [runtime.GOOS](https://pkg.go.dev/runtime?tab=doc#pkg-constants). |
 | `.chezmoi.osRelease`    | The information from `/etc/os-release`, Linux only, run `chezmoi data` to see its output.                                       |
 | `.chezmoi.sourceDir`    | The source directory.                                                                                                           |
+| `.chezmoi.rawHomeDir`   | The home directory of the user running chezmoi, without normalization.                                                          |
 | `.chezmoi.sourceFile`   | The path of the template relative to the source directory.                                                                      |
 | `.chezmoi.username`     | The username of the user running chezmoi.                                                                                       |
 | `.chezmoi.version`      | The version of chezmoi.                                                                                                         |

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -713,6 +713,13 @@ func (c *Config) defaultTemplateData() map[string]interface{} {
 			Msg("chezmoi.OSRelease")
 	}
 
+	userHomeDir, err := os.UserHomeDir()
+	if err != nil {
+		log.Debug().
+			Err(err).
+			Msg("os.UserHomeDir")
+	}
+
 	return map[string]interface{}{
 		"chezmoi": map[string]interface{}{
 			"arch":         runtime.GOARCH,
@@ -723,6 +730,7 @@ func (c *Config) defaultTemplateData() map[string]interface{} {
 			"kernel":       kernel,
 			"os":           runtime.GOOS,
 			"osRelease":    osRelease,
+			"rawHomeDir":   userHomeDir,
 			"sourceDir":    string(c.SourceDirAbsPath),
 			"username":     username,
 			"version": map[string]interface{}{

--- a/internal/cmd/testdata/scripts/templatedata.txt
+++ b/internal/cmd/testdata/scripts/templatedata.txt
@@ -1,3 +1,10 @@
+# test that .chezmoi.rawHomeDir uses the OS's path separator
+chezmoi execute-template '{{ .chezmoi.rawHomeDir }}'
+[!windows] stdout '/'
+[!windows] ! stdout '\\'
+[windows] stdout '\\'
+[windows] ! stdout '/'
+
 # test that .chezmoi.sourceDir can be used with joinPath
 [!windows] chezmoi execute-template '{{ joinPath .chezmoi.sourceDir ".file" }}'
 [!windows] stdout ${CHEZMOISOURCEDIR@R}/.file


### PR DESCRIPTION
This PR adds a `.chezmoi.rawHomeDir` template variable that uses the OS-specific path separator.

@derphilipp I think this should allow the creation of platform-appropriate symlinks. Something like

```
{{ joinPath .chezmoi.rawHomeDir ".config" "nvim" }}
```

should work.

Fixes #1329.
