### PR TITLE
 chore: Skip ArchLinux tests while ArchLinux's gcc is broken

### DIFF
--- a/assets/docker/archlinux.Dockerfile
+++ b/assets/docker/archlinux.Dockerfile
@@ -1,6 +1,6 @@
 FROM archlinux:latest
 
-RUN pacman -Sy --noconfirm --noprogressbar age gcc git go unzip zip
+RUN pacman -Syu --noconfirm age gcc git go unzip zip
 
 COPY assets/docker/entrypoint.sh /entrypoint.sh
 ENTRYPOINT /entrypoint.sh


### PR DESCRIPTION
The current `archlinux:latest` ([base-20220213.0.47747](https://hub.docker.com/layers/archlinux/library/archlinux/base-20220213.0.47747/images/sha256-fbd5fa7bb3380380aef04c8377745e7254c705a38c8ef55446e398df36762ba0?context=explore) is badly broken:

```console
$ docker run -it archlinux:latest
[root@b0dfa744686f /]# pacman -Sy age gcc git go unzip zip
:: Synchronizing package databases...
 core downloading...
 extra downloading...
 community downloading...
resolving dependencies...
looking for conflicting packages...

Package (15)          Old Version  New Version  Net Change  Download Size

core/binutils                      2.38-3        30.45 MiB       6.02 MiB
core/db                            5.3.28-5       6.41 MiB       1.07 MiB
core/gcc-libs         11.1.0-3     11.2.0-3       1.44 MiB      30.62 MiB
core/gdbm                          1.23-1         0.77 MiB       0.26 MiB
core/libmpc                        1.2.1-1        0.15 MiB       0.07 MiB
core/perl                          5.34.0-3      58.85 MiB      15.37 MiB
extra/perl-error                   0.17029-3      0.04 MiB       0.02 MiB
extra/perl-mailtools               2.21-5         0.11 MiB       0.06 MiB
extra/perl-timedate                2.33-3         0.08 MiB       0.03 MiB
community/age                      1.0.0-4        5.07 MiB       1.30 MiB
core/gcc                           11.2.0-3     156.72 MiB      42.32 MiB
extra/git                          2.35.1-1      33.31 MiB       5.98 MiB
community/go                       2:1.17.7-1   432.29 MiB      97.42 MiB
extra/unzip                        6.0-16         0.31 MiB       0.14 MiB
extra/zip                          3.0-9          0.55 MiB       0.17 MiB
...
installing go...
installing unzip...
installing zip...
:: Running post-transaction hooks...
(1/4) Creating system user accounts...
/usr/bin/systemd-sysusers: /usr/lib/libc.so.6: version `GLIBC_2.34' not found (required by /usr/lib/libgcc_s.so.1)
error: command failed to execute correctly
(2/4) Reloading system manager configuration...
systemd-detect-virt: /usr/lib/libc.so.6: version `GLIBC_2.34' not found (required by /usr/lib/libgcc_s.so.1)
  Skipped: Current root is not booted.
(3/4) Arming ConditionNeedsUpdate...
(4/4) Warn about old perl modules
```