### PR TITLE
feat: Support 1Password CLI 2.0

### DIFF
--- a/assets/chezmoi.io/docs/reference/templates/functions/onepassword.md
+++ b/assets/chezmoi.io/docs/reference/templates/functions/onepassword.md
@@ -21,3 +21,14 @@ be interactively prompted to sign in.
     {{ (onepassword "<uuid>" "<vault-uuid>" "<account-name>").details.password }}
     {{ (onepassword "<uuid>" "" "<account-name>").details.password }}
     ```
+
+!!! info
+
+    If you're using [1Password CLI 2.0](https://developer.1password.com/), then
+    the structure of the data returned by the `onepassword` template function
+    will be different and you will need to update your templates.
+
+    !!! warning
+
+    The structure of the data returned will not be finalized until 1Password
+    CLI 2.0 is released.

--- a/assets/chezmoi.io/docs/reference/templates/functions/onepasswordDetailsFields.md
+++ b/assets/chezmoi.io/docs/reference/templates/functions/onepasswordDetailsFields.md
@@ -69,3 +69,15 @@ accounts).
         }
     }
     ```
+
+!!! info
+
+    If you're using [1Password CLI 2.0](https://developer.1password.com/), then
+    the structure of the data returned by the `onepasswordDetailsFields`
+    template function will be different and you will need to update your
+    templates.
+
+    !!! warning
+
+    The structure of the data returned will not be finalized until 1Password
+    CLI 2.0 is released.

