### PR TITLE
chore: Restore OpenIndiana tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -181,6 +181,24 @@ jobs:
       - name: test
         run: |
           ( cd assets/vagrant && ./test.sh openbsd7 )
+  test-openindiana:
+    needs: changes
+    if: github.event_name == 'push' || needs.changes.outputs.code == 'true'
+    runs-on: macos-10.15
+    env:
+      VAGRANT_BOX: openindiana
+    steps:
+      - uses: actions/checkout@dcd71f646680f2efd8db4afa5ad64fdcba30e748 # pin@v3
+      - uses: actions/cache@136d96b4aee02b1f0de3ba493b1d47135042d9c0 # pin@v3.0.1
+        with:
+          path: ~/.vagrant.d
+          key: ${{ runner.os }}-vagrant-${{ env.VAGRANT_BOX }}-${{
+            hashFiles('assets/vagrant/openbsd7.Vagrantfile') }}
+          restore-keys: |
+            ${{ runner.os }}-vagrant-${{ env.VAGRANT_BOX }}-
+      - name: test
+        run: |
+          ( cd assets/vagrant && ./test.sh openindiana )
   test-ubuntu:
     needs: changes
     runs-on: ubuntu-18.04
@@ -415,6 +433,7 @@ jobs:
       - test-freebsd
       - test-macos
       - test-openbsd
+      - test-openindiana
       - test-ubuntu
       - test-ubuntu-go1-17
       - test-voidlinux

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ test-docker:
 
 .PHONY: test-vagrant
 test-vagrant:
-	( cd assets/vagrant && ./test.sh debian11-i386 freebsd13 openbsd7 )
+	( cd assets/vagrant && ./test.sh debian11-i386 freebsd13 openbsd7 openindiana )
 
 .PHONY: coverage-html
 coverage-html: coverage

--- a/assets/vagrant/openindiana.Vagrantfile
+++ b/assets/vagrant/openindiana.Vagrantfile
@@ -1,0 +1,15 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "openindiana/hipster"
+  config.vm.box_version = "20220105"
+  config.vm.synced_folder ".", "/chezmoi", type: "rsync"
+  config.vm.provision "shell", inline: <<-SHELL
+    pkg install -q compress/zip developer/gcc-7 developer/golang developer/versioning/git
+  SHELL
+  config.vm.provision "shell", inline: <<-SHELL
+    echo export CHEZMOI_GITHUB_ACCESS_TOKEN=#{ENV['CHEZMOI_GITHUB_ACCESS_TOKEN']} >> /export/home/vagrant/.profile
+    echo export CHEZMOI_GITHUB_TOKEN=#{ENV['CHEZMOI_GITHUB_TOKEN']} >> /export/home/vagrant/.profile
+    echo export GITHUB_ACCESS_TOKEN=#{ENV['GITHUB_ACCESS_TOKEN']} >> /export/home/vagrant/.profile
+    echo export GITHUB_TOKEN=#{ENV['GITHUB_TOKEN']} >> /export/home/vagrant/.profile
+  SHELL
+  config.vm.provision "file", source: "assets/vagrant/openindiana.test-chezmoi.sh", destination: "test-chezmoi.sh"
+end

--- a/assets/vagrant/openindiana.test-chezmoi.sh
+++ b/assets/vagrant/openindiana.test-chezmoi.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -eufo pipefail
+
+cd /chezmoi
+
+go test ./...


### PR DESCRIPTION
@torculus @bardo could I get some help with this?

In the current state, the OpenIndiana tests (which run on a Vagrant virtual machine) fail when I attempt to install Go and git:

```console
vagrant@openindiana:~$ pfexec pkg install -q developer/golang developer/versioning/git
pkg install: No matching version of developer/golang can be installed:
  Reject:  pkg://openindiana.org/developer/golang@1.17.8-2022.0.0.0
  Reason:  This version is excluded by installed incorporation consolidation/userland/userland-incorporation@0.5.11-2022.0.0.14866
No matching version of developer/versioning/git can be installed:
  Reject:  pkg://openindiana.org/developer/versioning/git@2.35.1-2022.0.0.0
  Reason:  This version is excluded by installed incorporation consolidation/userland/userland-incorporation@0.5.11-2022.0.0.14866
```

I've did some searching and came across [this article about relaxing version constraints](https://docs.oracle.com/cd/E26502_01/html/E28984/gmias.html) but it didn't seem to work:

```console
vagrant@openindiana:~$ pfexec pkg change-facet facet.version-lock.developer/golang=false
            Packages to change:   1
     Variants/Facets to change:   1
       Create boot environment:  No
Create backup boot environment: Yes

PHASE                                          ITEMS
Removing old actions                             1/1
Updating package state database                 Done 
Updating package cache                           0/0 
Updating image state                            Done 
Creating fast lookup database                   Done 

vagrant@openindiana:~$ pfexec pkg install developer/golang
Creating Plan (Solver setup): -
pkg install: No matching version of developer/golang can be installed:
  Reject:  pkg://openindiana.org/developer/golang@1.17.8-2022.0.0.0
  Reason:  No version matching 'require' dependency developer/golang-117 can be installed
    ----------------------------------------
    Reject:  pkg://openindiana.org/developer/golang-117@1.17.8-2022.0.0.0
    Reason:  This version is excluded by installed incorporation consolidation/userland/userland-incorporation@0.5.11-2022.0.0.14866
    ----------------------------------------
```

The relevant code is in the `config.vm.provision` block in `openindiana.Vagrantfile` in this PR. Note also that I bumped the [Vagrant box](https://app.vagrantup.com/openindiana/boxes/hipster) from version `202109` to `20220105`.

Do you know what commands are now required to install Go and git on OpenIndiana?