### PR TITLE
fix: Don't cache negative results of path lookups

### DIFF
--- a/pkg/chezmoi/lookpath.go
+++ b/pkg/chezmoi/lookpath.go
@@ -5,29 +5,25 @@ import (
 	"sync"
 )
 
-type lookPathCacheValue struct {
-	path string
-	err  error
-}
-
 var (
 	lookPathCacheMutex sync.Mutex
-	lookPathCache      = make(map[string]lookPathCacheValue)
+	lookPathCache      = make(map[string]string)
 )
 
-// LookPath is like os/exec.LookPath except that results are cached.
+// LookPath is like os/exec.LookPath except that the first positive result is
+// cached.
 func LookPath(file string) (string, error) {
 	lookPathCacheMutex.Lock()
 	defer lookPathCacheMutex.Unlock()
 
-	if result, ok := lookPathCache[file]; ok {
-		return result.path, result.err
+	if path, ok := lookPathCache[file]; ok {
+		return path, nil
 	}
 
 	path, err := exec.LookPath(file)
-	lookPathCache[file] = lookPathCacheValue{
-		path: path,
-		err:  err,
+	if err == nil {
+		lookPathCache[file] = path
 	}
+
 	return path, err
 }


### PR DESCRIPTION
The contents of the directories in `$PATH` might change between calls to `LookPath`, see https://github.com/twpayne/chezmoi/issues/2027.

Fixes #2027.