--- a/assets/chezmoi.io/docs/reference/templates/functions/onepasswordItemFields.md
+++ b/assets/chezmoi.io/docs/reference/templates/functions/onepasswordItemFields.md
@@ -64,3 +64,15 @@ in the environment, by default you will be interactively prompted to sign in.
         }
     }
     ```
+
+!!! info
+
+    If you're using [1Password CLI 2.0](https://developer.1password.com/), then
+    the structure of the data returned by the `onepasswordDetailsFields`
+    template function will be different and you will need to update your
+    templates.
+
+    !!! warning
+
+    The structure of the data returned will not be finalized until 1Password
+    CLI 2.0 is released.

--- a/assets/chezmoi.io/docs/user-guide/password-managers/1password.md
+++ b/assets/chezmoi.io/docs/user-guide/password-managers/1password.md
@@ -69,3 +69,15 @@ your configuration file:
     Do not use the prompt on shared machines. A session token verified or
     acquired interactively will be passed to the 1Password CLI through a
     command-line parameter, which is visible to other users of the same system.
+
+!!! info
+
+    If you're using [1Password CLI 2.0](https://developer.1password.com/), then
+    the structure of the data returned by the `onepassword`,
+    `onepasswordDetailsFields`, and `onePasswordItemFiles` template functions
+    will be different and you will need to update your templates.
+
+    !!! warning
+
+    The structure of the data returned will not be finalized until 1Password
+    CLI 2.0 is released.

--- a/pkg/chezmoi/nullsystem.go
+++ b/pkg/chezmoi/nullsystem.go
@@ -1,0 +1,6 @@
+package chezmoi
+
+type NullSystem struct {
+	emptySystemMixin
+	noUpdateSystemMixin
+}

--- a/pkg/chezmoi/nullsystem_test.go
+++ b/pkg/chezmoi/nullsystem_test.go
@@ -1,0 +1,3 @@
+package chezmoi
+
+var _ System = &NullSystem{}

--- a/pkg/cmd/doctorcmd.go
+++ b/pkg/cmd/doctorcmd.go
@@ -223,7 +223,7 @@ func (c *Config) runDoctorCmd(cmd *cobra.Command, args []string) error {
 			ifNotSet:    checkResultWarning,
 			ifNotExist:  checkResultInfo,
 			versionArgs: []string{"--version"},
-			versionRx:   regexp.MustCompile(`^(\d+\.\d+\.\d+)`),
+			versionRx:   onepasswordVersionRx,
 		},
 		&binaryCheck{
 			name:        "bitwarden-command",

--- a/pkg/cmd/onepasswordtemplatefuncs.go
+++ b/pkg/cmd/onepasswordtemplatefuncs.go
@@ -6,19 +6,49 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"regexp"
 	"strings"
+
+	"github.com/coreos/go-semver/semver"
 
 	"github.com/twpayne/chezmoi/v2/pkg/chezmoi"
 )
 
+type withSessionTokenType bool
+
+const (
+	withSessionToken    withSessionTokenType = true
+	withoutSessionToken withSessionTokenType = false
+)
+
+type unsupportedVersionError struct {
+	version *semver.Version
+}
+
+func (e unsupportedVersionError) Error() string {
+	return fmt.Sprintf("%s: unsupported version", e.version)
+}
+
+var onepasswordVersionRx = regexp.MustCompile(`^(\d+\.\d+\.\d+\S*)`)
+
 type onepasswordConfig struct {
 	Command       string
 	Prompt        bool
+	version       *semver.Version
+	versionErr    error
+	environFunc   func() []string
 	outputCache   map[string][]byte
 	sessionTokens map[string]string
 }
 
-type onePasswordItem struct {
+type onepasswordArgs struct {
+	item    string
+	vault   string
+	account string
+	args    []string
+}
+
+type onepasswordItemV1 struct {
 	Details struct {
 		Fields   []map[string]interface{} `json:"fields"`
 		Sections []struct {
@@ -27,20 +57,37 @@ type onePasswordItem struct {
 	} `json:"details"`
 }
 
-func (c *Config) onepasswordTemplateFunc(args ...string) map[string]interface{} {
-	sessionToken, err := c.onepasswordGetOrRefreshSessionToken(args)
+type onepasswordItemV2 struct {
+	Fields []map[string]interface{} `json:"fields"`
+}
+
+func (c *Config) onepasswordTemplateFunc(userArgs ...string) map[string]interface{} {
+	version, err := c.onepasswordVersion()
 	if err != nil {
 		raiseTemplateError(err)
 		return nil
 	}
 
-	onepasswordArgs, err := onepasswordArgs([]string{"get", "item"}, args)
+	var baseArgs []string
+	switch {
+	case version.Major == 1:
+		baseArgs = []string{"get", "item"}
+	case version.Major >= 2:
+		baseArgs = []string{"item", "get", "--format", "json"}
+	default:
+		raiseTemplateError(unsupportedVersionError{
+			version: version,
+		})
+		return nil
+	}
+
+	args, err := newOnepasswordArgs(baseArgs, userArgs)
 	if err != nil {
 		raiseTemplateError(err)
 		return nil
 	}
 
-	output, err := c.onepasswordOutput(onepasswordArgs, sessionToken)
+	output, err := c.onepasswordOutput(args, withSessionToken)
 	if err != nil {
 		raiseTemplateError(err)
 		return nil
@@ -48,42 +95,88 @@ func (c *Config) onepasswordTemplateFunc(args ...string) map[string]interface{} 
 
 	var data map[string]interface{}
 	if err := json.Unmarshal(output, &data); err != nil {
-		raiseTemplateError(fmt.Errorf("%s: %w\n%s", shellQuoteCommand(c.Onepassword.Command, onepasswordArgs), err, output))
+		raiseTemplateError(newParseCmdOutputError(c.Onepassword.Command, args.args, output, err))
 		return nil
 	}
 	return data
 }
 
-func (c *Config) onepasswordDetailsFieldsTemplateFunc(args ...string) map[string]interface{} {
-	onepasswordItem, err := c.onepasswordItem(args...)
+func (c *Config) onepasswordDetailsFieldsTemplateFunc(userArgs ...string) map[string]interface{} {
+	version, err := c.onepasswordVersion()
 	if err != nil {
 		raiseTemplateError(err)
 		return nil
 	}
 
-	result := make(map[string]interface{})
-	for _, field := range onepasswordItem.Details.Fields {
-		if designation, ok := field["designation"].(string); ok {
-			result[designation] = field
+	switch {
+	case version.Major == 1:
+		item, err := c.onepasswordItemV1(userArgs)
+		if err != nil {
+			raiseTemplateError(err)
+			return nil
 		}
+
+		result := make(map[string]interface{})
+		for _, field := range item.Details.Fields {
+			if designation, ok := field["designation"].(string); ok {
+				result[designation] = field
+			}
+		}
+		return result
+
+	case version.Major >= 2:
+		item, err := c.onepasswordItemV2(userArgs)
+		if err != nil {
+			raiseTemplateError(err)
+			return nil
+		}
+
+		result := make(map[string]interface{})
+		for _, field := range item.Fields {
+			if _, ok := field["section"]; ok {
+				continue
+			}
+			if label, ok := field["label"].(string); ok {
+				result[label] = field
+			}
+		}
+		return result
+
+	default:
+		raiseTemplateError(unsupportedVersionError{
+			version: version,
+		})
+		return nil
 	}
-	return result
 }
 
-func (c *Config) onepasswordDocumentTemplateFunc(args ...string) string {
-	sessionToken, err := c.onepasswordGetOrRefreshSessionToken(args)
+func (c *Config) onepasswordDocumentTemplateFunc(userArgs ...string) string {
+	version, err := c.onepasswordVersion()
 	if err != nil {
 		raiseTemplateError(err)
 		return ""
 	}
 
-	onepasswordArgs, err := onepasswordArgs([]string{"get", "document"}, args)
+	var baseArgs []string
+	switch {
+	case version.Major == 1:
+		baseArgs = []string{"get", "document"}
+	case version.Major >= 2:
+		baseArgs = []string{"document", "get"}
+	default:
+		raiseTemplateError(unsupportedVersionError{
+			version: version,
+		})
+		return ""
+	}
+
+	args, err := newOnepasswordArgs(baseArgs, userArgs)
 	if err != nil {
 		raiseTemplateError(err)
 		return ""
 	}
 
-	output, err := c.onepasswordOutput(onepasswordArgs, sessionToken)
+	output, err := c.onepasswordOutput(args, withSessionToken)
 	if err != nil {
 		raiseTemplateError(err)
 		return ""
@@ -91,127 +184,180 @@ func (c *Config) onepasswordDocumentTemplateFunc(args ...string) string {
 	return string(output)
 }
 
-func (c *Config) onepasswordItemFieldsTemplateFunc(args ...string) map[string]interface{} {
-	onepasswordItem, err := c.onepasswordItem(args...)
+func (c *Config) onepasswordItemFieldsTemplateFunc(userArgs ...string) map[string]interface{} {
+	version, err := c.onepasswordVersion()
 	if err != nil {
 		raiseTemplateError(err)
 		return nil
 	}
 
-	result := make(map[string]interface{})
-	for _, section := range onepasswordItem.Details.Sections {
-		for _, field := range section.Fields {
-			if t, ok := field["t"].(string); ok {
-				result[t] = field
+	switch {
+	case version.Major == 1:
+		item, err := c.onepasswordItemV1(userArgs)
+		if err != nil {
+			raiseTemplateError(err)
+			return nil
+		}
+
+		result := make(map[string]interface{})
+		for _, section := range item.Details.Sections {
+			for _, field := range section.Fields {
+				if t, ok := field["t"].(string); ok {
+					result[t] = field
+				}
 			}
 		}
+		return result
+
+	case version.Major >= 2:
+		item, err := c.onepasswordItemV2(userArgs)
+		if err != nil {
+			raiseTemplateError(err)
+			return nil
+		}
+
+		result := make(map[string]interface{})
+		for _, field := range item.Fields {
+			if _, ok := field["section"]; !ok {
+				continue
+			}
+			if label, ok := field["label"].(string); ok {
+				result[label] = field
+			}
+		}
+		return result
+
+	default:
+		raiseTemplateError(unsupportedVersionError{
+			version: version,
+		})
+		return nil
 	}
-	return result
 }
 
 // onepasswordGetOrRefreshSessionToken will return the current session token if
 // the token within the environment is still valid. Otherwise it will ask the
 // user to sign in and get the new token.
-func (c *Config) onepasswordGetOrRefreshSessionToken(callerArgs []string) (string, error) {
+func (c *Config) onepasswordGetOrRefreshSessionToken(args *onepasswordArgs) (string, error) {
 	if !c.Onepassword.Prompt {
 		return "", nil
 	}
 
-	var account string
-	if len(callerArgs) > 2 {
-		account = callerArgs[2]
-	}
-
-	// Check if there's already a valid token cached in this run for this
-	// account.
-	token, ok := c.Onepassword.sessionTokens[account]
+	// Check if there's already a valid session token cached in this run for
+	// this account.
+	sessionToken, ok := c.Onepassword.sessionTokens[args.account]
 	if ok {
-		return token, nil
+		return sessionToken, nil
 	}
 
-	var args []string
-	if account == "" {
-		// If no account has been given then look for any session tokens in the
-		// environment.
-		token = onepasswordSessionToken()
-		args = []string{"signin", "--raw"}
+	// If no account has been given then look for any session tokens in the
+	// environment.
+	if args.account == "" {
+		var environ []string
+		if c.Onepassword.environFunc != nil {
+			environ = c.Onepassword.environFunc()
+		} else {
+			environ = os.Environ()
+		}
+		sessionToken = onepasswordUniqueSessionToken(environ)
+		if sessionToken != "" {
+			return sessionToken, nil
+		}
+	}
+
+	var commandArgs []string
+	if args.account == "" {
+		commandArgs = []string{"signin", "--raw"}
 	} else {
-		token = os.Getenv("OP_SESSION_" + account)
-		args = []string{"signin", account, "--raw"}
+		sessionToken = os.Getenv("OP_SESSION_" + args.account)
+		commandArgs = []string{"signin", args.account, "--raw"}
+	}
+	if sessionToken != "" {
+		commandArgs = append([]string{"--session", sessionToken}, commandArgs...)
 	}
 
-	// Do not specify an empty session string if no session tokens were found.
-	var secretArgs []string
-	if token != "" {
-		secretArgs = []string{"--session", token}
-	}
-
-	name := c.Onepassword.Command
-	// Append the session token here, so it is not logged by accident.
-	cmd := exec.Command(name, append(secretArgs, args...)...)
+	//nolint:gosec
+	cmd := exec.Command(c.Onepassword.Command, commandArgs...)
 	cmd.Stdin = c.stdin
 	stderr := &bytes.Buffer{}
 	cmd.Stderr = stderr
-	output, err := cmd.Output()
+	output, err := c.baseSystem.IdempotentCmdOutput(cmd)
 	if err != nil {
-		commandStr := shellQuoteCommand(c.Onepassword.Command, args)
-		return "", fmt.Errorf("%s: %w: %s", commandStr, err, bytes.TrimSpace(stderr.Bytes()))
+		return "", newCmdOutputError(cmd, output, err)
 	}
-	token = strings.TrimSpace(string(output))
+	sessionToken = strings.TrimSpace(string(output))
 
 	// Cache the session token in memory, so we don't try to refresh it again
 	// for this run for this account.
 	if c.Onepassword.sessionTokens == nil {
 		c.Onepassword.sessionTokens = make(map[string]string)
 	}
-	c.Onepassword.sessionTokens[account] = token
+	c.Onepassword.sessionTokens[args.account] = sessionToken
 
-	return token, nil
+	return sessionToken, nil
 }
 
-func (c *Config) onepasswordItem(args ...string) (*onePasswordItem, error) {
-	sessionToken, err := c.onepasswordGetOrRefreshSessionToken(args)
+func (c *Config) onepasswordItemV1(userArgs []string) (*onepasswordItemV1, error) {
+	args, err := newOnepasswordArgs([]string{"get", "item"}, userArgs)
 	if err != nil {
 		return nil, err
 	}
 
-	onepasswordArgs, err := onepasswordArgs([]string{"get", "item"}, args)
+	output, err := c.onepasswordOutput(args, withSessionToken)
 	if err != nil {
 		return nil, err
 	}
 
-	output, err := c.onepasswordOutput(onepasswordArgs, sessionToken)
-	if err != nil {
-		return nil, err
+	var item onepasswordItemV1
+	if err := json.Unmarshal(output, &item); err != nil {
+		return nil, newParseCmdOutputError(c.Onepassword.Command, args.args, output, err)
 	}
-
-	var onepasswordItem onePasswordItem
-	if err := json.Unmarshal(output, &onepasswordItem); err != nil {
-		return nil, fmt.Errorf("%s: %w\n%s", shellQuoteCommand(c.Onepassword.Command, onepasswordArgs), err, output)
-	}
-	return &onepasswordItem, nil
+	return &item, nil
 }
 
-func (c *Config) onepasswordOutput(args []string, sessionToken string) ([]byte, error) {
-	key := strings.Join(args, "\x00")
+func (c *Config) onepasswordItemV2(userArgs []string) (*onepasswordItemV2, error) {
+	args, err := newOnepasswordArgs([]string{"item", "get", "--format", "json"}, userArgs)
+	if err != nil {
+		return nil, err
+	}
+
+	output, err := c.onepasswordOutput(args, withSessionToken)
+	if err != nil {
+		return nil, err
+	}
+
+	var item onepasswordItemV2
+	if err := json.Unmarshal(output, &item); err != nil {
+		return nil, newParseCmdOutputError(c.Onepassword.Command, args.args, output, err)
+	}
+	return &item, nil
+}
+
+func (c *Config) onepasswordOutput(args *onepasswordArgs, withSessionToken withSessionTokenType) ([]byte, error) {
+	key := strings.Join(args.args, "\x00")
 	if output, ok := c.Onepassword.outputCache[key]; ok {
 		return output, nil
 	}
 
-	var secretArgs []string
-	if sessionToken != "" {
-		secretArgs = []string{"--session", sessionToken}
+	commandArgs := args.args
+	if withSessionToken {
+		sessionToken, err := c.onepasswordGetOrRefreshSessionToken(args)
+		if err != nil {
+			return nil, err
+		}
+		if sessionToken != "" {
+			commandArgs = append([]string{"--session", sessionToken}, commandArgs...)
+		}
 	}
 
-	name := c.Onepassword.Command
-	// Append the session token here, so it is not logged by accident.
-	cmd := exec.Command(name, append(secretArgs, args...)...)
+	//nolint:gosec
+	cmd := exec.Command(c.Onepassword.Command, commandArgs...)
 	cmd.Stdin = c.stdin
 	stderr := &bytes.Buffer{}
 	cmd.Stderr = stderr
 	output, err := c.baseSystem.IdempotentCmdOutput(cmd)
 	if err != nil {
-		return nil, fmt.Errorf("%s: %w: %s", shellQuoteCommand(name, args), err, bytes.TrimSpace(stderr.Bytes()))
+		return nil, newCmdOutputError(cmd, output, err)
 	}
 
 	if c.Onepassword.outputCache == nil {
@@ -222,25 +368,62 @@ func (c *Config) onepasswordOutput(args []string, sessionToken string) ([]byte, 
 	return output, nil
 }
 
-func onepasswordArgs(baseArgs, args []string) ([]string, error) {
-	if len(args) < 1 || len(args) > 3 {
-		return nil, fmt.Errorf("expected 1, 2, or 3 arguments, got %d", len(args))
+func (c *Config) onepasswordVersion() (*semver.Version, error) {
+	if c.Onepassword.version != nil || c.Onepassword.versionErr != nil {
+		return c.Onepassword.version, c.Onepassword.versionErr
 	}
-	baseArgs = append(baseArgs, args[0])
-	if len(args) > 1 {
-		baseArgs = append(baseArgs, "--vault", args[1])
+
+	args := &onepasswordArgs{
+		args: []string{"--version"},
 	}
-	if len(args) > 2 {
-		baseArgs = append(baseArgs, "--account", args[2])
+	output, err := c.onepasswordOutput(args, withoutSessionToken)
+	if err != nil {
+		c.Onepassword.versionErr = err
+		return nil, c.Onepassword.versionErr
 	}
-	return baseArgs, nil
+
+	m := onepasswordVersionRx.FindSubmatch(output)
+	if m == nil {
+		c.Onepassword.versionErr = fmt.Errorf("%q: cannot extract version", bytes.TrimSpace(output))
+		return nil, c.Onepassword.versionErr
+	}
+
+	version, err := semver.NewVersion(string(m[1]))
+	if err != nil {
+		c.Onepassword.versionErr = fmt.Errorf("%q: cannot parse version: %w", m[1], err)
+		return nil, c.Onepassword.versionErr
+	}
+
+	c.Onepassword.version = version
+	return c.Onepassword.version, c.Onepassword.versionErr
 }
 
-// onepasswordSessionToken will look for any session tokens in the environment.
-// If it finds exactly one then it will return it.
-func onepasswordSessionToken() string {
+func newOnepasswordArgs(baseArgs, userArgs []string) (*onepasswordArgs, error) {
+	if len(userArgs) < 1 || 3 < len(userArgs) {
+		return nil, fmt.Errorf("expected 1, 2, or 3 arguments, got %d", len(userArgs))
+	}
+
+	a := &onepasswordArgs{
+		args: baseArgs,
+	}
+	a.item = userArgs[0]
+	a.args = append(a.args, a.item)
+	if len(userArgs) > 1 {
+		a.vault = userArgs[1]
+		a.args = append(a.args, "--vault", a.vault)
+	}
+	if len(userArgs) > 2 {
+		a.account = userArgs[2]
+		a.args = append(a.args, "--account", a.account)
+	}
+	return a, nil
+}
+
+// onepasswordUniqueSessionToken will look for any session tokens in the
+// environment. If it finds exactly one then it will return it.
+func onepasswordUniqueSessionToken(environ []string) string {
 	var token string
-	for _, env := range os.Environ() {
+	for _, env := range environ {
 		key, value, found := chezmoi.CutString(env, "=")
 		if found && strings.HasPrefix(key, "OP_SESSION_") {
 			if token != "" {

--- a/pkg/cmd/onepasswordtemplatefuncs_test.go
+++ b/pkg/cmd/onepasswordtemplatefuncs_test.go
@@ -1,0 +1,193 @@
+package cmd
+
+import (
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/muesli/combinator"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/twpayne/chezmoi/v2/pkg/chezmoi"
+)
+
+type onepasswordTestCase struct {
+	Prompt      bool
+	EnvironFunc func() []string
+}
+
+//nolint:dupl,forcetypeassert
+func TestOnepasswordTemplateFuncV1(t *testing.T) {
+	for i, tc := range onepasswordTestCases(t) {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			c := &Config{
+				baseSystem: &testSystem{
+					System:     chezmoi.NullSystem{},
+					outputFunc: onepasswordV1OutputFunc,
+				},
+				Onepassword: onepasswordConfig{
+					Command:     "op",
+					Prompt:      tc.Prompt,
+					environFunc: tc.EnvironFunc,
+				},
+			}
+
+			require.NotPanics(t, func() {
+				actual := c.onepasswordTemplateFunc("ExampleLogin")
+				assert.Equal(t, actual["uuid"], "wxcplh5udshnonkzg2n4qx262y")
+			})
+
+			require.NotPanics(t, func() {
+				actual := c.onepasswordDetailsFieldsTemplateFunc("ExampleLogin")
+				assert.Equal(t, actual["password"].(map[string]interface{})["value"], "L8rm1JXJIE1b8YUDWq7h")
+			})
+
+			require.NotPanics(t, func() {
+				actual := c.onepasswordDocumentTemplateFunc("ExampleDocument")
+				assert.Equal(t, "ExampleDocumentContents", actual)
+			})
+
+			require.NotPanics(t, func() {
+				actual := c.onepasswordItemFieldsTemplateFunc("ExampleLogin")
+				assert.Equal(t, actual["exampleLabel"].(map[string]interface{})["v"], "exampleValue")
+			})
+		})
+	}
+}
+
+//nolint:dupl,forcetypeassert
+func TestOnepasswordTemplateFuncV2(t *testing.T) {
+	for i, tc := range onepasswordTestCases(t) {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			c := &Config{
+				baseSystem: &testSystem{
+					System:     chezmoi.NullSystem{},
+					outputFunc: onepasswordV2OutputFunc,
+				},
+				Onepassword: onepasswordConfig{
+					Command:     "op",
+					Prompt:      tc.Prompt,
+					environFunc: tc.EnvironFunc,
+				},
+			}
+
+			require.NotPanics(t, func() {
+				actual := c.onepasswordTemplateFunc("ExampleLogin")
+				assert.Equal(t, actual["id"], "wxcplh5udshnonkzg2n4qx262y")
+			})
+
+			require.NotPanics(t, func() {
+				actual := c.onepasswordDetailsFieldsTemplateFunc("ExampleLogin")
+				assert.Equal(t, actual["password"].(map[string]interface{})["value"], "L8rm1JXJIE1b8YUDWq7h")
+			})
+
+			require.NotPanics(t, func() {
+				actual := c.onepasswordDocumentTemplateFunc("ExampleDocument")
+				assert.Equal(t, "ExampleDocumentContents", actual)
+			})
+
+			require.NotPanics(t, func() {
+				actual := c.onepasswordItemFieldsTemplateFunc("ExampleLogin")
+				assert.Equal(t, actual["exampleLabel"].(map[string]interface{})["value"], "exampleValue")
+			})
+		})
+	}
+}
+
+func onepasswordTestCases(t *testing.T) []onepasswordTestCase {
+	t.Helper()
+	var testCases []onepasswordTestCase
+	require.NoError(t, combinator.Generate(&testCases, struct {
+		Prompt      []bool
+		EnvironFunc []func() []string
+	}{
+		Prompt: []bool{false, true},
+		EnvironFunc: []func() []string{
+			func() []string {
+				return nil
+			},
+			func() []string {
+				return []string{
+					"OP_SESSION_account=session-token",
+				}
+			},
+			func() []string {
+				return []string{
+					"OP_SESSION_account1=session-token-1",
+					"OP_SESSION_account2=session-token-2",
+				}
+			},
+		},
+	}))
+	return testCases
+}
+
+func onepasswordV1OutputFunc(cmd *exec.Cmd) ([]byte, error) {
+	switch {
+	case assert.ObjectsAreEqual(cmd.Args, []string{"op", "--version"}):
+		return []byte("1.3.0\n"), nil
+	case assert.ObjectsAreEqual(cmd.Args, []string{"op", "signin", "--raw"}):
+		return []byte("session-token\n"), nil
+	case assert.ObjectsAreEqual(cmd.Args, []string{"op", "get", "item", "ExampleLogin"}):
+		fallthrough
+	case assert.ObjectsAreEqual(cmd.Args, []string{"op", "--session", "session-token", "get", "item", "ExampleLogin"}):
+		return []byte(`` +
+			`{"uuid":"wxcplh5udshnonkzg2n4qx262y","templateUuid":"001","trashed":"N",` +
+			`"createdAt":"2020-07-28T13:44:57Z","updatedAt":"2020-07-28T14:27:46Z",` +
+			`"changerUuid":"VBDXOA4MPVHONK5IIJVKUQGLXM","itemVersion":2,"vaultUuid":"tscpxgi6s7c662jtqn3vmw4n5a",` +
+			`"details":{"fields":[{"designation":"username","name":"username","type":"T","value":"exampleuser"},` +
+			`{"designation":"password","name":"password","type":"P","value":"L8rm1JXJIE1b8YUDWq7h"}],` +
+			`"notesPlain":"","passwordHistory":[],"sections":[{"name":"linked items","title":"Related Items"},` +
+			`{"fields":[{"k":"string","n":"D4328E0846D2461E8E455D7A07B93397","t":"exampleLabel",` +
+			`"v":"exampleValue"}],"name":"Section_20E0BD380789477D8904F830BFE8A121","title":""}]},` +
+			`"overview":{"URLs":[{"l":"website","u":"https://www.example.com/"}],"ainfo":"exampleuser",` +
+			`"pbe":119.083926,"pgrng":true,"ps":100,"tags":[],"title":"ExampleLogin",` +
+			`"url":"https://www.example.com/"}}`,
+		), nil
+	case assert.ObjectsAreEqual(cmd.Args, []string{"op", "get", "document", "ExampleDocument"}):
+		fallthrough
+	case assert.ObjectsAreEqual(cmd.Args, []string{"op", "--session", "session-token", "get", "document", "ExampleDocument"}):
+		return []byte(`ExampleDocumentContents`), nil
+	default:
+		timeStr := time.Now().Format("2006/01/02 15:04:05")
+		fmt.Fprintf(cmd.Stderr, "[ERROR] %s unknown command \"%s\" for \"op\"\n", timeStr, strings.Join(cmd.Args[1:], " "))
+		return nil, &exec.ExitError{}
+	}
+}
+
+func onepasswordV2OutputFunc(cmd *exec.Cmd) ([]byte, error) {
+	switch {
+	case assert.ObjectsAreEqual(cmd.Args, []string{"op", "--version"}):
+		return []byte("2.0.0-beta8\n"), nil
+	case assert.ObjectsAreEqual(cmd.Args, []string{"op", "signin", "--raw"}):
+		return []byte("session-token\n"), nil
+	case assert.ObjectsAreEqual(cmd.Args, []string{"op", "item", "get", "--format", "json", "ExampleLogin"}):
+		fallthrough
+	case assert.ObjectsAreEqual(cmd.Args, []string{"op", "--session", "session-token", "item", "get", "--format", "json", "ExampleLogin"}):
+		return []byte(`` +
+			`{"id":"wxcplh5udshnonkzg2n4qx262y","title":"ExampleLogin","version":1,"vault":` +
+			`{"id":"tscpxgi6s7c662jtqn3vmw4n5a"},"category":"LOGIN","last_edited_by":"YO4UTYPAD3ZFBNZG5DVAZFBNZM",` +
+			`"created_at":"2022-01-17T01:53:50Z","updated_at":"2022-01-17T01:55:35Z",` +
+			`"sections":[{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"}],` +
+			`"fields":[{"id":"username","type":"STRING","purpose":"USERNAME","label":"username",` +
+			`"value":"exampleuser"},{"id":"password","type":"CONCEALED","purpose":"PASSWORD","label":"password",` +
+			`"value":"L8rm1JXJIE1b8YUDWq7h","password_details":{"strength":"EXCELLENT"}},{"id":"notesPlain",` +
+			`"type":"STRING","purpose":"NOTES","label":"notesPlain"},{"id":"cqn7oda7wkcsar7rzcr52i2m3u",` +
+			`"section":{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"},"type":"STRING",` +
+			`"label":"exampleLabel","value":"exampleValue"}],"urls":[{"primary":true,` +
+			`"href":"https://www.example.com/"}]}`,
+		), nil
+	case assert.ObjectsAreEqual(cmd.Args, []string{"op", "document", "get", "ExampleDocument"}):
+		fallthrough
+	case assert.ObjectsAreEqual(cmd.Args, []string{"op", "--session", "session-token", "document", "get", "ExampleDocument"}):
+		return []byte(`ExampleDocumentContents`), nil
+	default:
+		timeStr := time.Now().Format("2006/01/02 15:04:05")
+		fmt.Fprintf(cmd.Stderr, "[ERROR] %s unknown command \"%s\" for \"op\"\n", timeStr, strings.Join(cmd.Args[1:], " "))
+		return nil, &exec.ExitError{}
+	}
+}

