### PR TITLE
refactor: use `[` instead of `test`

### DIFF
--- a/assets/scripts/install.sh
+++ b/assets/scripts/install.sh
@@ -83,7 +83,7 @@ main() {
 	(cd "${tmpdir}" && untar "${TARBALL}")
 
 	# install binary
-	test ! -d "${BINDIR}" && install -d "${BINDIR}"
+	[ ! -d "${BINDIR}" ] && install -d "${BINDIR}"
 	BINARY="chezmoi${BINSUFFIX}"
 	install "${tmpdir}/${BINARY}" "${BINDIR}/"
 	log_info "installed ${BINDIR}/${BINARY}"
@@ -212,7 +212,7 @@ real_tag() {
 		log_err "real_tag error determining real tag of GitHub release ${tag}"
 		return 1
 	fi
-	test -z "${real_tag}" && return 1
+	[ -z "${real_tag}" ] && return 1
 	log_debug "found tag ${real_tag} for ${tag}"
 	echo "${real_tag}"
 }


### PR DESCRIPTION
Just making 2 lines of code in `assets/scripts/install.sh` a little more readable, by using `[` instead of the `test` command.
