### PR TITLE
Fix the FreeBSD installation method

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -61,7 +61,7 @@ Install chezmoi with a single command.
 | macOS        | MacPorts   | `sudo port install chezmoi`                                                                 |
 | Windows      | Scoop      | `scoop bucket add twpayne https://github.com/twpayne/scoop-bucket && scoop install chezmoi` |
 | Windows      | Chocolatey | `choco install chezmoi`                                                                     |
-| FreeBSD      | ports      | `pkg install chezmoi`                                                                       |
+| FreeBSD      | pkg        | `pkg install chezmoi`                                                                       |
 
 ## Pre-built Linux packages
 


### PR DESCRIPTION
The "ports" method of software installation
on FreeBSD is `make -C /usr/ports/sysutils/chezmoi install`.

It's better to call the method described in the documentation as
"pkg".