--- a/pkg/cmd/testdata/scripts/onepassword2.txt
+++ b/pkg/cmd/testdata/scripts/onepassword2.txt
@@ -1,0 +1,46 @@
+[!windows] chmod 755 bin/op
+[windows] unix2dos bin/op.cmd
+
+# test onepassword template function
+chezmoi execute-template '{{ (onepassword "ExampleLogin").id }}'
+stdout '^wxcplh5udshnonkzg2n4qx262y$'
+
+# test onepasswordDetailsFields template function
+chezmoi execute-template '{{ (onepasswordDetailsFields "ExampleLogin").password.value }}'
+stdout '^L8rm1JXJIE1b8YUDWq7h$'
+
+# test onepasswordItemFields template function
+chezmoi execute-template '{{ (onepasswordItemFields "ExampleLogin").exampleLabel.value }}'
+stdout exampleValue
+
+-- bin/op --
+#!/bin/sh
+
+case "$*" in
+"--version")
+    echo 2.0.0-beta.8
+    ;;
+"item get --format json ExampleLogin" | "--session thisIsAFakeSessionToken item get --format json ExampleLogin")
+    echo '{"id":"wxcplh5udshnonkzg2n4qx262y","title":"ExampleLogin","version":1,"vault":{"id":"tscpxgi6s7c662jtqn3vmw4n5a"},"category":"LOGIN","last_edited_by":"YO4UTYPAD3ZFBNZG5DVAZFBNZM","created_at":"2022-01-17T01:53:50Z","updated_at":"2022-01-17T01:55:35Z","sections":[{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"}],"fields":[{"id":"username","type":"STRING","purpose":"USERNAME","label":"username","value":"exampleuser "},{"id":"password","type":"CONCEALED","purpose":"PASSWORD","label":"password","value":"L8rm1JXJIE1b8YUDWq7h","password_details":{"strength":"EXCELLENT"}},{"id":"notesPlain","type":"STRING","purpose":"NOTES","label":"notesPlain"},{"id":"cqn7oda7wkcsar7rzcr52i2m3u","section":{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"},"type":"STRING","label":"exampleLabel","value":"exampleValue"}],"urls":[{"primary":true,"href":"https://www.example.com/"}]}'
+    ;;
+"signin --raw")
+    echo 'thisIsAFakeSessionToken'
+    ;;
+*)
+    echo [ERROR] 2020/01/01 00:00:00 unknown command \"$*\" for \"op\" 1>&2
+    exit 1
+esac
+-- bin/op.cmd --
+@echo off
+IF "%*" == "--version" (
+    echo 2.0.0-beta.8
+) ELSE IF "%*" == "item get --format json ExampleLogin" (
+    echo.{"id":"wxcplh5udshnonkzg2n4qx262y","title":"ExampleLogin","version":1,"vault":{"id":"tscpxgi6s7c662jtqn3vmw4n5a"},"category":"LOGIN","last_edited_by":"YO4UTYPAD3ZFBNZG5DVAZFBNZM","created_at":"2022-01-17T01:53:50Z","updated_at":"2022-01-17T01:55:35Z","sections":[{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"}],"fields":[{"id":"username","type":"STRING","purpose":"USERNAME","label":"username","value":"exampleuser "},{"id":"password","type":"CONCEALED","purpose":"PASSWORD","label":"password","value":"L8rm1JXJIE1b8YUDWq7h","password_details":{"strength":"EXCELLENT"}},{"id":"notesPlain","type":"STRING","purpose":"NOTES","label":"notesPlain"},{"id":"cqn7oda7wkcsar7rzcr52i2m3u","section":{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"},"type":"STRING","label":"exampleLabel","value":"exampleValue"}],"urls":[{"primary":true,"href":"https://www.example.com/"}]}
+) ELSE IF "%*" == "--session thisIsAFakeSessionToken item get --format json ExampleLogin" (
+    echo.{"id":"wxcplh5udshnonkzg2n4qx262y","title":"ExampleLogin","version":1,"vault":{"id":"tscpxgi6s7c662jtqn3vmw4n5a"},"category":"LOGIN","last_edited_by":"YO4UTYPAD3ZFBNZG5DVAZFBNZM","created_at":"2022-01-17T01:53:50Z","updated_at":"2022-01-17T01:55:35Z","sections":[{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"}],"fields":[{"id":"username","type":"STRING","purpose":"USERNAME","label":"username","value":"exampleuser "},{"id":"password","type":"CONCEALED","purpose":"PASSWORD","label":"password","value":"L8rm1JXJIE1b8YUDWq7h","password_details":{"strength":"EXCELLENT"}},{"id":"notesPlain","type":"STRING","purpose":"NOTES","label":"notesPlain"},{"id":"cqn7oda7wkcsar7rzcr52i2m3u","section":{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"},"type":"STRING","label":"exampleLabel","value":"exampleValue"}],"urls":[{"primary":true,"href":"https://www.example.com/"}]}
+) ELSE IF "%*" == "signin --raw" (
+    echo thisIsAFakeSessionToken
+) ELSE (
+    echo.[ERROR] 2020/01/01 00:00:00 unknown command "%*" for "op" 1>&2
+    exit /b 1
+)

