### PR TITLE
feat: Add .chezmoi.configFile template variable

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -1891,6 +1891,7 @@ chezmoi provides the following automatically-populated variables:
 | -------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | `.chezmoi.arch`            | `string`   | Architecture, e.g. `amd64`, `arm`, etc. as returned by [runtime.GOARCH](https://pkg.go.dev/runtime?tab=doc#pkg-constants).      |
 | `.chezmoi.args`            | `[]string` | The arguments passed to the `chezmoi` command, starting with the program command.                                               |
+| `.chezmoi.configFile`      | `string`   | The path to the configuration file used by chezmoi, if any.                                                                     |
 | `.chezmoi.executable`      | `string`   | The path to the `chezmoi` executable, if available.                                                                             |
 | `.chezmoi.fqdnHostname`    | `string`   | The fully-qualified domain name hostname of the machine chezmoi is running on.                                                  |
 | `.chezmoi.group`           | `string`   | The group of the user running chezmoi.                                                                                          |

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -930,6 +930,7 @@ func (c *Config) defaultTemplateData() map[string]interface{} {
 		"chezmoi": map[string]interface{}{
 			"arch":         runtime.GOARCH,
 			"args":         os.Args,
+			"configFile":   c.configFileAbsPath.String(),
 			"executable":   executable,
 			"fqdnHostname": fqdnHostname,
 			"group":        group,


### PR DESCRIPTION
<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://github.com/twpayne/chezmoi/blob/master/docs/CONTRIBUTING.md

-->

I have two use cases for this one:

`run_before_migrate.sh.tmpl`:
```
#!/bin/bash

{{ if hasSuffix .chezmoi.configFile ".toml" -}}
rm -f "{{ .chezmoi.configFile }}"
echo "We need to update the config file format, please run the following command:"
echo "chezmoi init --source '{{ .chezmoi.sourceDir }}'"
{{- end -}}
```

And:

`home/dot_local/bin/executable_rootmoi.tmpl`:
```
#!/bin/bash

readonly config_dir="{{ dir .chezmoi.configFile }}"

readonly config="${config_dir}/root.config.json"
readonly persistent_state="${config_dir}/root.chezmoistate.boltdb"

exec sudo "{{ .chezmoi.executable }}" \
  --config="${config}" \
  --persistent-state="${persistent_state}" \
  "$@"
```
