### PR TITLE
feat: Add support for Homebrew on Linux to upgrade command

### DIFF
--- a/internal/cmd/doctorcmd.go
+++ b/internal/cmd/doctorcmd.go
@@ -193,6 +193,7 @@ func (c *Config) runDoctorCmd(cmd *cobra.Command, args []string) error {
 			versionArgs: []string{"-version"},
 			versionRx:   regexp.MustCompile(`v(\d+\.\d+\.\d+\S*)`),
 			ifNotSet:    checkResultWarning,
+			ifNotExist:  checkResultInfo,
 		},
 		&binaryCheck{
 			name:        "gpg-command",
@@ -200,6 +201,7 @@ func (c *Config) runDoctorCmd(cmd *cobra.Command, args []string) error {
 			versionArgs: []string{"--version"},
 			versionRx:   regexp.MustCompile(`(?m)^gpg\s+\(.*?\)\s+(\d+\.\d+\.\d+)`),
 			ifNotSet:    checkResultWarning,
+			ifNotExist:  checkResultInfo,
 		},
 		&binaryCheck{
 			name:        "pinentry-command",

--- a/internal/cmd/noupgradecmd.go
+++ b/internal/cmd/noupgradecmd.go
@@ -5,6 +5,9 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/twpayne/go-vfs/v4"
+
+	"github.com/twpayne/chezmoi/v2/internal/chezmoi"
 )
 
 type upgradeCmdConfig struct {
@@ -15,4 +18,8 @@ type upgradeCmdConfig struct {
 
 func (c *Config) newUpgradeCmd() *cobra.Command {
 	return nil
+}
+
+func getUpgradeMethod(vfs.FS, chezmoi.AbsPath) (string, error) {
+	return "", nil
 }


### PR DESCRIPTION
Fixes #1609.
Fixes #314.

@felipecrs as discussed yesterday, this is a little tricky to test. You can, however, do:
1. Install chemzoi 2.7.4 with Homebrew on Linux as you described in #1609.
2. Build chezmoi with these changes and replace the `which chezmoi` with the newly-built binary (`/home/linuxbrew/.linuxbrew/bin/chezmoi` on my test system, `/home/felipecrs/.linuxbrew/bin/chezmoi` on yours).
3. Run `chezmoi upgrade --debug --force`, and it should install chezmoi 2.7.5 using `brew update chezmoi`. The `--force` is needed as the new binary will have version `dev` and so won't upgrade itself unless forced.