### PR TITLE
chore: Skip test requiring zip if zip is not in installed

### DIFF
--- a/internal/cmd/testdata/scripts/externalguess.txt
+++ b/internal/cmd/testdata/scripts/externalguess.txt
@@ -20,6 +20,9 @@ cp www/archive.tar.gz www/archive
 chezmoi apply --force --refresh-externals
 cmp $HOME/.dir/dir/file golden/dir/file
 
+# remaining tests require zip
+[!exec:zip] skip 'zip not found in $PATH'
+
 # test that chezmoi sniffs the format of zip files
 exec zip -r www/archive.zip archive
 cp www/archive.zip www/archive


### PR DESCRIPTION
Fixes #1452.