### PR TITLE
onepassword: prompt to sign-in if the current session is missing or expired

### DIFF
--- a/docs/HOWTO.md
+++ b/docs/HOWTO.md
@@ -32,6 +32,7 @@
   * [Create an archive of your dotfiles](#create-an-archive-of-your-dotfiles)
 * [Keep data private](#keep-data-private)
   * [Use 1Password](#use-1password)
+    * [1Password sign-in prompt](#1password-sign-in-prompt)
   * [Use Bitwarden](#use-bitwarden)
   * [Use gopass](#use-gopass)
   * [Use KeePassXC](#use-keepassxc)
@@ -943,6 +944,26 @@ Note the extra `-` after the opening `{{` and before the closing `}}`. This
 instructs the template language to remove any whitespace before and after the
 substitution. This removes any trailing newline added by your editor when saving
 the template.
+
+#### 1Password sign-in prompt
+
+chezmoi will verify the availability and validity of a session token in
+the current environment. If it is missing or expired, you will be interactively
+prompted to sign-in again.
+
+In the past chezmoi used to simply exit with an error when no valid session
+was available. If you'd like to restore that behavior, set the following option
+in your configuration file (`chezmoi.toml`):
+
+```toml
+[onepassword]
+    prompt = false
+```
+
+**A session token verified or acquired interactively will be passed to
+the 1Password CLI through a command-line parameter, which could be visible to other
+users of the same system. You should disable the prompt on shared machines
+for improved security.**
 
 ---
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -412,6 +412,7 @@ The following configuration variables are available:
 |                | `command`             | string   | `vimdiff`                | 3-way merge command                                    |
 | `onepassword`  | `cache`               | bool     | `true`                   | Enable optional caching provided by `op`               |
 |                | `command`             | string   | `op`                     | 1Password CLI command                                  |
+|                | `prompt`              | bool     | `true`                   | Prompt for sign-in when no valid session is available  |
 | `pass`         | `command`             | string   | `pass`                   | Pass CLI command                                       |
 | `pinentry`     | `args`                | []string | *none*                   | Extra args to the pinentry command                     |
 |                | `command`             | string   | *none*                   | pinentry command                                       |
@@ -2335,7 +2336,9 @@ same *uuid* will only invoke `op` once.  If the optional *vault-uuid* is
 supplied, it will be passed along to the `op get` call, which can significantly
 improve performance. If the optional *account-name* is supplied, it will be
 passed along to the `op get` call, which will help it look in the right account,
-in case you have multiple accounts (eg. personal and work accounts).
+in case you have multiple accounts (eg. personal and work accounts). If there
+is no valid session in the environment, by default you will be interactively
+prompted to sign in.
 
 #### `onepassword` examples
 
@@ -2359,7 +2362,8 @@ multiple times with the same *uuid* will only invoke `op` once.  If the optional
 can significantly improve performance. If the optional *account-name* is
 supplied, it will be passed along to the `op get` call, which will help it look
 in the right account, in case you have multiple accounts (eg. personal and work
-accounts).
+accounts). If there is no valid session in the environment, by default you will
+be interactively prompted to sign in.
 
 #### `onepasswordDocument` examples
 
@@ -2379,7 +2383,8 @@ accounts).
 CLI](https://support.1password.com/command-line-getting-started/) (`op`). *uuid*
 is passed to `op get item <uuid>`, the output from `op` is parsed as JSON, and
 elements of `details.fields` are returned as a map indexed by each field's
-`designation`. For example, give the output from `op`:
+`designation`. If there is no valid session in the environment, by default you
+will be interactively prompted to sign in. For example, give the output from `op`:
 
 ```json
 {
@@ -2448,8 +2453,9 @@ accounts).
 CLI](https://support.1password.com/command-line-getting-started/) (`op`). *uuid*
 is passed to `op get item <uuid>`, the output from `op` is parsed as JSON, and
 each element of `details.sections` are iterated over and any `fields` are
-returned as a map indexed by each field's `n`. For example, give the output from
-`op`:
+returned as a map indexed by each field's `n`. If there is no valid session
+in the environment, by default you will be interactively prompted to sign in.
+For example, give the output from `op`:
 
 ```json
 {

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -279,6 +279,7 @@ func newConfig(options ...configOption) (*Config, error) {
 		},
 		Onepassword: onepasswordConfig{
 			Command: "op",
+			Prompt:  true,
 		},
 		Pass: passConfig{
 			Command: "pass",

--- a/internal/cmd/onepasswordtemplatefuncs.go
+++ b/internal/cmd/onepasswordtemplatefuncs.go
@@ -13,6 +13,7 @@ import (
 
 type onepasswordConfig struct {
 	Command       string
+	Prompt        bool
 	outputCache   map[string][]byte
 	sessionTokens map[string]string
 }
@@ -129,7 +130,12 @@ func getOnepasswordArgs(baseArgs, args []string) []string {
 
 // refreshSession will return the current session token if the token within the environment is still valid.
 // Otherwise it will ask the user to sign in and get the new token.
+// If `sessioncheck` is disabled, it returns an empty string.
 func (c *Config) onepasswordGetOrRefreshSession(callerArgs []string) string {
+	if !c.Onepassword.Prompt {
+		return ""
+	}
+
 	var account string
 	if len(callerArgs) > 2 {
 		account = callerArgs[2]

--- a/internal/cmd/onepasswordtemplatefuncs.go
+++ b/internal/cmd/onepasswordtemplatefuncs.go
@@ -4,13 +4,17 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/twpayne/chezmoi/v2/internal/chezmoi"
 )
 
 type onepasswordConfig struct {
-	Command     string
-	outputCache map[string][]byte
+	Command       string
+	outputCache   map[string][]byte
+	sessionTokens map[string]string
 }
 
 type onePasswordItem struct {
@@ -23,8 +27,9 @@ type onePasswordItem struct {
 }
 
 func (c *Config) onepasswordItem(args ...string) *onePasswordItem {
+	sessionToken := c.onepasswordGetOrRefreshSession(args)
 	onepasswordArgs := getOnepasswordArgs([]string{"get", "item"}, args)
-	output := c.onepasswordOutput(onepasswordArgs)
+	output := c.onepasswordOutput(onepasswordArgs, sessionToken)
 	var onepasswordItem onePasswordItem
 	if err := json.Unmarshal(output, &onepasswordItem); err != nil {
 		returnTemplateError(fmt.Errorf("%s: %w\n%s", shellQuoteCommand(c.Onepassword.Command, onepasswordArgs), err, output))
@@ -58,19 +63,26 @@ func (c *Config) onepasswordItemFieldsTemplateFunc(args ...string) map[string]in
 }
 
 func (c *Config) onepasswordDocumentTemplateFunc(args ...string) string {
+	sessionToken := c.onepasswordGetOrRefreshSession(args)
 	onepasswordArgs := getOnepasswordArgs([]string{"get", "document"}, args)
-	output := c.onepasswordOutput(onepasswordArgs)
+	output := c.onepasswordOutput(onepasswordArgs, sessionToken)
 	return string(output)
 }
 
-func (c *Config) onepasswordOutput(args []string) []byte {
+func (c *Config) onepasswordOutput(args []string, sessionToken string) []byte {
 	key := strings.Join(args, "\x00")
 	if output, ok := c.Onepassword.outputCache[key]; ok {
 		return output
 	}
 
+	var secretArgs []string
+	if sessionToken != "" {
+		secretArgs = []string{"--session", sessionToken}
+	}
+
 	name := c.Onepassword.Command
-	cmd := exec.Command(name, args...)
+	// appending the session token here, so we don't log it by accident
+	cmd := exec.Command(name, append(secretArgs, args...)...)
 	cmd.Stdin = c.stdin
 	stderr := &bytes.Buffer{}
 	cmd.Stderr = stderr
@@ -88,8 +100,9 @@ func (c *Config) onepasswordOutput(args []string) []byte {
 }
 
 func (c *Config) onepasswordTemplateFunc(args ...string) map[string]interface{} {
+	sessionToken := c.onepasswordGetOrRefreshSession(args)
 	onepasswordArgs := getOnepasswordArgs([]string{"get", "item"}, args)
-	output := c.onepasswordOutput(onepasswordArgs)
+	output := c.onepasswordOutput(onepasswordArgs, sessionToken)
 	var data map[string]interface{}
 	if err := json.Unmarshal(output, &data); err != nil {
 		returnTemplateError(fmt.Errorf("%s: %w\n%s", shellQuoteCommand(c.Onepassword.Command, onepasswordArgs), err, output))
@@ -110,5 +123,77 @@ func getOnepasswordArgs(baseArgs, args []string) []string {
 	if len(args) > 2 {
 		baseArgs = append(baseArgs, "--account", args[2])
 	}
+
 	return baseArgs
+}
+
+// refreshSession will return the current session token if the token within the environment is still valid.
+// Otherwise it will ask the user to sign in and get the new token.
+func (c *Config) onepasswordGetOrRefreshSession(callerArgs []string) string {
+	var account string
+	if len(callerArgs) > 2 {
+		account = callerArgs[2]
+	}
+
+	// maybe there's already a valid token cached in this run for this account
+	token, ok := c.Onepassword.sessionTokens[account]
+	if ok {
+		return token
+	}
+
+	var args []string
+	if account == "" {
+		// If no account has been given then look for any session tokens you can find in the environment
+		token = onepasswordInferSessionToken()
+		args = []string{"signin", "--raw"}
+	} else {
+		token = os.Getenv("OP_SESSION_" + account)
+		args = []string{"signin", account, "--raw"}
+	}
+
+	// Let's not even specify an empty session string if we din't find anything
+	var secretArgs []string
+	if token != "" {
+		secretArgs = []string{"--session", token}
+	}
+
+	name := c.Onepassword.Command
+	// appending the session token here, so we don't log it by accident
+	cmd := exec.Command(name, append(secretArgs, args...)...)
+	cmd.Stdin = c.stdin
+	stderr := &bytes.Buffer{}
+	cmd.Stderr = stderr
+	output, err := cmd.Output()
+	if err != nil {
+		returnTemplateError(fmt.Errorf("%s: %w: %s",
+			shellQuoteCommand(c.Onepassword.Command, args), err, bytes.TrimSpace(stderr.Bytes())))
+		return ""
+	}
+	token = strings.TrimSpace(string(output))
+
+	// cache the session token in memory, so we don't try to refresh it again for this run for this account
+	if c.Onepassword.sessionTokens == nil {
+		c.Onepassword.sessionTokens = make(map[string]string)
+	}
+	c.Onepassword.sessionTokens[account] = token
+
+	return token
+}
+
+// onepasswordInferSessionToken will look for any session tokens in the environment
+// and if it finds exactly one then it will return it.
+func onepasswordInferSessionToken() string {
+	var token string
+	for _, env := range os.Environ() {
+		key, value, found := chezmoi.CutString(env, "=")
+
+		if found && strings.HasPrefix(key, "OP_SESSION_") {
+			if token != "" {
+				// This is the second session we find. Let's bail.
+				return ""
+			}
+			token = value
+		}
+	}
+	return token
 }

--- a/internal/cmd/testdata/scripts/onepassword.txt
+++ b/internal/cmd/testdata/scripts/onepassword.txt
@@ -24,7 +24,7 @@ case "$*" in
     echo '{"uuid":"wxcplh5udshnonkzg2n4qx262y","templateUuid":"001","trashed":"N","createdAt":"2020-07-28T13:44:57Z","updatedAt":"2020-07-28T14:27:46Z","changerUuid":"VBDXOA4MPVHONK5IIJVKUQGLXM","itemVersion":2,"vaultUuid":"tscpxgi6s7c662jtqn3vmw4n5a","details":{"fields":[{"designation":"username","name":"username","type":"T","value":"exampleuser"},{"designation":"password","name":"password","type":"P","value":"L8rm1JXJIE1b8YUDWq7h"}],"notesPlain":"","passwordHistory":[],"sections":[{"name":"linked items","title":"Related Items"},{"fields":[{"k":"string","n":"D4328E0846D2461E8E455D7A07B93397","t":"exampleLabel","v":"exampleValue"}],"name":"Section_20E0BD380789477D8904F830BFE8A121","title":""}]},"overview":{"URLs":[{"l":"website","u":"https://www.example.com/"}],"ainfo":"exampleuser","pbe":119.083926,"pgrng":true,"ps":100,"tags":[],"title":"ExampleLogin","url":"https://www.example.com/"}}'
     ;;
 *)
-    echo [ERROR] 2020/01/01 00:00:00 unknown command \"$*\" for \"op\"
+    echo [ERROR] 2020/01/01 00:00:00 unknown command \"$*\" for \"op\" 1>&2
     exit 1
 esac
 -- bin/op.cmd --
@@ -34,6 +34,6 @@ IF "%*" == "--version" (
 ) ELSE IF "%*" == "get item ExampleLogin" (
     echo.{"uuid":"wxcplh5udshnonkzg2n4qx262y","templateUuid":"001","trashed":"N","createdAt":"2020-07-28T13:44:57Z","updatedAt":"2020-07-28T14:27:46Z","changerUuid":"VBDXOA4MPVHONK5IIJVKUQGLXM","itemVersion":2,"vaultUuid":"tscpxgi6s7c662jtqn3vmw4n5a","details":{"fields":[{"designation":"username","name":"username","type":"T","value":"exampleuser"},{"designation":"password","name":"password","type":"P","value":"L8rm1JXJIE1b8YUDWq7h"}],"notesPlain":"","passwordHistory":[],"sections":[{"name":"linked items","title":"Related Items"},{"fields":[{"k":"string","n":"D4328E0846D2461E8E455D7A07B93397","t":"exampleLabel","v":"exampleValue"}],"name":"Section_20E0BD380789477D8904F830BFE8A121","title":""}]},"overview":{"URLs":[{"l":"website","u":"https://www.example.com/"}],"ainfo":"exampleuser","pbe":119.083926,"pgrng":true,"ps":100,"tags":[],"title":"ExampleLogin","url":"https://www.example.com/"}}
 ) ELSE (
-    echo.[ERROR] 2020/01/01 00:00:00 unknown command "%*" for "op"
+    echo.[ERROR] 2020/01/01 00:00:00 unknown command "%*" for "op" 1>&2
     exit /b 1
 )

--- a/internal/cmd/testdata/scripts/onepassword.txt
+++ b/internal/cmd/testdata/scripts/onepassword.txt
@@ -34,9 +34,11 @@ esac
 @echo off
 IF "%*" == "--version" (
     echo 1.3.0
-) ELSE IF "%*" == "get item ExampleLogin" OR "%*" == "--session thisIsAFakeSessionToken get item ExampleLogin" (
+) ELSE IF "%*" == "get item ExampleLogin" (
     echo.{"uuid":"wxcplh5udshnonkzg2n4qx262y","templateUuid":"001","trashed":"N","createdAt":"2020-07-28T13:44:57Z","updatedAt":"2020-07-28T14:27:46Z","changerUuid":"VBDXOA4MPVHONK5IIJVKUQGLXM","itemVersion":2,"vaultUuid":"tscpxgi6s7c662jtqn3vmw4n5a","details":{"fields":[{"designation":"username","name":"username","type":"T","value":"exampleuser"},{"designation":"password","name":"password","type":"P","value":"L8rm1JXJIE1b8YUDWq7h"}],"notesPlain":"","passwordHistory":[],"sections":[{"name":"linked items","title":"Related Items"},{"fields":[{"k":"string","n":"D4328E0846D2461E8E455D7A07B93397","t":"exampleLabel","v":"exampleValue"}],"name":"Section_20E0BD380789477D8904F830BFE8A121","title":""}]},"overview":{"URLs":[{"l":"website","u":"https://www.example.com/"}],"ainfo":"exampleuser","pbe":119.083926,"pgrng":true,"ps":100,"tags":[],"title":"ExampleLogin","url":"https://www.example.com/"}}
-) ELSE IF "%*" == "signin --raw" OR "%*" == "--session thisIsAFakeSessionToken get item ExampleLogin" (
+) ELSE IF "%*" == "--session thisIsAFakeSessionToken get item ExampleLogin" (
+    echo.{"uuid":"wxcplh5udshnonkzg2n4qx262y","templateUuid":"001","trashed":"N","createdAt":"2020-07-28T13:44:57Z","updatedAt":"2020-07-28T14:27:46Z","changerUuid":"VBDXOA4MPVHONK5IIJVKUQGLXM","itemVersion":2,"vaultUuid":"tscpxgi6s7c662jtqn3vmw4n5a","details":{"fields":[{"designation":"username","name":"username","type":"T","value":"exampleuser"},{"designation":"password","name":"password","type":"P","value":"L8rm1JXJIE1b8YUDWq7h"}],"notesPlain":"","passwordHistory":[],"sections":[{"name":"linked items","title":"Related Items"},{"fields":[{"k":"string","n":"D4328E0846D2461E8E455D7A07B93397","t":"exampleLabel","v":"exampleValue"}],"name":"Section_20E0BD380789477D8904F830BFE8A121","title":""}]},"overview":{"URLs":[{"l":"website","u":"https://www.example.com/"}],"ainfo":"exampleuser","pbe":119.083926,"pgrng":true,"ps":100,"tags":[],"title":"ExampleLogin","url":"https://www.example.com/"}}
+) ELSE IF "%*" == "signin --raw" (
     echo thisIsAFakeSessionToken
 ) ELSE (
     echo.[ERROR] 2020/01/01 00:00:00 unknown command "%*" for "op" 1>&2

--- a/internal/cmd/testdata/scripts/onepassword.txt
+++ b/internal/cmd/testdata/scripts/onepassword.txt
@@ -20,8 +20,11 @@ case "$*" in
 "--version")
     echo 1.3.0
     ;;
-"get item ExampleLogin")
+"get item ExampleLogin" | "--session thisIsAFakeSessionToken get item ExampleLogin")
     echo '{"uuid":"wxcplh5udshnonkzg2n4qx262y","templateUuid":"001","trashed":"N","createdAt":"2020-07-28T13:44:57Z","updatedAt":"2020-07-28T14:27:46Z","changerUuid":"VBDXOA4MPVHONK5IIJVKUQGLXM","itemVersion":2,"vaultUuid":"tscpxgi6s7c662jtqn3vmw4n5a","details":{"fields":[{"designation":"username","name":"username","type":"T","value":"exampleuser"},{"designation":"password","name":"password","type":"P","value":"L8rm1JXJIE1b8YUDWq7h"}],"notesPlain":"","passwordHistory":[],"sections":[{"name":"linked items","title":"Related Items"},{"fields":[{"k":"string","n":"D4328E0846D2461E8E455D7A07B93397","t":"exampleLabel","v":"exampleValue"}],"name":"Section_20E0BD380789477D8904F830BFE8A121","title":""}]},"overview":{"URLs":[{"l":"website","u":"https://www.example.com/"}],"ainfo":"exampleuser","pbe":119.083926,"pgrng":true,"ps":100,"tags":[],"title":"ExampleLogin","url":"https://www.example.com/"}}'
+    ;;
+"signin --raw")
+    echo 'thisIsAFakeSessionToken'
     ;;
 *)
     echo [ERROR] 2020/01/01 00:00:00 unknown command \"$*\" for \"op\" 1>&2
@@ -31,8 +34,10 @@ esac
 @echo off
 IF "%*" == "--version" (
     echo 1.3.0
-) ELSE IF "%*" == "get item ExampleLogin" (
+) ELSE IF "%*" == "get item ExampleLogin" OR "%*" == "--session thisIsAFakeSessionToken get item ExampleLogin" (
     echo.{"uuid":"wxcplh5udshnonkzg2n4qx262y","templateUuid":"001","trashed":"N","createdAt":"2020-07-28T13:44:57Z","updatedAt":"2020-07-28T14:27:46Z","changerUuid":"VBDXOA4MPVHONK5IIJVKUQGLXM","itemVersion":2,"vaultUuid":"tscpxgi6s7c662jtqn3vmw4n5a","details":{"fields":[{"designation":"username","name":"username","type":"T","value":"exampleuser"},{"designation":"password","name":"password","type":"P","value":"L8rm1JXJIE1b8YUDWq7h"}],"notesPlain":"","passwordHistory":[],"sections":[{"name":"linked items","title":"Related Items"},{"fields":[{"k":"string","n":"D4328E0846D2461E8E455D7A07B93397","t":"exampleLabel","v":"exampleValue"}],"name":"Section_20E0BD380789477D8904F830BFE8A121","title":""}]},"overview":{"URLs":[{"l":"website","u":"https://www.example.com/"}],"ainfo":"exampleuser","pbe":119.083926,"pgrng":true,"ps":100,"tags":[],"title":"ExampleLogin","url":"https://www.example.com/"}}
+) ELSE IF "%*" == "signin --raw" OR "%*" == "--session thisIsAFakeSessionToken get item ExampleLogin" (
+    echo thisIsAFakeSessionToken
 ) ELSE (
     echo.[ERROR] 2020/01/01 00:00:00 unknown command "%*" for "op" 1>&2
     exit /b 1


### PR DESCRIPTION
Currently when a user tries to run `chezmoi` against a repo which uses the 1Passoword template functions, it will work correctly with a session token already exported within the environment, but fail if e.g. the session is expired.

With this change, chezmoi will use the `op signin` function to verify the validity of current session and interactively prompt for master password if that fails. This prevents the user from having to repeatedly sign in and export their session manually.

Before:
```
$ chezmoi diff
chezmoi: template: xxx.sh.tmpl:5:30: executing "xxx.sh.tmpl" at <onepassword "xxx">: error calling onepassword: op get item xxx: exit status 1: [ERROR] 2021/12/26 01:28:33 You are not currently signed in. Please run `op signin --help` for instructions
```

After (in an interactive session):
```
$ chezmoi diff
Enter the password for user@example.com at my.1password.com:
```

After (without a TTY):
```
chezmoi: template: xxx.sh.tmpl:5:30: executing "xxx.sh.tmpl" at <onepassword "xxx">: error calling onepassword: op signin --raw: exit status 1: [ERROR] 2021/12/26 01:32:08 inappropriate ioctl for device
```