### PR TITLE
Update gh-pages: fix broken link to user manual

### DIFF
--- a/quick-start/index.html
+++ b/quick-start/index.html
@@ -3708,7 +3708,7 @@ contents of the file:</p>
 <p>chezmoi has much more functionality. Good starting points are reading <a href="/links/articles-podcasts-and-videos/">articles
 about chezmoi</a> adding more dotfiles, and
 using templates to manage files that vary from machine to machine and retrieve
-secrets from your password manager. Read the <a href="/user-manual/">user manual</a> to
+secrets from your password manager. Read the <a href="/user-guide/">user manual</a> to
 explore.</p>
 
               


### PR DESCRIPTION
The link to the user manual at the end of the “Quick start” page is broken. This is a fix, making it point to the user guide.