### PR TITLE
feat: Make editors see target filenames

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -72,8 +72,9 @@ you can run `chezmoi diff` to check what effect the changes would have, and run
 `chezmoi apply` if you're happy with them.
 
 `chezmoi edit` provides the following useful features:
-* It opens the correct file in the source state for you, so you don't have to
-  know anything about source state attributes.
+* It opens the correct file in the source state for you with a filename matching
+  the target filename, so your editor's syntax highlighting will work and you
+  don't have to know anything about source state attributes.
 * If the dotfile is encrypted in the source state, then `chezmoi edit` will
   decrypt it to a private directory, open that file in your `$EDITOR`, and then
   re-encrypt the file when you quit your editor. That makes encryption more

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -1165,6 +1165,13 @@ on Windows systems and `vi` on non-Windows systems.
 When the `edit.command` configuration variable is used, extra arguments can be
 passed to the editor with the `editor.args` configuration variable.
 
+Encrypted files are decrypted to a private temporary directory and the editor is
+invoked with the decrypted file. When the editor exits the edited decrypted file
+is re-encrypted and replaces the original file in the source state.
+
+If the operating system supports hard links, then the edit command invokes the
+editor with filenames which match the target filename.
+
 #### `-a`, `--apply`
 
 Apply target immediately after editing. Ignored if there are no targets.

--- a/internal/chezmoi/debugsystem.go
+++ b/internal/chezmoi/debugsystem.go
@@ -64,6 +64,16 @@ func (s *DebugSystem) IdempotentCmdOutput(cmd *exec.Cmd) ([]byte, error) {
 	return output, err
 }
 
