### PR TITLE
chore: Prepare for next release of golangci-lint

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ env:
   AGE_VERSION: 1.0.0
   GO_VERSION: 1.17.6
   GOFUMPT_VERSION: 0.2.1
-  GOLANGCI_LINT_VERSION: 1.43.0
+  GOLANGCI_LINT_VERSION: 1.44.0
 jobs:
   changes:
     runs-on: ubuntu-20.04

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,11 +5,13 @@ linters:
   - bodyclose
   - contextcheck
   - deadcode
+  - decorder
   - depguard
   - dogsled
   - dupl
   - durationcheck
   - errcheck
+  - errchkjson
   - errname
   - errorlint
   - exportloopref
@@ -31,6 +33,7 @@ linters:
   - ifshort
   - importas
   - ineffassign
+  - ireturn
   - lll
   - makezero
   - misspell
@@ -69,6 +72,7 @@ linters:
   - godox
   - goheader
   - gomnd
+  - maintidx
   - maligned
   - nakedret
   - nestif
@@ -91,6 +95,20 @@ linters-settings:
     extra-rules: true
   goimports:
     local-prefixes: github.com/twpayne/chezmoi
+  ireturn:
+    allow:
+    - anon
+    - empty
+    - error
+    - github.com/go-git/go-git/v5/plumbing/format/diff\.File
+    - github.com/go-git/go-git/v5/plumbing/format/diff\.Patch
+    - github.com/mitchellh/mapstructure\.DecodeHookFunc
+    - github.com/twpayne/chezmoi/v2/pkg/chezmoi\.ActualStateEntry
+    - github.com/twpayne/chezmoi/v2/pkg/chezmoi\.Encryption
+    - github.com/twpayne/chezmoi/v2/pkg/chezmoi\.SourceStateEntry
+    - github.com/twpayne/chezmoi/v2/pkg/chezmoi\.TargetStateEntry
+    - github.com/twpayne/go-vfs/v4\.FS
+    - stdlib
   misspell:
     locale: US
 

--- a/pkg/cmd/util_unix.go
+++ b/pkg/cmd/util_unix.go
@@ -21,5 +21,6 @@ func enableVirtualTerminalProcessing(w io.Writer) error {
 }
 
 func fileInfoUID(info fs.FileInfo) int {
+	//nolint:forcetypeassert
 	return int(info.Sys().(*syscall.Stat_t).Uid)
 }


### PR DESCRIPTION
Draft PR, not ready for merge yet.

Refs https://github.com/breml/errchkjson/issues/5.