### PR TITLE
Add collapsible details to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/03_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/03_bug_report.md
@@ -26,9 +26,13 @@ $ chezmoi --verbose <your-command>
 
 ## Output of `chezmoi doctor`
 
+<details>
+
 ```console
 $ chezmoi doctor
 ```
+
+</details>
 
 ## Additional context
 


### PR DESCRIPTION
It just looks better when the extra details are not visible by default:
- https://github.com/twpayne/chezmoi/issues/1780