### PR TITLE
feat: Add .chezmoi.executable template variable

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,12 +14,12 @@
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": {
-		"terminal.integrated.shell.linux": "/bin/bash",
 		"go.toolsManagement.checkForUpdates": "off",
 		"go.useLanguageServer": true,
 		"go.gopath": "/go",
 		"go.goroot": "/usr/local/go",
-		"go.toolsGopath": "/go/bin"
+		"go.toolsGopath": "/go/bin",
+		"markdown.extension.toc.updateOnSave": false
 	},
 
 	// Add the IDs of extensions you want installed when the container is created.

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -451,25 +451,25 @@ names.
 The following prefixes and suffixes are special, and are collectively referred
 to as "attributes":
 
-| Prefix       | Effect                                                                          |
-| ------------ | ------------------------------------------------------------------------------- |
-| `after_`     | Run script after updating the destination.                                      |
-| `before_`    | Run script before updating the destination.                                     |
-| `create_`    | Ensure that the file exists, and create it with contents if it does not.        |
-| `dot_`       | Rename to use a leading dot, e.g. `dot_foo` becomes `.foo`.                     |
-| `empty_`     | Ensure the file exists, even if is empty. By default, empty files are removed.  |
-| `encrypted_` | Encrypt the file in the source state.                                           |
-| `exact_`     | Remove anything not managed by chezmoi.                                         |
-| `executable_`| Add executable permissions to the target file.                                  |
-| `literal_`   | Stop parsing prefix attributes.                                                 |
-| `modify_`    | Treat the contents as a script that modifies an existing file.                  |
-| `once_`      | Only run the script if it has not been run before.                              |
-| `onchange_`  | Only run the script if its contents have changed from the last time it was run. |
-| `private_`   | Remove all group and world permissions from the target file or directory.       |
-| `readonly_`  | Remove all write permissions from the target file or directory.                 |
-| `remove_`    | Remove the entry if it exists.                                                  |
-| `run_`       | Treat the contents as a script to run.                                          |
-| `symlink_`   | Create a symlink instead of a regular file.                                     |
+| Prefix        | Effect                                                                          |
+| ------------- | ------------------------------------------------------------------------------- |
+| `after_`      | Run script after updating the destination.                                      |
+| `before_`     | Run script before updating the destination.                                     |
+| `create_`     | Ensure that the file exists, and create it with contents if it does not.        |
+| `dot_`        | Rename to use a leading dot, e.g. `dot_foo` becomes `.foo`.                     |
+| `empty_`      | Ensure the file exists, even if is empty. By default, empty files are removed.  |
+| `encrypted_`  | Encrypt the file in the source state.                                           |
+| `exact_`      | Remove anything not managed by chezmoi.                                         |
+| `executable_` | Add executable permissions to the target file.                                  |
+| `literal_`    | Stop parsing prefix attributes.                                                 |
+| `modify_`     | Treat the contents as a script that modifies an existing file.                  |
+| `once_`       | Only run the script if it has not been run before.                              |
+| `onchange_`   | Only run the script if its contents have changed from the last time it was run. |
+| `private_`    | Remove all group and world permissions from the target file or directory.       |
+| `readonly_`   | Remove all write permissions from the target file or directory.                 |
+| `remove_`     | Remove the entry if it exists.                                                  |
+| `run_`        | Treat the contents as a script to run.                                          |
+| `symlink_`    | Create a symlink instead of a regular file.                                     |
 
 | Suffix     | Effect                                               |
 | ---------- | ---------------------------------------------------- |
@@ -1853,6 +1853,7 @@ chezmoi provides the following automatically-populated variables:
 | -------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | `.chezmoi.arch`            | `string`   | Architecture, e.g. `amd64`, `arm`, etc. as returned by [runtime.GOARCH](https://pkg.go.dev/runtime?tab=doc#pkg-constants).      |
 | `.chezmoi.args`            | `[]string` | The arguments passed to the `chezmoi` command, starting with the program command.                                               |
+| `.chezmoi.executable`      | `string`   | The path to the `chezmoi` executable, if available.                                                                             |
 | `.chezmoi.fqdnHostname`    | `string`   | The fully-qualified domain name hostname of the machine chezmoi is running on.                                                  |
 | `.chezmoi.group`           | `string`   | The group of the user running chezmoi.                                                                                          |
 | `.chezmoi.homeDir`         | `string`   | The home directory of the user running chezmoi.                                                                                 |

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -890,10 +890,13 @@ func (c *Config) defaultTemplateData() map[string]interface{} {
 			Msg("chezmoi.OSRelease")
 	}
 
+	executable, _ := os.Executable()
+
 	return map[string]interface{}{
 		"chezmoi": map[string]interface{}{
 			"arch":         runtime.GOARCH,
 			"args":         os.Args,
+			"executable":   executable,
 			"fqdnHostname": fqdnHostname,
 			"group":        group,
 			"homeDir":      c.homeDir,

--- a/internal/cmd/testdata/scripts/templatevars.txt
+++ b/internal/cmd/testdata/scripts/templatevars.txt
@@ -9,6 +9,9 @@ chezmoi execute-template '{{ .chezmoi.arch }}'
 chezmoi execute-template '{{ index .chezmoi.args 1 }}'
 stdout execute-template
 
+chezmoi execute-template '{{ .chezmoi.executable }}'
+stdout [\\/]chezmoi(.exe)?$
+
 chezmoi execute-template '{{ .chezmoi.homeDir }}'
 stdout ${HOME@R}
 


### PR DESCRIPTION
So, it turns out that `.chezmoi.args[0]` is not the path for the chezmoi binary as I thought. It was during my test because I was indeed calling the chezmoi by providing the full path to its executable.

Refs https://github.com/twpayne/chezmoi/pull/1534