### PR TITLE
Allow overriding GitHub user in shell installer

### DIFF
--- a/assets/scripts/install.sh
+++ b/assets/scripts/install.sh
@@ -8,11 +8,12 @@
 set -e
 
 BINDIR=${BINDIR:-./bin}
+GITHUB_USER=${GITHUB_USER:-twpayne}
 TAGARG=latest
 LOG_LEVEL=2
 EXECARGS=
 
-GITHUB_DOWNLOAD=https://github.com/twpayne/chezmoi/releases/download
+GITHUB_DOWNLOAD=https://github.com/${GITHUB_USER}/chezmoi/releases/download
 
 tmpdir=$(mktemp -d)
 trap 'rm -rf ${tmpdir}' EXIT
@@ -206,7 +207,7 @@ get_libc() {
 real_tag() {
 	tag=$1
 	log_debug "checking GitHub for tag ${tag}"
-	release_url="https://github.com/twpayne/chezmoi/releases/${tag}"
+	release_url="https://github.com/${GITHUB_USER}/chezmoi/releases/${tag}"
 	json=$(http_get "${release_url}" "Accept: application/json")
 	if [ -z "${json}" ]; then
 		log_err "real_tag error retrieving GitHub release ${tag}"

--- a/assets/scripts/install.sh
+++ b/assets/scripts/install.sh
@@ -8,12 +8,11 @@
 set -e
 
 BINDIR=${BINDIR:-./bin}
-GITHUB_USER=${GITHUB_USER:-twpayne}
 TAGARG=latest
 LOG_LEVEL=2
 EXECARGS=
 
-GITHUB_DOWNLOAD=https://github.com/${GITHUB_USER}/chezmoi/releases/download
+GITHUB_DOWNLOAD=https://github.com/twpayne/chezmoi/releases/download
 
 tmpdir=$(mktemp -d)
 trap 'rm -rf ${tmpdir}' EXIT
@@ -207,7 +206,7 @@ get_libc() {
 real_tag() {
 	tag=$1
 	log_debug "checking GitHub for tag ${tag}"
-	release_url="https://github.com/${GITHUB_USER}/chezmoi/releases/${tag}"
+	release_url="https://github.com/twpayne/chezmoi/releases/${tag}"
 	json=$(http_get "${release_url}" "Accept: application/json")
 	if [ -z "${json}" ]; then
 		log_err "real_tag error retrieving GitHub release ${tag}"

--- a/internal/cmds/generate-install.sh/install.sh.tmpl
+++ b/internal/cmds/generate-install.sh/install.sh.tmpl
@@ -8,11 +8,12 @@
 set -e
 
 BINDIR=${BINDIR:-./bin}
+GITHUB_USER=${GITHUB_USER:-twpayne}
 TAGARG=latest
 LOG_LEVEL=2
 EXECARGS=
 
-GITHUB_DOWNLOAD=https://github.com/twpayne/chezmoi/releases/download
+GITHUB_DOWNLOAD=https://github.com/${GITHUB_USER}/chezmoi/releases/download
 
 tmpdir=$(mktemp -d)
 trap 'rm -rf ${tmpdir}' EXIT
@@ -188,7 +189,7 @@ get_libc() {
 real_tag() {
 	tag=$1
 	log_debug "checking GitHub for tag ${tag}"
-	release_url="https://github.com/twpayne/chezmoi/releases/${tag}"
+	release_url="https://github.com/${GITHUB_USER}/chezmoi/releases/${tag}"
 	json=$(http_get "${release_url}" "Accept: application/json")
 	if [ -z "${json}" ]; then
 		log_err "real_tag error retrieving GitHub release ${tag}"


### PR DESCRIPTION
Not set in stone, but was hoping to start the conversation with a little code. I would prefer to maintain my own fork of chezmoi and this would still allow me to use a single-line installer (obviously with my own url).

A couple things I noticed:
1. I was not sure how to accomplish this same edit in the PowerShell variant.
2. Similar to the BINDIR, maybe you want the GITHUB_USER to additionally be set via switch?

Not a life-or-death change, but does abstract the code a bit from your namespace.