### PR TITLE
chore: Don't read full source state in execute-template

### DIFF
--- a/internal/cmd/executetemplatecmd.go
+++ b/internal/cmd/executetemplatecmd.go
@@ -39,7 +39,9 @@ func (c *Config) newExecuteTemplateCmd() *cobra.Command {
 }
 
 func (c *Config) runExecuteTemplateCmd(cmd *cobra.Command, args []string) error {
-	var options []chezmoi.SourceStateOption
+	options := []chezmoi.SourceStateOption{
+		chezmoi.WithControlOnly(true),
+	}
 	if c.executeTemplate.init {
 		options = append(options, chezmoi.WithReadTemplateData(false))
 	}


### PR DESCRIPTION
This speeds up `chezmoi execute-template` by only reading control data, not the full source state.

Refs #1715.