### PR TITLE
Fix managed command example docs

### DIFF
--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -1570,8 +1570,8 @@ Only include entries of type *types*.
 $ chezmoi managed
 $ chezmoi managed --include=files
 $ chezmoi managed --include=files,symlinks
-$ chezmoi managed -i d
-$ chezmoi managed -i d,f
+$ chezmoi managed -i dirs
+$ chezmoi managed -i dirs,files
 ```
 
 ---


### PR DESCRIPTION
<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://github.com/twpayne/chezmoi/blob/master/docs/CONTRIBUTING.md

-->
Running the examples using the short-hand `-i` flag listed in the output of `chezmoi managed --help` results in errors:

```
$ chezmoi managed -i d
chezmoi: invalid argument "d" for "-i, --include" flag: d: unknown entry type
$ chezmoi managed -i d,f
chezmoi: invalid argument "d,f" for "-i, --include" flag: d: unknown entry type
```

If this behaviour is actually a regression and thus a bug I can also look into how to fix it.
