### PR TITLE
Disable broken chocolatey install gpg4win in Windows CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,7 +69,9 @@ jobs:
       run: go test -ldflags="-X github.com/twpayne/chezmoi/internal/chezmoitest.umaskStr=0o002" -race ./...
     - name: Test (Windows)
       if: runner.os == 'Windows'
-      run: go test -race ./...
+      run: |
+        go run . doctor
+        go test -race ./...
   test-release:
     runs-on: ubuntu-18.04
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,20 +48,26 @@ jobs:
         curl -fsSL https://dl.filippo.io/age/v${AGE_VERSION}?for=${goos}/amd64 | tar xzf -
         sudo install -m 755 age/age /usr/local/bin
         sudo install -m 755 age/age-keygen /usr/local/bin
-    - name: Install age and gpg4win (Windows)
+    - name: Install age (Windows)
       if: runner.os == 'Windows'
       run: |
         $env:PATH = "C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\ProgramData\chocolatey\bin"
         [Environment]::SetEnvironmentVariable("Path", $env:PATH, "Machine")
-        choco install --yes age.portable gpg4win
+        choco install --yes age.portable
+    - name: Install gpg4win (Windows)
+      if: runner.os == 'Windows'
+      run: |
+        $env:PATH = "C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\ProgramData\chocolatey\bin"
+        [Environment]::SetEnvironmentVariable("Path", $env:PATH, "Machine")
+        choco install --yes gpg4win
         echo "C:\Program Files (x86)\GnuPG\bin" >> $env:GITHUB_PATH
-    - name: Test (umask 022)
+    - name: Test (UNIX, umask 022)
       if: runner.os != 'Windows'
       run: go test -ldflags="-X github.com/twpayne/chezmoi/internal/chezmoitest.umaskStr=0o022" -race ./...
-    - name: Test (umask 002)
+    - name: Test (UNIX, umask 002)
       if: runner.os != 'Windows'
       run: go test -ldflags="-X github.com/twpayne/chezmoi/internal/chezmoitest.umaskStr=0o002" -race ./...
-    - name: Test
+    - name: Test (Windows)
       if: runner.os == 'Windows'
       run: go test -race ./...
   test-release:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
         [Environment]::SetEnvironmentVariable("Path", $env:PATH, "Machine")
         choco install --yes age.portable
     - name: Install gpg4win (Windows)
-      if: runner.os == 'Windows'
+      if: false && runner.os == 'Windows' # FIXME
       run: |
         $env:PATH = "C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem;C:\Windows\System32\WindowsPowerShell\v1.0\;C:\ProgramData\chocolatey\bin"
         [Environment]::SetEnvironmentVariable("Path", $env:PATH, "Machine")


### PR DESCRIPTION
Looks like something is broken upstream:

```
Chocolatey v0.11.1
Installing the following packages:
age.portable;gpg4win
By installing, you accept licenses for the packages.

Progress: Downloading age.portable 1.0.0... 19%
Progress: Downloading age.portable 1.0.0... 58%
Progress: Downloading age.portable 1.0.0... 96%
Progress: Downloading age.portable 1.0.0... 100%

age.portable v1.0.0 [Approved]
age.portable package files install completed. Performing other installation steps.
Downloading age.portable 64 bit
  from 'https://github.com/FiloSottile/age/releases/download/v1.0.0/age-v1.0.0-windows-amd64.zip'

Progress: 0% - Saving 13.39 KB of 4.11 MB
...
Progress: 100% - Completed download of C:\Users\runneradmin\AppData\Local\Temp\chocolatey\age.portable\1.0.0\age-v1.0.0-windows-amd64.zip (4.11 MB).
Download of age-v1.0.0-windows-amd64.zip (4.11 MB) completed.
Hashes match.
Extracting C:\Users\runneradmin\AppData\Local\Temp\chocolatey\age.portable\1.0.0\age-v1.0.0-windows-amd64.zip to C:\ProgramData\chocolatey\lib\age.portable\tools...
C:\ProgramData\chocolatey\lib\age.portable\tools
 ShimGen has successfully created a shim for age-keygen.exe
 ShimGen has successfully created a shim for age.exe
 The install of age.portable was successful.
  Software installed to 'C:\ProgramData\chocolatey\lib\age.portable\tools'

Progress: Downloading Gpg4win 3.1.16... 0%
...
Progress: Downloading Gpg4win 3.1.16... 100%

Gpg4win v3.1.16 [Approved]
gpg4win package files install completed. Performing other installation steps.
Installing gpg4win...
gpg4win has been installed.
ERROR: A positional parameter cannot be found that accepts argument ''.
  gpg4win may be able to be automatically uninstalled.
Environment Vars (like PATH) have changed. Close/reopen your shell to
 see the changes (or in powershell/cmd.exe just type `refreshenv`).
The install of gpg4win was NOT successful.
Error while running 'C:\ProgramData\chocolatey\lib\Gpg4win\tools\chocolateyInstall.ps1'.
 See log for details.
This is try 1/3. Retrying after 300 milliseconds.
 Error converted to warning:
 (5) Access is denied: [\\?\C:\ProgramData\chocolatey\lib-bad\Gpg4win]
This is try 2/3. Retrying after 400 milliseconds.
 Error converted to warning:
 (5) Access is denied: [\\?\C:\ProgramData\chocolatey\lib-bad\Gpg4win]
Maximum tries of 3 reached. Throwing error.
This is try 1/3. Retrying after 300 milliseconds.
 Error converted to warning:
 (32) The process cannot access the file because it is being used by another process: [\\?\C:\ProgramData\chocolatey\lib-bad\Gpg4win\tools\gpg4win-3.1.16.exe]
This is try 2/3. Retrying after 400 milliseconds.
 Error converted to warning:
 (32) The process cannot access the file because it is being used by another process: [\\?\C:\ProgramData\chocolatey\lib-bad\Gpg4win\tools\gpg4win-3.1.16.exe]
Maximum tries of 3 reached. Throwing error.
Could not move the bad package to the failure directory. It will show as installed.
 C:\ProgramData\chocolatey\lib\Gpg4win
 The error:
 (32) The process cannot access the file because it is being used by another process: [\\?\C:\ProgramData\chocolatey\lib-bad\Gpg4win\tools\gpg4win-3.1.16.exe]

Chocolatey installed 1/2 packages. 1 packages failed.
 See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).

Failures
 - gpg4win (exited -1) - Error while running 'C:\ProgramData\chocolatey\lib\Gpg4win\tools\chocolateyInstall.ps1'.
 See log for details.
Error: Process completed with exit code 1.
```