+// Link implements System.Link.
+func (s *DebugSystem) Link(oldpath, newpath AbsPath) error {
+	err := s.system.Link(oldpath, newpath)
+	log.Err(err).
+		Stringer("oldpath", oldpath).
+		Stringer("newpath", newpath).
+		Msg("Link")
+	return err
+}
+
 // Lstat implements System.Lstat.
 func (s *DebugSystem) Lstat(name AbsPath) (fs.FileInfo, error) {
 	info, err := s.system.Lstat(name)

--- a/internal/chezmoi/dryrunsystem.go
+++ b/internal/chezmoi/dryrunsystem.go
@@ -42,6 +42,12 @@ func (s *DryRunSystem) IdempotentCmdOutput(cmd *exec.Cmd) ([]byte, error) {
 	return s.system.IdempotentCmdOutput(cmd)
 }
 
+// Link implements System.Link.
+func (s *DryRunSystem) Link(oldname, newname AbsPath) error {
+	s.setModified()
+	return nil
+}
+
 // Lstat implements System.Lstat.
 func (s *DryRunSystem) Lstat(name AbsPath) (fs.FileInfo, error) {
 	return s.system.Lstat(name)

--- a/internal/chezmoi/externaldiffsystem.go
+++ b/internal/chezmoi/externaldiffsystem.go
@@ -62,6 +62,12 @@ func (s *ExternalDiffSystem) IdempotentCmdOutput(cmd *exec.Cmd) ([]byte, error) 
 	return s.system.IdempotentCmdOutput(cmd)
 }
 
+// Link implements System.Link.
+func (s *ExternalDiffSystem) Link(oldname, newname AbsPath) error {
+	// FIXME generate suitable inputs for s.command
+	return s.system.Link(oldname, newname)
+}
+
 // Lstat implements System.Lstat.
 func (s *ExternalDiffSystem) Lstat(name AbsPath) (fs.FileInfo, error) {
 	return s.system.Lstat(name)

--- a/internal/chezmoi/gitdiffsystem.go
+++ b/internal/chezmoi/gitdiffsystem.go
@@ -71,6 +71,12 @@ func (s *GitDiffSystem) IdempotentCmdOutput(cmd *exec.Cmd) ([]byte, error) {
 	return s.system.IdempotentCmdOutput(cmd)
 }
 
+// Link implements System.Link.
+func (s *GitDiffSystem) Link(oldname, newname AbsPath) error {
+	// LATER generate a diff
+	return s.system.Link(oldname, newname)
+}
+
 // Lstat implements System.Lstat.
 func (s *GitDiffSystem) Lstat(name AbsPath) (fs.FileInfo, error) {
 	return s.system.Lstat(name)

--- a/internal/chezmoi/realsystem.go
+++ b/internal/chezmoi/realsystem.go
@@ -32,6 +32,11 @@ func (s *RealSystem) IdempotentCmdOutput(cmd *exec.Cmd) ([]byte, error) {
 	return chezmoilog.LogCmdOutput(cmd)
 }
 
+// Link implements System.Link.
+func (s *RealSystem) Link(oldname, newname AbsPath) error {
+	return s.fileSystem.Link(oldname.String(), newname.String())
+}
+
 // Lstat implements System.Lstat.
 func (s *RealSystem) Lstat(filename AbsPath) (fs.FileInfo, error) {
 	return s.fileSystem.Lstat(filename.String())

--- a/internal/chezmoi/system.go
+++ b/internal/chezmoi/system.go
@@ -15,6 +15,7 @@ type System interface {
 	Glob(pattern string) ([]string, error)
 	IdempotentCmdCombinedOutput(cmd *exec.Cmd) ([]byte, error)
 	IdempotentCmdOutput(cmd *exec.Cmd) ([]byte, error)
+	Link(oldname, newname AbsPath) error
 	Lstat(filename AbsPath) (fs.FileInfo, error)
 	Mkdir(name AbsPath, perm fs.FileMode) error
 	RawPath(absPath AbsPath) (AbsPath, error)
@@ -51,6 +52,7 @@ func (emptySystemMixin) UnderlyingFS() vfs.FS                                   
 type noUpdateSystemMixin struct{}
 
 func (noUpdateSystemMixin) Chmod(name AbsPath, perm fs.FileMode) error { panic(nil) }
+func (noUpdateSystemMixin) Link(oldname, newname AbsPath) error        { panic(nil) }
 func (noUpdateSystemMixin) Mkdir(name AbsPath, perm fs.FileMode) error { panic(nil) }
 func (noUpdateSystemMixin) RemoveAll(name AbsPath) error               { panic(nil) }
 func (noUpdateSystemMixin) Rename(oldpath, newpath AbsPath) error      { panic(nil) }

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -281,6 +281,7 @@ func runMain(versionInfo VersionInfo, args []string) error {
 	if err != nil {
 		return err
 	}
+	defer config.close()
 	switch err := config.execute(args); {
 	case errors.Is(err, bbolt.ErrTimeout):
 		// Translate bbolt timeout errors into a friendlier message. As the

--- a/internal/cmd/mergecmd.go
+++ b/internal/cmd/mergecmd.go
@@ -46,12 +46,10 @@ func (c *Config) runMergeCmd(cmd *cobra.Command, args []string, sourceState *che
 	// Create a temporary directory to store the target state and ensure that it
 	// is removed afterwards. We cannot use fs as it lacks TempDir
 	// functionality.
-	tempDir, err := os.MkdirTemp("", "chezmoi-merge")
+	tempDirAbsPath, err := c.tempDir("chezmoi-merge")
 	if err != nil {
 		return err
 	}
-	defer os.RemoveAll(tempDir)
-	tempDirAbsPath := chezmoi.NewAbsPath(tempDir)
 
 	var plaintextTempDirAbsPath chezmoi.AbsPath
 	defer func() {
@@ -72,12 +70,9 @@ func (c *Config) runMergeCmd(cmd *cobra.Command, args []string, sourceState *che
 		)
 		if sourceStateFile, ok := sourceStateEntry.(*chezmoi.SourceStateFile); ok {
 			if sourceStateFile.Attr.Encrypted {
-				if plaintextTempDirAbsPath.Empty() {
-					plaintextTempDir, err := os.MkdirTemp("", "chezmoi-merge-plaintext")
-					if err != nil {
-						return err
-					}
-					plaintextTempDirAbsPath = chezmoi.NewAbsPath(plaintextTempDir)
+				plaintextTempDirAbsPath, err := c.tempDir("chezmoi-merge-plaintext")
+				if err != nil {
+					return err
 				}
 				plaintextAbsPath = plaintextTempDirAbsPath.Join(sourceStateEntry.SourceRelPath().RelPath())
 				plaintext, err := sourceStateFile.Contents()

--- a/internal/cmd/upgradecmd.go
+++ b/internal/cmd/upgradecmd.go
@@ -372,18 +372,9 @@ func (c *Config) upgradePackage(ctx context.Context, rr *github.RepositoryReleas
 		}
 
 		// Create a temporary directory for the package.
-		var tempDirAbsPath chezmoi.AbsPath
-		if c.dryRun {
-			tempDirAbsPath = chezmoi.NewAbsPath(os.TempDir())
-		} else {
-			tempDir, err := os.MkdirTemp("", "chezmoi")
-			if err != nil {
-				return err
-			}
-			tempDirAbsPath = chezmoi.NewAbsPath(tempDir)
-			defer func() {
-				_ = c.baseSystem.RemoveAll(tempDirAbsPath)
-			}()
+		tempDirAbsPath, err := c.tempDir("chezmoi")
+		if err != nil {
+			return err
 		}
 
 		data, err := c.downloadURL(ctx, releaseAsset.GetBrowserDownloadURL())


### PR DESCRIPTION
This PR makes `chezmoi edit $TARGET` invoke your editor with an unmangled filename matching `$TARGET` exactly, independent of chezmoi's file name mangling.

For example, say you have a `private_dot_bashrc` in your source state. When you run `chezmoi edit ~/.bashrc` then your editor will be opened with a file with the basename `.bashrc`, so all of your editor's syntax highlighting should work.

Under the hood it creates a hard link from a file in a temporary directory (e.g.`$TMPDIR/.bashrc`) to the actual file in your source directory (e.g. `~/.local/share/chezmoi/private_dot_bashrc`) so your editor thinks it's actually editing `$HOME/.bashrc`.

After you quit your editor the directory with the hard links is cleaned up.

Refs #752 #769
cc @alker0 @m-rey @thernstig

This is an experimental feature - I'd love to hear your feedback.
