### PR TITLE
docs: fix error in HOWTO guide

### DIFF
--- a/docs/HOWTO.md
+++ b/docs/HOWTO.md
@@ -775,12 +775,13 @@ a shared template.
 
 Create the common file in the `.chezmoitemplates` directory in the source state. For
 example, create `.chezmoitemplates/file.conf`. The contents of this file are
-available in templates with the `template *name*` function where *name* is the
-name of the file.
+available in templates with the `template *name* .` function where *name* is the
+name of the file (`.` passes the current data to the template code in `file.conf`;
+see https://pkg.go.dev/text/template#hdr-Actions for details).
 
 Then create files for each system, for example `Library/Application
 Support/App/file.conf.tmpl` for macOS and `dot_config/app/file.conf.tmpl` for
-Linux. Both template files should contain `{{- template "file.conf" -}}`.
+Linux. Both template files should contain `{{- template "file.conf" . -}}`.
 
 Finally, tell chezmoi to ignore files where they are not needed by adding lines
 to your `.chezmoiignore` file, for example:


### PR DESCRIPTION
The "different files locations on different systems" guide didn't pass data to the template file, which can result in errors. See https://github.com/twpayne/chezmoi/issues/1108 for an example of this problem.

<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://github.com/twpayne/chezmoi/blob/master/docs/CONTRIBUTING.md

-->
