### PR TITLE
WIP support 1Password CLI 2.0

### DIFF
--- a/internal/cmd/doctorcmd.go
+++ b/internal/cmd/doctorcmd.go
@@ -221,7 +221,7 @@ func (c *Config) runDoctorCmd(cmd *cobra.Command, args []string) error {
 			ifNotSet:    checkResultWarning,
 			ifNotExist:  checkResultInfo,
 			versionArgs: []string{"--version"},
-			versionRx:   regexp.MustCompile(`^(\d+\.\d+\.\d+(?:\-beta\.\d+)?)`),
+			versionRx:   regexp.MustCompile(onePasswordVersionRegexp),
 		},
 		&binaryCheck{
 			name:        "bitwarden-command",

--- a/internal/cmd/doctorcmd.go
+++ b/internal/cmd/doctorcmd.go
@@ -221,7 +221,7 @@ func (c *Config) runDoctorCmd(cmd *cobra.Command, args []string) error {
 			ifNotSet:    checkResultWarning,
 			ifNotExist:  checkResultInfo,
 			versionArgs: []string{"--version"},
-			versionRx:   regexp.MustCompile(`^(\d+\.\d+\.\d+)`),
+			versionRx:   regexp.MustCompile(`^(\d+\.\d+\.\d+(?:\-beta\.\d+)?)`),
 		},
 		&binaryCheck{
 			name:        "bitwarden-command",

--- a/internal/cmd/testdata/scripts/onepassword2.txt
+++ b/internal/cmd/testdata/scripts/onepassword2.txt
@@ -1,0 +1,46 @@
+[!windows] chmod 755 bin/op
+[windows] unix2dos bin/op.cmd
+
+# test onepassword template function
+chezmoi execute-template '{{ (onepassword "ExampleLogin").id }}'
+stdout '^wxcplh5udshnonkzg2n4qx262y$'
+
+# test onepasswordDetailsFields template function
+chezmoi execute-template '{{ (onepasswordDetailsFields "ExampleLogin").password.value }}'
+stdout '^L8rm1JXJIE1b8YUDWq7h$'
+
+# test onepasswordItemFields template function
+chezmoi execute-template '{{ (onepasswordItemFields "ExampleLogin").exampleLabel.value }}'
+stdout exampleValue
+
+-- bin/op --
+#!/bin/sh
+
+case "$*" in
+"--version")
+    echo 2.0.0-beta.8
+    ;;
+"item get --format json ExampleLogin" | "--session thisIsAFakeSessionToken item get --format json ExampleLogin")
+    echo '{"id":"wxcplh5udshnonkzg2n4qx262y","title":"ExampleLogin","version":1,"vault":{"id":"tscpxgi6s7c662jtqn3vmw4n5a"},"category":"LOGIN","last_edited_by":"YO4UTYPAD3ZFBNZG5DVAZFBNZM","created_at":"2022-01-17T01:53:50Z","updated_at":"2022-01-17T01:55:35Z","sections":[{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"}],"fields":[{"id":"username","type":"STRING","purpose":"USERNAME","label":"username","value":"exampleuser "},{"id":"password","type":"CONCEALED","purpose":"PASSWORD","label":"password","value":"L8rm1JXJIE1b8YUDWq7h","password_details":{"strength":"EXCELLENT"}},{"id":"notesPlain","type":"STRING","purpose":"NOTES","label":"notesPlain"},{"id":"cqn7oda7wkcsar7rzcr52i2m3u","section":{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"},"type":"STRING","label":"exampleLabel","value":"exampleValue"}],"urls":[{"primary":true,"href":"https://www.example.com/"}]}'
+    ;;
+"signin --raw")
+    echo 'thisIsAFakeSessionToken'
+    ;;
+*)
+    echo [ERROR] 2020/01/01 00:00:00 unknown command \"$*\" for \"op\" 1>&2
+    exit 1
+esac
+-- bin/op.cmd --
+@echo off
+IF "%*" == "--version" (
+    echo 2.0.0-beta.8
+) ELSE IF "%*" == "item get --format json ExampleLogin" (
+    echo.{"id":"wxcplh5udshnonkzg2n4qx262y","title":"ExampleLogin","version":1,"vault":{"id":"tscpxgi6s7c662jtqn3vmw4n5a"},"category":"LOGIN","last_edited_by":"YO4UTYPAD3ZFBNZG5DVAZFBNZM","created_at":"2022-01-17T01:53:50Z","updated_at":"2022-01-17T01:55:35Z","sections":[{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"}],"fields":[{"id":"username","type":"STRING","purpose":"USERNAME","label":"username","value":"exampleuser "},{"id":"password","type":"CONCEALED","purpose":"PASSWORD","label":"password","value":"L8rm1JXJIE1b8YUDWq7h","password_details":{"strength":"EXCELLENT"}},{"id":"notesPlain","type":"STRING","purpose":"NOTES","label":"notesPlain"},{"id":"cqn7oda7wkcsar7rzcr52i2m3u","section":{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"},"type":"STRING","label":"exampleLabel","value":"exampleValue"}],"urls":[{"primary":true,"href":"https://www.example.com/"}]}
+) ELSE IF "%*" == "--session thisIsAFakeSessionToken item get --format json ExampleLogin" (
+    echo.{"id":"wxcplh5udshnonkzg2n4qx262y","title":"ExampleLogin","version":1,"vault":{"id":"tscpxgi6s7c662jtqn3vmw4n5a"},"category":"LOGIN","last_edited_by":"YO4UTYPAD3ZFBNZG5DVAZFBNZM","created_at":"2022-01-17T01:53:50Z","updated_at":"2022-01-17T01:55:35Z","sections":[{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"}],"fields":[{"id":"username","type":"STRING","purpose":"USERNAME","label":"username","value":"exampleuser "},{"id":"password","type":"CONCEALED","purpose":"PASSWORD","label":"password","value":"L8rm1JXJIE1b8YUDWq7h","password_details":{"strength":"EXCELLENT"}},{"id":"notesPlain","type":"STRING","purpose":"NOTES","label":"notesPlain"},{"id":"cqn7oda7wkcsar7rzcr52i2m3u","section":{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"},"type":"STRING","label":"exampleLabel","value":"exampleValue"}],"urls":[{"primary":true,"href":"https://www.example.com/"}]}
+) ELSE IF "%*" == "signin --raw" (
+    echo thisIsAFakeSessionToken
+) ELSE (
+    echo.[ERROR] 2020/01/01 00:00:00 unknown command "%*" for "op" 1>&2
+    exit /b 1
+)


### PR DESCRIPTION
With the changed API structure IMO I'd reconsider whether having both `onepasswordDetailsFields` and `onepasswordItemFields` with different behavior makes sense. As far as I can tell, all fields are now returned in one array, but some have a Section field and some don't.