### PR TITLE
chore: Use conventional subdirectory for source archives

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -198,3 +198,4 @@ snapcrafts:
 
 source:
   enabled: true
+  prefix_template: '{{ .ProjectName }}-{{ .Version }}/'


### PR DESCRIPTION
Fixes #1576.

This should only be merged when the next version of goreleaser is released, which will include https://github.com/goreleaser/goreleaser/pull/2620.

cc @torculus this will affect the [OpenIndiana package](https://github.com/OpenIndiana/oi-userland/tree/oi/hipster/components/sysutils/chezmoi) for chezmoi once this merged (2.7.4 and previous versions are not affected). Specifically, instead of the source tarball unpacking the source code into the current directory, the source tarball will unpack into a `chezmoi-$VERSION/` subdirectory.