### PR TITLE
docs: Update dotbot Windows support

### DIFF
--- a/assets/chezmoi.io/docs/comparison-table.md
+++ b/assets/chezmoi.io/docs/comparison-table.md
@@ -12,7 +12,7 @@
 | Distribution                           | Single binary | Python package    | Multiple files    | Single script or package | Single script                | -          |
 | Install method                         | Many          | git submodule     | Many              | Many                     | Many                         | Manual     |
 | Non-root install on bare system        | ✅            | ⁉️                 | ⁉️                 | ✅                       | ✅                           | ✅         |
-| Windows support                        | ✅            | ❌                | ❌                | ❌                       | ✅                           | ✅         |
+| Windows support                        | ✅            | ✅                | ❌                | ❌                       | ✅                           | ✅         |
 | Bootstrap requirements                 | None          | Python, git       | Perl, git         | sh, git                  | git                          | git        |
 | Source repos                           | Single        | Single            | Multiple          | Multiple                 | Single                       | Single     |
 | dotfiles are...                        | Files         | Symlinks          | Files             | Files                    | Files                        | Files      |


### PR DESCRIPTION
As of https://github.com/anishathalye/dotbot/pull/246, dotbot supports Windows via PowerShell.

<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer/contributing-changes/

-->
