### PR TITLE
fix: `lookPath` panics when file does not exists

### DIFF
--- a/internal/cmd/templatefuncs.go
+++ b/internal/cmd/templatefuncs.go
@@ -73,6 +73,8 @@ func (c *Config) lookPathTemplateFunc(file string) string {
 		return path
 	case errors.Is(err, exec.ErrNotFound):
 		return ""
+	case errors.Is(err, fs.ErrNotExist):
+		return ""
 	default:
 		returnTemplateError(err)
 		return ""

--- a/internal/cmd/testdata/scripts/templatefuncs.txt
+++ b/internal/cmd/testdata/scripts/templatefuncs.txt
@@ -27,9 +27,13 @@ cmp stdout golden/include-relpath
 chezmoi execute-template '{{ joinPath "a" "b" }}'
 stdout a${/}b
 
-# test lookPath template function
+# test lookPath template function to find in PATH
 chezmoi execute-template '{{ lookPath "go" }}'
 stdout go$exe
+
+# test lookPath template function to check if file exists
+chezmoi execute-template '{{ lookPath "/non-existing-file" }}'
+! stdout .
 
 # test mozillaInstallHash template function
 chezmoi execute-template '{{ mozillaInstallHash "/Applications/Firefox.app/Contents/MacOS" }}'


### PR DESCRIPTION
When it should just return an empty string, specifically when looking for an absolute path.

Fixes #1606 