### PR TITLE
feat: Make upgrade command work without calling GitHub API

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -1750,16 +1750,9 @@ $ chezmoi update
 ### `upgrade`
 
 Upgrade chezmoi by downloading and installing the latest released version. This
-will call the GitHub API to determine if there is a new version of chezmoi
+will call the GitHub Releases to determine if there is a new version of chezmoi
 available, and if so, download and attempt to install it in the same way as
 chezmoi was previously installed.
-
-If the any of the `$CHEZMOI_GITHUB_ACCESS_TOKEN`, `$GITHUB_ACCESS_TOKEN`, or
-`$GITHUB_TOKEN` environment variables are set, then the first value found will
-be used to authenticate requests to the GitHub API, otherwise unauthenticated
-requests are used which are subject to stricter [rate
-limiting](https://developer.github.com/v3/#rate-limiting). Unauthenticated
-requests should be sufficient for most cases.
 
 ---
 


### PR DESCRIPTION
I converted my dotfiles to install chezmoi using the binary directly rather than using Homebrew. In the moment I applied these changes in my work environment, I noticed that chezmoi upgrade command fails in the very beginning.

At my work environment we do not use GitHub, and therefore it's not desirable to ask my colleagues to create a GitHub account just for running chezmoi upgrade.

![image](https://user-images.githubusercontent.com/29582865/143611812-a9e58a14-9000-4687-b0c9-3e3eb2a3a389.png)
