### PR TITLE
Read data from source state during init

### DIFF
--- a/internal/cmd/initcmd.go
+++ b/internal/cmd/initcmd.go
@@ -203,6 +203,12 @@ func (c *Config) runInitCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	sourceState, err := c.sourceState()
+	if err != nil {
+		return err
+	}
+	c.Data = sourceState.TemplateData()
+
 	// Find config template, execute it, and create config file.
 	configTemplateRelPath, ext, configTemplateContents, err := c.findConfigTemplate()
 	if err != nil {


### PR DESCRIPTION
Read source state before creating the configuration file.
Data is still not used is `--data=false` is passed to init.

Fix #1336 
