### PR TITLE
fix: .chezmoiremove with `*` when destDir is `/`

### DIFF
--- a/internal/chezmoi/chezmoi.go
+++ b/internal/chezmoi/chezmoi.go
@@ -179,3 +179,11 @@ func mustTrimSuffix(s, suffix string) string {
 	}
 	return s[:len(s)-len(suffix)]
 }
+
+// ensureSuffix adds suffix to s if s is not suffixed by suffix.
+func ensureSuffix(s, suffix string) string {
+	if strings.HasSuffix(s, suffix) {
+		return s
+	}
+	return s + suffix
+}

--- a/internal/chezmoi/sourcestate.go
+++ b/internal/chezmoi/sourcestate.go
@@ -754,7 +754,7 @@ func (s *SourceState) Read(ctx context.Context, options *ReadOptions) error {
 			if err := s.addPatterns(removePatterns, sourceAbsPath, sourceRelPath); err != nil {
 				return err
 			}
-			matches, err := removePatterns.glob(s.system.UnderlyingFS(), s.destDirAbsPath.String()+"/")
+			matches, err := removePatterns.glob(s.system.UnderlyingFS(), ensureSuffix(s.destDirAbsPath.String(), "/"))
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/testdata/scripts/remove.txt
+++ b/internal/cmd/testdata/scripts/remove.txt
@@ -29,8 +29,24 @@ chezmoi apply
 ! exists $HOME/.file
 ! exists $HOME/.dir
 
+chhome home3/user
+
+# test that chezmoi apply with .chezmoiremove with star works on destination dir with trailing slash
+exists $HOME/.star-file
+exists $HOME/.star-dir
+chezmoi apply --destination=$HOME/
+! exists $HOME/.star-file
+! exists $HOME/.star-dir
+
 -- home2/user/.dir/.keep --
 -- home2/user/.file --
 # contents of .file
 -- home2/user/.local/share/chezmoi/remove_dot_file --
 -- home2/user/.local/share/chezmoi/remove_dot_dir --
+
+-- home3/user/.star-dir/.keep --
+-- home3/user/.star-file --
+# contents of .star-file
+-- home3/user/.local/share/chezmoi/.chezmoiremove --
+.*-dir/
+.*-file


### PR DESCRIPTION
Fixes #1651

<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://github.com/twpayne/chezmoi/blob/master/docs/CONTRIBUTING.md

-->
