### PR TITLE
Use index function to access an item in the example

### DIFF
--- a/assets/chezmoi.io/docs/user-guide/password-managers/1password.md
+++ b/assets/chezmoi.io/docs/user-guide/password-managers/1password.md
@@ -75,7 +75,7 @@ and returns it as structured data. For example, if the output is:
 Then you can access the password field with the syntax
 
 ```
-{{ (onepassword "$UUID").fields[1].value }}
+{{ (index (onepassword "$UUID").fields 1).value }}
 ```
 
 or:


### PR DESCRIPTION
This PR fixes an example in the documentation.

```
chezmoi execute-template "{{ (onepassword \"$UUID\").fields[1].value }}"
```

yields the following error

```
chezmoi: template: stdin:1: bad character U+005B '['
```