### PR TITLE
feat: Add .chezmoi.args template variable

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -40,10 +40,10 @@ builds:
   env:
   - CGO_ENABLED=0
   goos:
-  - illumos
-  - linux
   - darwin
   - freebsd
+  - illumos
+  - linux
   - openbsd
   - solaris
   - windows

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -1762,6 +1762,7 @@ chezmoi provides the following automatically-populated variables:
 | Variable                   | Type       | Value                                                                                                                           |
 | -------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | `.chezmoi.arch`            | `string`   | Architecture, e.g. `amd64`, `arm`, etc. as returned by [runtime.GOARCH](https://pkg.go.dev/runtime?tab=doc#pkg-constants).      |
+| `.chezmoi.args`            | `[]string` | The arguments passed to the `chezmoi` command, starting with the program command.                                               |
 | `.chezmoi.fqdnHostname`    | `string`   | The fully-qualified domain name hostname of the machine chezmoi is running on.                                                  |
 | `.chezmoi.group`           | `string`   | The group of the user running chezmoi.                                                                                          |
 | `.chezmoi.homeDir`         | `string`   | The home directory of the user running chezmoi.                                                                                 |

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -1759,20 +1759,23 @@ For a full list of options, see
 
 chezmoi provides the following automatically-populated variables:
 
-| Variable                | Value                                                                                                                           |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `.chezmoi.arch`         | Architecture, e.g. `amd64`, `arm`, etc. as returned by [runtime.GOARCH](https://pkg.go.dev/runtime?tab=doc#pkg-constants).      |
-| `.chezmoi.fqdnHostname` | The fully-qualified domain name hostname of the machine chezmoi is running on.                                                  |
-| `.chezmoi.group`        | The group of the user running chezmoi.                                                                                          |
-| `.chezmoi.homeDir`      | The home directory of the user running chezmoi.                                                                                 |
-| `.chezmoi.hostname`     | The hostname of the machine chezmoi is running on, up to the first `.`.                                                         |
-| `.chezmoi.kernel`       | Contains information from `/proc/sys/kernel`. Linux only, useful for detecting specific kernels (i.e. Microsoft's WSL kernel).  |
-| `.chezmoi.os`           | Operating system, e.g. `darwin`, `linux`, etc. as returned by [runtime.GOOS](https://pkg.go.dev/runtime?tab=doc#pkg-constants). |
-| `.chezmoi.osRelease`    | The information from `/etc/os-release`, Linux only, run `chezmoi data` to see its output.                                       |
-| `.chezmoi.sourceDir`    | The source directory.                                                                                                           |
-| `.chezmoi.sourceFile`   | The path of the template relative to the source directory.                                                                      |
-| `.chezmoi.username`     | The username of the user running chezmoi.                                                                                       |
-| `.chezmoi.version`      | The version of chezmoi.                                                                                                         |
+| Variable                   | Type       | Value                                                                                                                           |
+| -------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `.chezmoi.arch`            | `string`   | Architecture, e.g. `amd64`, `arm`, etc. as returned by [runtime.GOARCH](https://pkg.go.dev/runtime?tab=doc#pkg-constants).      |
+| `.chezmoi.fqdnHostname`    | `string`   | The fully-qualified domain name hostname of the machine chezmoi is running on.                                                  |
+| `.chezmoi.group`           | `string`   | The group of the user running chezmoi.                                                                                          |
+| `.chezmoi.homeDir`         | `string`   | The home directory of the user running chezmoi.                                                                                 |
+| `.chezmoi.hostname`        | `string`   | The hostname of the machine chezmoi is running on, up to the first `.`.                                                         |
+| `.chezmoi.kernel`          | `string`   | Contains information from `/proc/sys/kernel`. Linux only, useful for detecting specific kernels (e.g. Microsoft's WSL kernel).  |
+| `.chezmoi.os`              | `string`   | Operating system, e.g. `darwin`, `linux`, etc. as returned by [runtime.GOOS](https://pkg.go.dev/runtime?tab=doc#pkg-constants). |
+| `.chezmoi.osRelease`       | `string`   | The information from `/etc/os-release`, Linux only, run `chezmoi data` to see its output.                                       |
+| `.chezmoi.sourceDir`       | `string`   | The source directory.                                                                                                           |
+| `.chezmoi.sourceFile`      | `string`   | The path of the template relative to the source directory.                                                                      |
+| `.chezmoi.username`        | `string`   | The username of the user running chezmoi.                                                                                       |
+| `.chezmoi.version.builtBy` | `string`   | The program that built the `chezmoi` executable, if set.                                                                        |
+| `.chezmoi.version.commit`  | `string`   | The git commit at which the `chezmoi` executable was built, if set.                                                             |
+| `.chezmoi.version.date`    | `string`   | The timestamp at which the `chezmoi` executable was built, if set.                                                              |
+| `.chezmoi.version.version` | `string`   | The version of chezmoi.                                                                                                         |
 
 Additional variables can be defined in the config file in the `data` section.
 Variable names must consist of a letter and be followed by zero or more letters

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -889,6 +889,7 @@ func (c *Config) defaultTemplateData() map[string]interface{} {
 	return map[string]interface{}{
 		"chezmoi": map[string]interface{}{
 			"arch":         runtime.GOARCH,
+			"args":         os.Args,
 			"fqdnHostname": fqdnHostname,
 			"group":        group,
 			"homeDir":      c.homeDir,

--- a/internal/cmd/testdata/scripts/templatevars.txt
+++ b/internal/cmd/testdata/scripts/templatevars.txt
@@ -1,0 +1,22 @@
+chezmoi execute-template '{{ .chezmoi.arch }}'
+[386] stdout 386
+[amd64] stdout amd64
+[arm] stdout arm
+[arm64] stdout arm64
+[ppc64] stdout ppc64
+[ppc64le] stdout ppc64le
+
+chezmoi execute-template '{{ .chezmoi.homeDir }}'
+stdout ${HOME@R}
+
+chezmoi execute-template '{{ .chezmoi.os }}'
+[darwin] stdout darwin
+[freebsd] stdout freebsd
+[illumos] stdout illumos
+[linux] stdout linux
+[openbsd] stdout openbsd
+[solaris] stdout solaris
+[windows] stdout windows
+
+chezmoi execute-template '{{ .chezmoi.sourceDir }}'
+stdout ${CHEZMOISOURCEDIR@R}

--- a/internal/cmd/testdata/scripts/templatevars.txt
+++ b/internal/cmd/testdata/scripts/templatevars.txt
@@ -6,6 +6,9 @@ chezmoi execute-template '{{ .chezmoi.arch }}'
 [ppc64] stdout ppc64
 [ppc64le] stdout ppc64le
 
+chezmoi execute-template '{{ index .chezmoi.args 1 }}'
+stdout execute-template
+
 chezmoi execute-template '{{ .chezmoi.homeDir }}'
 stdout ${HOME@R}
 


### PR DESCRIPTION
Fixes #1532.

`.chezmoi.executable` is the requested `.chezmoi.binPath`.

`.chezmoi.args` combine the requested `.chezmoi.command` and `.chezmoi.options`.

I really don't think that this is a good idea, but here's a PR for you to experiment with :)