### PR TITLE
docs: Add clarification about all lowercase custom data fields

### DIFF
--- a/assets/chezmoi.io/docs/reference/templates/variables.md
+++ b/assets/chezmoi.io/docs/reference/templates/variables.md
@@ -28,3 +28,8 @@ chezmoi provides the following automatically-populated variables:
 Additional variables can be defined in the config file in the `data` section.
 Variable names must consist of a letter and be followed by zero or more letters
 and/or digits.
+
+!!! hint
+
+    Until [#463](https://github.com/twpayne/chezmoi/issues/463) is resolved, custom
+    data fields from the `data` section appear as all lowercase strings.


### PR DESCRIPTION
Hi, 

I'm new to chezmoi and started to look into templates. I've spent quite some time to figure out why I could not get custom variables in the `data` section of the config to work until I realized that I've stumbled upon #463.

I propose to add a hint or disclaimer to the documentation here to make it easier for newcomers to spot this pitfall (and avoid it). The  FAQ added in  #671 contains a reference already, but I only found it by backtracking from the issue.

Maybe adding the hint (also) to [User Guide > Templating](https://www.chezmoi.io/user-guide/templating/) would also help?

Please let me know if I need to change or update anything.