### PR TITLE
Fix delete-bucket command in HOWTO doc

### DIFF
--- a/docs/HOWTO.md
+++ b/docs/HOWTO.md
@@ -1440,7 +1440,7 @@ chezmoi stores whether and when `run_once_` scripts have been run in the
 scripts, run:
 
 ```console
-$ chezmoi delete-bucket --bucket=scriptState
+$ chezmoi state delete-bucket --bucket=scriptState
 ```
 
 ---


### PR DESCRIPTION
The HOWTO document says to use "chezmoi delete-bucket" to clear
the state of the `run_once_` scripts, but when I try that I
get this error:

  chezmoi: unknown command "delete-bucket" for "chezmoi"

This commit updates the documentation to use
"chezmoi state delete-bucket" instead,
which I believe is the intended command.
