### PR TITLE
Fix link on chezmoi.io from templating to reference

### DIFF
--- a/docs/TEMPLATING.md
+++ b/docs/TEMPLATING.md
@@ -331,7 +331,7 @@ for complete list.
 
 chezmoi defines a few useful templates variables that depend on the system you
 are currently on. A list of the variables defined by chezmoi can be found
-[here](REFERENCE.md#template-variables).
+[here](https://github.com/twpayne/chezmoi/blob/master/docs/REFERENCE.md#template-variables).
 
 There are, however more variables than that. To view the variables available on
 your system, execute:


### PR DESCRIPTION
Website generation seems to rely on absolute links to git repository.

(As seen line 325 right above the change)

PS: hugo seems to be broken though. Maybe this is the reason the relative link does not work :shrug:

```
❯ ( cd assets/chezmoi.io/ && hugo serve )
Start building sites … 
hugo v0.89.3+extended linux/amd64 BuildDate=unknown
ERROR 2021/12/10 12:25:05 [en] REF_NOT_FOUND: Ref "/docs/install.md": "/home/syphdias/git/private/chezmoi/assets/chezmoi.io/content/docs/menu/index.md:5:13": page not found
ERROR 2021/12/10 12:25:05 [en] REF_NOT_FOUND: Ref "/docs/quick-start.md": "/home/syphdias/git/private/chezmoi/assets/chezmoi.io/content/docs/menu/index.md:6:17": page not found
ERROR 2021/12/10 12:25:05 [en] REF_NOT_FOUND: Ref "/docs/how-to.md": "/home/syphdias/git/private/chezmoi/assets/chezmoi.io/content/docs/menu/index.md:7:12": page not found
ERROR 2021/12/10 12:25:05 [en] REF_NOT_FOUND: Ref "/docs/templating.md": "/home/syphdias/git/private/chezmoi/assets/chezmoi.io/content/docs/menu/index.md:8:16": page not found
ERROR 2021/12/10 12:25:05 [en] REF_NOT_FOUND: Ref "/docs/faq.md": "/home/syphdias/git/private/chezmoi/assets/chezmoi.io/content/docs/menu/index.md:9:9": page not found
ERROR 2021/12/10 12:25:05 [en] REF_NOT_FOUND: Ref "/docs/changes.md": "/home/syphdias/git/private/chezmoi/assets/chezmoi.io/content/docs/menu/index.md:10:13": page not found
ERROR 2021/12/10 12:25:05 [en] REF_NOT_FOUND: Ref "/docs/reference.md": "/home/syphdias/git/private/chezmoi/assets/chezmoi.io/content/docs/menu/index.md:11:15": page not found
ERROR 2021/12/10 12:25:05 [en] REF_NOT_FOUND: Ref "/docs/media.md": "/home/syphdias/git/private/chezmoi/assets/chezmoi.io/content/docs/menu/index.md:12:11": page not found
ERROR 2021/12/10 12:25:05 [en] REF_NOT_FOUND: Ref "/docs/comparison.md": "/home/syphdias/git/private/chezmoi/assets/chezmoi.io/content/docs/menu/index.md:13:16": page not found
ERROR 2021/12/10 12:25:05 [en] REF_NOT_FOUND: Ref "/docs/contributing.md": "/home/syphdias/git/private/chezmoi/assets/chezmoi.io/content/docs/menu/index.md:14:18": page not found
ERROR 2021/12/10 12:25:05 [en] REF_NOT_FOUND: Ref "/docs/architecture.md": "/home/syphdias/git/private/chezmoi/assets/chezmoi.io/content/docs/menu/index.md:15:18": page not found
ERROR 2021/12/10 12:25:05 [en] REF_NOT_FOUND: Ref "/docs/related.md": "/home/syphdias/git/private/chezmoi/assets/chezmoi.io/content/docs/menu/index.md:16:22": page not found
ERROR 2021/12/10 12:25:05 [en] REF_NOT_FOUND: Ref "/docs/security.md": "/home/syphdias/git/private/chezmoi/assets/chezmoi.io/content/docs/menu/index.md:17:14": page not found
WARN 2021/12/10 12:25:05 Bundle menu mode is deprecated and will be removed
Error: Error building site: logged 13 error(s)
Built in 27 ms
```