--- a/pkg/cmd/testsystem_test.go
+++ b/pkg/cmd/testsystem_test.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"os/exec"
+
+	"github.com/twpayne/chezmoi/v2/pkg/chezmoi"
+)
+
+// A testSystem passes method calls to the underlying wrapped system, except for
+// explicitly-overridden methods.
+type testSystem struct {
+	chezmoi.System
+	outputFunc func(cmd *exec.Cmd) ([]byte, error)
+}
+
+func (s *testSystem) IdempotentCmdOutput(cmd *exec.Cmd) ([]byte, error) {
+	if s.outputFunc != nil {
+		return s.outputFunc(cmd)
+	}
+	return s.System.IdempotentCmdOutput(cmd)
+}


### PR DESCRIPTION
Fixes #1860.
Closes #1828.
cc @cadenkriese

This builds on @kdomanski's work in #1828 (commit is co-authored by @kdomanski) to take into account the refactoring of template functions in #1859 and further refactoring.

At this instant, I believe the code is correct, but there's a bug in the tests that get confused by existing `OP_SESSION_` environment variables, and I'm most of the way through fixing it.

This, [raised by @kdomanski](https://github.com/twpayne/chezmoi/pull/1828#issue-1106185987), still needs to be addressed:

> With the changed API structure IMO I'd reconsider whether having both `onepasswordDetailsFields` and `onepasswordItemFields` with different behavior makes sense. As far as I can tell, all fields are now returned in one array, but some have a Section field and some don't.

Note that as the structure of the data returned by 1Password CLI 2.0 is different to 1Password CLI 1.x, users will have to update their templates when they switch to version 2 anyhow.
