### PR TITLE
Support paths containing spaces in VIM integration

### DIFF
--- a/docs/HOWTO.md
+++ b/docs/HOWTO.md
@@ -344,7 +344,7 @@ GitHub username:
 Put the following in your `.vimrc`:
 
 ```vim
-autocmd BufWritePost ~/.local/share/chezmoi/* ! chezmoi apply --source-path %
+autocmd BufWritePost ~/.local/share/chezmoi/* ! chezmoi apply --source-path "%"
 ```
 
 ---


### PR DESCRIPTION
Paths of files managed by chezmoi can contain spaces, such as configuration files in `~/Library/Application Support` on MacOS. The current Vim integration command would fail as spaces in the path where not escaped. The usage of quotation marks should avoid this problem.

<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://github.com/twpayne/chezmoi/blob/master/docs/CONTRIBUTING.md

-->
