### PR TITLE
fix: Warn, don't fail, if age version cannot be parsed in doctor command

### DIFF
--- a/internal/cmd/doctorcmd.go
+++ b/internal/cmd/doctorcmd.go
@@ -340,7 +340,7 @@ func (c *binaryCheck) Run(system chezmoi.System, homeDirAbsPath chezmoi.AbsPath)
 	if c.versionRx != nil {
 		match := c.versionRx.FindSubmatch(versionBytes)
 		if len(match) != 2 {
-			return checkResultFailed, fmt.Sprintf("found %s, could not parse version from %s", pathAbsPath, bytes.TrimSpace(versionBytes))
+			return checkResultWarning, fmt.Sprintf("found %s, cannot parse version from %s", pathAbsPath, bytes.TrimSpace(versionBytes))
 		}
 		versionBytes = match[1]
 	}

--- a/internal/cmd/testdata/scripts/doctor_unix.txt
+++ b/internal/cmd/testdata/scripts/doctor_unix.txt
@@ -29,7 +29,7 @@ stdout '^ok\s+shell\s+'
 stdout '^ok\s+edit-command\s+'
 stdout '^ok\s+git-command\s+'
 stdout '^ok\s+merge-command\s+'
-stdout '^ok\s+age-command\s+'
+stdout '^warning\s+age-command\s+'
 stdout '^ok\s+gpg-command\s+'
 stdout '^ok\s+pinentry-command\s+'
 stdout '^ok\s+1password-command\s+'
@@ -59,7 +59,7 @@ stdout '^warning\s+suspicious-entries\s+'
 -- bin/age --
 #!/bin/sh
 
-echo "v1.0.0-rc.1"
+echo "(devel)"
 -- bin/bw --
 #!/bin/sh
 


### PR DESCRIPTION
Fixes #1607.