### PR TITLE
chore: Factor out common exec errors

### DIFF
--- a/pkg/cmd/bitwardentemplatefuncs.go
+++ b/pkg/cmd/bitwardentemplatefuncs.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"encoding/json"
-	"fmt"
 	"os/exec"
 	"strings"
 )
@@ -31,7 +30,7 @@ func (c *Config) bitwardenFieldsTemplateFunc(args ...string) map[string]interfac
 		Fields []map[string]interface{} `json:"fields"`
 	}
 	if err := json.Unmarshal(output, &data); err != nil {
-		raiseTemplateError(fmt.Errorf("%s: %w\n%s", shellQuoteCommand(c.Bitwarden.Command, args), err, output))
+		raiseTemplateError(newParseCmdOutputError(c.Bitwarden.Command, args, output, err))
 		return nil
 	}
 	result := make(map[string]interface{})
@@ -51,7 +50,7 @@ func (c *Config) bitwardenTemplateFunc(args ...string) map[string]interface{} {
 	}
 	var data map[string]interface{}
 	if err := json.Unmarshal(output, &data); err != nil {
-		raiseTemplateError(fmt.Errorf("%s: %w\n%s", shellQuoteCommand(c.Bitwarden.Command, args), err, output))
+		raiseTemplateError(newParseCmdOutputError(c.Bitwarden.Command, args, output, err))
 		return nil
 	}
 	return data
@@ -70,7 +69,7 @@ func (c *Config) bitwardenOutput(args []string) ([]byte, error) {
 	cmd.Stderr = c.stderr
 	output, err := c.baseSystem.IdempotentCmdOutput(cmd)
 	if err != nil {
-		return nil, fmt.Errorf("%s: %w\n%s", shellQuoteCommand(name, args), err, output)
+		return nil, newCmdOutputError(cmd, output, err)
 	}
 
 	if c.Bitwarden.outputCache == nil {

--- a/pkg/cmd/errors.go
+++ b/pkg/cmd/errors.go
@@ -1,0 +1,57 @@
+package cmd
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+type cmdOutputError struct {
+	path   string
+	args   []string
+	output []byte
+	err    error
+}
+
+func newCmdOutputError(cmd *exec.Cmd, output []byte, err error) *cmdOutputError {
+	return &cmdOutputError{
+		path:   cmd.Path,
+		args:   cmd.Args,
+		output: output,
+		err:    err,
+	}
+}
+
+func (e *cmdOutputError) Error() string {
+	if len(e.output) == 0 {
+		return fmt.Sprintf("%s: %v", shellQuoteCommand(e.path, e.args[1:]), e.err)
+	}
+	return fmt.Sprintf("%s: %v\n%s", shellQuoteCommand(e.path, e.args[1:]), e.err, e.output)
+}
+
+func (e *cmdOutputError) Unrwap() error {
+	return e.err
+}
+
+type parseCmdOutputError struct {
+	command string
+	args    []string
+	output  []byte
+	err     error
+}
+
+func newParseCmdOutputError(command string, args []string, output []byte, err error) *parseCmdOutputError {
+	return &parseCmdOutputError{
+		command: command,
+		args:    args,
+		output:  output,
+		err:     err,
+	}
+}
+
+func (e *parseCmdOutputError) Error() string {
+	return fmt.Sprintf("%s: %v\n%s", shellQuoteCommand(e.command, e.args), e.err, e.output)
+}
+
+func (e *parseCmdOutputError) Unwrap() error {
+	return e.err
+}

--- a/pkg/cmd/gopasstemplatefuncs.go
+++ b/pkg/cmd/gopasstemplatefuncs.go
@@ -42,7 +42,7 @@ func (c *Config) gopassTemplateFunc(id string) string {
 	args := []string{"show", "--password", id}
 	output, err := c.gopassOutput(args...)
 	if err != nil {
-		raiseTemplateError(fmt.Errorf("%s: %w", shellQuoteCommand(c.Gopass.Command, args), err))
+		raiseTemplateError(err)
 		return ""
 	}
 
@@ -73,7 +73,7 @@ func (c *Config) gopassRawTemplateFunc(id string) string {
 	args := []string{"show", "--noparsing", id}
 	output, err := c.gopassOutput(args...)
 	if err != nil {
-		raiseTemplateError(fmt.Errorf("%s: %w", shellQuoteCommand(c.Gopass.Command, args), err))
+		raiseTemplateError(err)
 		return ""
 	}
 
@@ -92,7 +92,7 @@ func (c *Config) gopassOutput(args ...string) ([]byte, error) {
 	cmd.Stderr = c.stderr
 	output, err := c.baseSystem.IdempotentCmdOutput(cmd)
 	if err != nil {
-		return nil, err
+		return nil, newCmdOutputError(cmd, output, err)
 	}
 	return output, nil
 }

--- a/pkg/cmd/passtemplatefuncs.go
+++ b/pkg/cmd/passtemplatefuncs.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"bytes"
-	"fmt"
 	"os/exec"
 
 	"github.com/twpayne/chezmoi/v2/pkg/chezmoi"
@@ -53,14 +52,14 @@ func (c *Config) passOutput(id string) ([]byte, error) {
 		return output, nil
 	}
 
-	name := c.Pass.Command
 	args := []string{"show", id}
-	cmd := exec.Command(name, args...)
+	//nolint:gosec
+	cmd := exec.Command(c.Pass.Command, args...)
 	cmd.Stdin = c.stdin
 	cmd.Stderr = c.stderr
 	output, err := c.baseSystem.IdempotentCmdOutput(cmd)
 	if err != nil {
-		return nil, fmt.Errorf("%s: %w", shellQuoteCommand(name, args), err)
+		return nil, newCmdOutputError(cmd, output, err)
 	}
 
 	if c.Pass.cache == nil {

--- a/pkg/cmd/testdata/scripts/templatefuncs.txt
+++ b/pkg/cmd/testdata/scripts/templatefuncs.txt
@@ -37,8 +37,8 @@ stdout 2656FF1E876E9973
 
 # test that the output function returns an error if the command fails
 [!windows] ! chezmoi execute-template '{{ output "false" }}'
-[!(windows||illumos)] stderr 'error calling output: exit status 1'
-[illumos] stderr 'error calling output: exit status 255'
+[!(windows||illumos)] stderr 'error calling output: .*/false: exit status 1'
+[illumos] stderr 'error calling output: .*/false: exit status 255'
 
 # test stat template function
 chezmoi execute-template '{{ (stat ".").isDir }}'


### PR DESCRIPTION
This needs to be applied to 1Password too, but #1861 should probably land first.