### PR TITLE
chore: Show OS release name in doctor command even if version is not present

### DIFF
--- a/internal/chezmoi/data_test.go
+++ b/internal/chezmoi/data_test.go
@@ -68,6 +68,35 @@ func TestOSRelease(t *testing.T) {
 		expected map[string]interface{}
 	}{
 		{
+			name: "archlinux",
+			root: map[string]interface{}{
+				"/usr/lib/os-release": chezmoitest.JoinLines(
+					`NAME="Arch Linux"`,
+					`PRETTY_NAME="Arch Linux"`,
+					`ID=arch`,
+					`BUILD_ID=rolling`,
+					`ANSI_COLOR="38;2;23;147;209"`,
+					`HOME_URL="https://archlinux.org/"`,
+					`DOCUMENTATION_URL="https://wiki.archlinux.org/"`,
+					`SUPPORT_URL="https://bbs.archlinux.org/"`,
+					`BUG_REPORT_URL="https://bugs.archlinux.org/"`,
+					`LOGO=archlinux`,
+				),
+			},
+			expected: map[string]interface{}{
+				"NAME":              "Arch Linux",
+				"PRETTY_NAME":       "Arch Linux",
+				"ID":                "arch",
+				"BUILD_ID":          "rolling",
+				"ANSI_COLOR":        "38;2;23;147;209",
+				"HOME_URL":          "https://archlinux.org/",
+				"DOCUMENTATION_URL": "https://wiki.archlinux.org/",
+				"SUPPORT_URL":       "https://bbs.archlinux.org/",
+				"BUG_REPORT_URL":    "https://bugs.archlinux.org/",
+				"LOGO":              "archlinux",
+			},
+		},
+		{
 			name: "fedora",
 			root: map[string]interface{}{
 				"/etc/os-release": chezmoitest.JoinLines(

--- a/internal/cmd/doctorcmd.go
+++ b/internal/cmd/doctorcmd.go
@@ -429,7 +429,9 @@ func (osArchCheck) Run(system chezmoi.System) (checkResult, string) {
 	if osRelease, err := chezmoi.OSRelease(system); err == nil {
 		if name, ok := osRelease["NAME"].(string); ok {
 			if version, ok := osRelease["VERSION"].(string); ok {
-				fields = append(fields, "("+name+"/"+version+")")
+				fields = append(fields, "("+name+" "+version+")")
+			} else {
+				fields = append(fields, "("+name+")")
 			}
 		}
 	}


### PR DESCRIPTION
Specifically, this applies to Arch Linux.