### PR TITLE
fix: Fix use of drives as home directories on Windows

### DIFF
--- a/pkg/chezmoi/abspath.go
+++ b/pkg/chezmoi/abspath.go
@@ -53,7 +53,7 @@ func (p AbsPath) Bytes() []byte {
 
 // Dir returns p's directory.
 func (p AbsPath) Dir() AbsPath {
-	return NewAbsPath(path.Dir(p.absPath))
+	return NewAbsPath(filepath.Dir(p.absPath)).ToSlash()
 }
 
 // Empty returns if p is empty.
@@ -147,7 +147,7 @@ func (p AbsPath) TrimDirPrefix(dirPrefixAbsPath AbsPath) (RelPath, error) {
 		return EmptyRelPath, nil
 	}
 	dirAbsPath := dirPrefixAbsPath
-	if dirAbsPath.absPath != "/" {
+	if !strings.HasSuffix(dirAbsPath.absPath, "/") {
 		dirAbsPath.absPath += "/"
 	}
 	if !strings.HasPrefix(p.absPath, dirAbsPath.absPath) {

--- a/pkg/chezmoi/path_windows_test.go
+++ b/pkg/chezmoi/path_windows_test.go
@@ -1,10 +1,52 @@
 package chezmoi
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestAbsPathTrimDirPrefix(t *testing.T) {
+	for i, tc := range []struct {
+		absPath          AbsPath
+		dirPrefixAbsPath AbsPath
+		expected         RelPath
+	}{
+		{
+			absPath:          NewAbsPath("/home/user/.config"),
+			dirPrefixAbsPath: NewAbsPath("/home/user"),
+			expected:         NewRelPath(".config"),
+		},
+		{
+			absPath:          NewAbsPath("H:/.config"),
+			dirPrefixAbsPath: NewAbsPath("H:"),
+			expected:         NewRelPath(".config"),
+		},
+		{
+			absPath:          NewAbsPath("H:/.config"),
+			dirPrefixAbsPath: NewAbsPath("H:/"),
+			expected:         NewRelPath(".config"),
+		},
+		{
+			absPath:          NewAbsPath("H:/home/user/.config"),
+			dirPrefixAbsPath: NewAbsPath("H:/home/user"),
+			expected:         NewRelPath(".config"),
+		},
+		{
+			absPath:          NewAbsPath(`//server/user/.config`),
+			dirPrefixAbsPath: NewAbsPath(`//server/user`),
+			expected:         NewRelPath(".config"),
+		},
+	} {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			actual, err := tc.absPath.TrimDirPrefix(tc.dirPrefixAbsPath)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}
 
 func TestNormalizeLinkname(t *testing.T) {
 	for _, tc := range []struct {


### PR DESCRIPTION
Fixes #1964.

@zb140 would you mind reviewing this?

From [your comment](https://github.com/twpayne/chezmoi/issues/1964#issuecomment-1086414230):

> It may also be possible to fix it by also applying the "sometimes add a slash" logic in `TrimDirPrefix` but a) I haven't tried it, and b) I'm not as big a fan of that solution on a philosophical level because I think it's buggy behavior on Go's part to not include the slash in the first place. `H:` by itself is just a volume specifier, not a directory, so I don't think it's really a proper return value for `path.Dir()`. But reasonable minds can differ, and I'm happy to be told I'm wrong about that.

I've actually taken this approach in this PR. I agree with your assessment that it's buggy behavior from Go to not include the slash in the first place, but this is sadly something that is unlikely to be ever fixed as it would likely break too much existing code.

> The immediate source of the error message is this check: https://github.com/twpayne/chezmoi/blob/master/pkg/chezmoi/abspath.go#L150, which is adding an extra `/` to the end of the path. The `HasPrefix` check on line 153 then checks if `H:/` has a prefix of `H://`, which of course it doesn't 😄 I think the goal of the check is to make sure that paths that are not the root directory always end in a `/`.

The reason for adding the `/` is so that the `strings.HasPrefix` check can be used later in the function. Without a trailing `/`, `/some/dir` would be a considered a prefix of `/some/dirfoo`, which is obviously incorrect. The previous check was just for `/`, which Go returns as the directory of `/`. In the PR, I ensure that the prefix has the `/` suffix, which also fixes the case where Go returns `H:` as the directory of `H:/foo`.

Please take a look.

