### PR TITLE
Correctly cut hostname off at . character

### DIFF
--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -920,7 +920,7 @@ func (c *Config) defaultTemplateData() map[string]interface{} {
 
 	var hostname string
 	if rawHostname, err := os.Hostname(); err == nil {
-		hostname, _, _ = chezmoi.CutString(rawHostname, "=")
+		hostname, _, _ = chezmoi.CutString(rawHostname, ".")
 	} else {
 		c.logger.Info().
 			Err(err).


### PR DESCRIPTION
The `hostname` variable was not being cut off at the first `.` character,
as intended. This is because a previous revision of the code accidentally
changed the separator character to `=` instead of `.`

This change returns the behaviour of the `hostname` variable to match
its documentation.

Opening this as a draft while I work out how to add a test for this behaviour
(not a Go developer sorry, so need to find an appropriate existing test
to use as a template). I've checked that the existing tests pass. 

Fixes #1920 
