### PR TITLE
fix: Fix upgrade command on non-amd64 Linux machines

### DIFF
--- a/internal/cmd/upgradecmd.go
+++ b/internal/cmd/upgradecmd.go
@@ -281,7 +281,7 @@ func (c *Config) getLibc() (string, error) {
 
 func (c *Config) replaceExecutable(ctx context.Context, executableFilenameAbsPath chezmoi.AbsPath, releaseVersion *semver.Version, rr *github.RepositoryRelease) error {
 	goos := runtime.GOOS
-	if goos == "linux" {
+	if goos == "linux" && runtime.GOARCH == "amd64" {
 		libc, err := c.getLibc()
 		if err != nil {
 			return err


### PR DESCRIPTION
Fixes #1479.