### PR TITLE
feat: Add support for GNOME Keyring on FreeBSD

### DIFF
--- a/assets/chezmoi.io/docs/reference/commands/secret.md
+++ b/assets/chezmoi.io/docs/reference/commands/secret.md
@@ -24,3 +24,10 @@ manager. Normally you would use chezmoi's existing template functions to retriev
     $ chezmoi secret keyring get --service=service --user=user
     $ chezmoi secret keyring delete --service=service --user=user
     ```
+
+!!! warning
+
+    On FreeBSD, the `secret keyring` command is only available if chezmoi was
+    compiled with cgo enabled. The official release binaries of chezmoi are
+    **not** compiled with cgo enabled, and `secret keyring` command is not
+    available.

--- a/assets/chezmoi.io/docs/reference/templates/functions/keyring.md
+++ b/assets/chezmoi.io/docs/reference/templates/functions/keyring.md
@@ -8,6 +8,7 @@ user's keyring.
 | macOS   | Keychain                    |
 | Linux   | GNOME Keyring               |
 | Windows | Windows Credentials Manager |
+| FreeBSD | GNOME Keyring               |
 
 !!! example
 
@@ -16,3 +17,10 @@ user's keyring.
         user = {{ .github.user | quote }}
         token = {{ keyring "github" .github.user | quote }}
     ```
+
+!!! warning
+
+    On FreeBSD, the `keyring` template function is only available if chezmoi
+    was compiled with cgo enabled. The official release binaries of chezmoi are
+    **not** compiled with cgo enabled, and `keyring` will always return an
+    empty string.

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/coreos/go-semver v0.3.0
 	github.com/danieljoos/wincred v1.1.2 // indirect
 	github.com/go-git/go-git/v5 v5.4.2
-	github.com/godbus/dbus/v5 v5.0.6 // indirect
 	github.com/google/btree v1.0.1 // indirect
 	github.com/google/go-github/v42 v42.0.0
 	github.com/google/gops v0.3.22
@@ -45,7 +44,7 @@ require (
 	github.com/ulikunitz/xz v0.5.10
 	github.com/xanzy/ssh-agent v0.3.1 // indirect
 	github.com/yuin/goldmark v1.4.7 // indirect
-	github.com/zalando/go-keyring v0.1.1
+	github.com/zalando/go-keyring v0.2.0
 	go.etcd.io/bbolt v1.3.6
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -94,6 +94,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4 h1:Hs82Z41s6SdL1CELW+XaDYmOH4hkBN4/N9og/AsOv7E=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
+github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/antihax/optional v1.0.0 h1:xK2lYat7ZLaVVcIuj82J8kIro4V6kDe0AUDFboUCwcg=
@@ -226,7 +228,6 @@ github.com/go-ole/go-ole v1.2.6-0.20210915003542-8b1f7f90f6b1 h1:4dntyT+x6QTOSCI
 github.com/go-ole/go-ole v1.2.6-0.20210915003542-8b1f7f90f6b1/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
-github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.0.6 h1:mkgN1ofwASrYnJ5W6U/BxG15eXXXjirgZc7CLqkcaro=
 github.com/godbus/dbus/v5 v5.0.6/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
@@ -651,8 +652,8 @@ github.com/yuin/goldmark v1.4.7 h1:KHHlQL4EKBZ43vpA1KBEQHfodk4JeIgeb0xJLg7rvDI=
 github.com/yuin/goldmark v1.4.7/go.mod h1:rmuwmfZ0+bvzB24eSC//bk1R1Zp3hM0OXYv/G2LIilg=
 github.com/yuin/goldmark-emoji v1.0.1 h1:ctuWEyzGBwiucEqxzwe0SOYDXPAucOrE9NQC18Wa1os=
 github.com/yuin/goldmark-emoji v1.0.1/go.mod h1:2w1E6FEWLcDQkoTE+7HU6QF1F6SLlNGjRIBbIZQFqkQ=
-github.com/zalando/go-keyring v0.1.1 h1:w2V9lcx/Uj4l+dzAf1m9s+DJ1O8ROkEHnynonHjTcYE=
-github.com/zalando/go-keyring v0.1.1/go.mod h1:OIC+OZ28XbmwFxU/Rp9V7eKzZjamBJwRzC8UFJH9+L8=
+github.com/zalando/go-keyring v0.2.0 h1:IZOFhp3Gw5WeaGTVpKtKD2o/s+BeeqQkKUhtMDTQ190=
+github.com/zalando/go-keyring v0.2.0/go.mod h1:cu3uCHLkG4H4ali7PdTkEWoq2p07YHHoI+oi16YT5x8=
 go.etcd.io/bbolt v1.3.6 h1:/ecaJf0sk1l4l6V4awd65v2C3ILy7MSj+s/x1ADCIMU=
 go.etcd.io/bbolt v1.3.6/go.mod h1:qXsaaIqmgQH0T+OPdb99Bf+PKfBBQVAdyD6TY9G8XM4=
 go.etcd.io/etcd/api/v3 v3.5.1 h1:v28cktvBq+7vGyJXF8G+rWJmj+1XUmMtqcLnH8hDocM=

--- a/pkg/cmd/keyringtemplatefuncs.go
+++ b/pkg/cmd/keyringtemplatefuncs.go
@@ -1,3 +1,6 @@
+//go:build !freebsd || (freebsd && cgo)
+// +build !freebsd freebsd,cgo
+
 package cmd
 
 import (

--- a/pkg/cmd/keyringtemplatefuncs_freebsdnocgo.go
+++ b/pkg/cmd/keyringtemplatefuncs_freebsdnocgo.go
@@ -1,0 +1,10 @@
+//go:build freebsd && !cgo
+// +build freebsd,!cgo
+
+package cmd
+
+type keyringData struct{}
+
+func (c *Config) keyringTemplateFunc(service, user string) string {
+	return ""
+}

--- a/pkg/cmd/secretcmd.go
+++ b/pkg/cmd/secretcmd.go
@@ -15,7 +15,9 @@ func (c *Config) newSecretCmd() *cobra.Command {
 		Example: example("secret"),
 	}
 
-	secretCmd.AddCommand(c.newSecretKeyringCmd())
+	if secretKeyringCmd := c.newSecretKeyringCmd(); secretKeyringCmd != nil {
+		secretCmd.AddCommand(secretKeyringCmd)
+	}
 
 	return secretCmd
 }

--- a/pkg/cmd/secretkeyringcmd.go
+++ b/pkg/cmd/secretkeyringcmd.go
@@ -1,3 +1,6 @@
+//go:build !freebsd || (freebsd && cgo)
+// +build !freebsd freebsd,cgo
+
 package cmd
 
 import (

--- a/pkg/cmd/secretkeyringcmd_freebsdnocgo.go
+++ b/pkg/cmd/secretkeyringcmd_freebsdnocgo.go
@@ -1,0 +1,12 @@
+//go:build freebsd && !cgo
+// +build freebsd,!cgo
+
+package cmd
+
+import "github.com/spf13/cobra"
+
+type secretKeyringCmdConfig struct{}
+
+func (c *Config) newSecretKeyringCmd() *cobra.Command {
+	return nil
+}


### PR DESCRIPTION
Fixes #1918.

@torculus if you [build chezmoi from source](https://www.chezmoi.io/install/#install-from-source) from this PR you should get GNOME Keyring support on FreeBSD. I'll wait for the official tag of zalando/go-keyring before merging this.