### PR TITLE
fix: Run run_once_ scripts when their contents change

### DIFF
--- a/internal/chezmoi/hexbytes.go
+++ b/internal/chezmoi/hexbytes.go
@@ -7,6 +7,11 @@ import (
 // A HexBytes is a []byte which is marshaled as a hex string.
 type HexBytes []byte
 
+// Bytes returns h as a []byte.
+func (h HexBytes) Bytes() []byte {
+	return []byte(h)
+}
+
 // MarshalText implements encoding.TextMarshaler.MarshalText.
 func (h HexBytes) MarshalText() ([]byte, error) {
 	if len(h) == 0 {

--- a/internal/cmd/testdata/scripts/scriptonce2_unix.txt
+++ b/internal/cmd/testdata/scripts/scriptonce2_unix.txt
@@ -1,0 +1,22 @@
+[windows] skip 'UNIX only'
+
+# test that chezmoi apply runs scripts when their contents are reverted
+mkdir $CHEZMOISOURCEDIR
+cp golden/script-one.sh $CHEZMOISOURCEDIR/run_once_script.sh
+chezmoi apply
+stdout one
+cp golden/script-two.sh $CHEZMOISOURCEDIR/run_once_script.sh
+chezmoi apply
+stdout two
+cp golden/script-one.sh $CHEZMOISOURCEDIR/run_once_script.sh
+chezmoi apply
+stdout one
+
+-- golden/script-one.sh --
+#!/bin/sh
+
+echo one
+-- golden/script-two.sh --
+#!/bin/sh
+
+echo two

--- a/internal/cmd/testdata/scripts/state_unix.txt
+++ b/internal/cmd/testdata/scripts/state_unix.txt
@@ -11,8 +11,7 @@ exists $CHEZMOICONFIGDIR/chezmoistate.boltdb
 
 # test that the persistent state records that script was run
 chezmoi state dump --format=yaml
-stdout a8076d3d28d21e02012b20eaf7dbf75409a6277134439025f282e368e3305abf:
-stdout runAt:
+stdout ${HOME@R}/script:
 
 # test that chezmoi state reset removes the persistent state
 chezmoi --force state reset


### PR DESCRIPTION
Fixes #1497.

This fixes the implementation to match the docs (c.f. #1501 which fixes the docs to match the implementation).

It's not quite finished yet, there's a test failure around `chezmoi status` that still needs to be fixed, and the migration story needs a bunch of testing.