### PR TITLE
Add support for xz archives

### DIFF
--- a/assets/chezmoi.io/docs/reference/commands/import.md
+++ b/assets/chezmoi.io/docs/reference/commands/import.md
@@ -6,7 +6,7 @@ exactly match the contents of a downloaded archive. You will generally always
 want to set the `--destination`, `--exact`, and `--remove-destination` flags.
 
 The supported archive formats are `tar`, `tar.gz`, `tgz`, `tar.bz2`, `tbz2`,
-and `zip`.
+`xz`, and `zip`.
 
 ## `--destination` *directory*
 

--- a/assets/chezmoi.io/docs/reference/special-files-and-directories/chezmoiexternal-format.md
+++ b/assets/chezmoi.io/docs/reference/special-files-and-directories/chezmoiexternal-format.md
@@ -49,7 +49,7 @@ the directory and all subdirectories will be treated as exact directories, i.e.
 integer field `stripComponents` will remove leading path components from the
 members of archive. The optional string field `format` sets the archive format.
 The supported archive formats are `tar`, `tar.gz`, `tgz`, `tar.bz2`, `tbz2`,
-and `zip`. If `format` is not specified then chezmoi will guess the format
+`xz`, and `zip`. If `format` is not specified then chezmoi will guess the format
 using firstly the path of the URL and secondly its contents.
 
 By default, chezmoi will cache downloaded URLs. The optional duration

--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/twpayne/go-shell v0.3.1
 	github.com/twpayne/go-vfs/v4 v4.1.0
 	github.com/twpayne/go-xdg/v6 v6.0.0
+	github.com/ulikunitz/xz v0.5.10
 	github.com/xanzy/ssh-agent v0.3.1 // indirect
 	github.com/yuin/goldmark v1.4.5 // indirect
 	github.com/zalando/go-keyring v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -633,6 +633,8 @@ github.com/twpayne/go-vfs/v4 v4.1.0 h1:58tmzvh3AEKgqXlRZvlKn9HD6g1Q9T9bYdob0GhAR
 github.com/twpayne/go-vfs/v4 v4.1.0/go.mod h1:05bOnh2SNnRsIp/ensn6WLeHSttxklPlQzi4JtTGofc=
 github.com/twpayne/go-xdg/v6 v6.0.0 h1:kt2KGpflK5q8ZpkmQfX6kJphh6+oAWikf4LiAZxFT0Y=
 github.com/twpayne/go-xdg/v6 v6.0.0/go.mod h1:XlfiGBU0iBxudVRWh+SXF+I1Cfb7rMq1IFwOprG4Ts8=
+github.com/ulikunitz/xz v0.5.10 h1:t92gobL9l3HE202wg3rlk19F6X+JOxl9BBrCCMYEYd8=
+github.com/ulikunitz/xz v0.5.10/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/xanzy/ssh-agent v0.3.1 h1:AmzO1SSWxw73zxFZPRwaMN1MohDw8UyHnmuxyceTEGo=
 github.com/xanzy/ssh-agent v0.3.1/go.mod h1:QIE4lCeL7nkC25x+yA3LBIYfwCc1TFziCtG7cBAac6w=

--- a/pkg/cmd/testdata/scripts/importxz.txt
+++ b/pkg/cmd/testdata/scripts/importxz.txt
@@ -1,0 +1,12 @@
+[!exec:xz] skip 'xz not found in $PATH'
+exec tar cJf archive.tar.xz archive
+
+# test that chezmoi import imports a zip archive
+chezmoi import --destination=$HOME${/}.dir --strip-components=1 archive.tar.xz
+cmp $CHEZMOISOURCEDIR/dot_dir/dir/file golden/dot_dir/dir/file
+
+-- archive/dir/file --
+# contents of dir/file
+-- golden/dot_dir/dir/file --
+# contents of dir/file
+-- home/user/.local/share/chezmoi/dot_dir/.keep --


### PR DESCRIPTION
This change adds support for `XZ` archives.

Notes:
* adds new dependency `github.com/ulikunitz/xz` (Pure golang package for reading and writing xz-compressed files)
* new archive format comes before `zip` because I sorted list after adding this new one
* only two small documentation changes (could not find any other notable place)
* one new test was added; uses `tar` and requires `xz-utils` (or comparable package); run with `go test -v -run TestScript/importxz ./...`
* the `make test-release` run was done in `golang:1.17.7-bullseye` container

closes #1883