### PR TITLE
docs: Fix small typo in User guide

### DIFF
--- a/assets/chezmoi.io/docs/user-guide/manage-machine-to-machine-differences.md
+++ b/assets/chezmoi.io/docs/user-guide/manage-machine-to-machine-differences.md
@@ -188,7 +188,7 @@ on any variable. For example, if you want `~/.bashrc` to be different on Linux
 and macOS you would create a file in the source state called `dot_bashrc.tmpl`
 containing:
 
-``` title="~/.local/share/chezmoi/.chezmoiignore"
+``` title="~/.local/share/chezmoi/dot_bashrc.tmpl"
 {{ if eq .chezmoi.os "darwin" -}}
 # macOS .bashrc contents
 {{ else if eq .chezmoi.os "linux" -}}


### PR DESCRIPTION
Fix small typo in the docs example under User Guide -> Manage machine-to-machine differences where the code snippet did not match the filename in the example.

<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer/contributing-changes/

-->
