### PR TITLE
fix #2056: extract files from sub-directory of external archive with include but w/o excludes

### DIFF
--- a/assets/chezmoi.io/docs/reference/special-files-and-directories/chezmoiexternal-format.md
+++ b/assets/chezmoi.io/docs/reference/special-files-and-directories/chezmoiexternal-format.md
@@ -62,7 +62,8 @@ archive, not the target state. chezmoi uses the following algorithm to
 determine whether an archive member is included:
 
 1. If the archive member name matches any `exclude` pattern, then the archive
-   member is excluded.
+   member is excluded. In addition, if the archive member is a directory, then
+   all contained files and sub-directories will be excluded, too (recursively).
 2. Otherwise, if the archive member name matches any `include` pattern, then
    the archive member is included.
 3. Otherwise, if only `include` patterns were specified then the archive member

--- a/pkg/chezmoi/sourcestate.go
+++ b/pkg/chezmoi/sourcestate.go
@@ -1889,7 +1889,11 @@ func (s *SourceState) readExternalArchive(
 		// otherwise it is not possible to differentiate between
 		// identically-named files at the same level.
 		if patternSet.match(name) == patternSetMatchExclude {
-			if fileInfo.IsDir() {
+			// in case that `name` is a directory tree which matched an
+			// explicit exclude pattern, return fs.SkipDir to exclude
+			// not just the directory itself but also everything it
+			// contains (recursively).
+			if fileInfo.IsDir() && len(patternSet.excludePatterns) > 0 {
 				return fs.SkipDir
 			}
 			return nil

--- a/pkg/cmd/testdata/scripts/externalarchiveinclude.txt
+++ b/pkg/cmd/testdata/scripts/externalarchiveinclude.txt
@@ -27,6 +27,12 @@ chhome home4/user
 chezmoi managed
 cmp stdout golden/managed4
 
+chhome home5/user
+
+# test that chezmoi can include selected files in sub-directories
+chezmoi managed
+cmp stdout golden/managed5
+
 -- archive/dir/subdir1/file1 --
 # contents of dir/subdir1/file1
 -- archive/dir/subdir1/file2 --
@@ -75,6 +81,10 @@ cmp stdout golden/managed4
 .dir/file1
 .dir/symlink1
 .dir/symlink2
+-- golden/managed5 --
+.dir
+.dir/dir/subdir2/file1
+.dir/dir/subdir2/file2
 -- home/user/.local/share/chezmoi/.chezmoiexternal.toml --
 [".dir"]
     type = "archive"
@@ -99,3 +109,9 @@ cmp stdout golden/managed4
     stripComponents = 1
     include = ["*/dir", "*/dir/**"]
     exclude = ["**/file2"]
+-- home5/user/.local/share/chezmoi/.chezmoiexternal.toml --
+[".dir"]
+    type = "archive"
+    url = "{{ env "HTTPD_URL" }}/archive.tar.gz"
+    stripComponents = 1
+    include = ["*/dir/subdir2/*"]


### PR DESCRIPTION
Fixes #2056

Also updates the documentation and adds a test which checks the new
behaviour.

# Example:

archive centent:
```
bsl-develop/LICENSE
bsl-develop/Makefile
bsl-develop/README.org
bsl-develop/src/
bsl-develop/src/bsl_logging.bash
bsl-develop/src/bsl_misc.bash
bsl-develop/src/bsl_path.bash
bsl-develop/src/bsl_string.bash
bsl-develop/src/load.bash
bsl-develop/test/
bsl-develop/test/bsl_logging.bats
bsl-develop/test/bsl_misc.bats
bsl-develop/test/bsl_path.bats
bsl-develop/test/bsl_string.bats
bsl-develop/test/test_helper.bash
```

.chezmoiexternal.yaml:
```yaml
---
.local/lib/bash/bsl:
  type: 'archive'
  url: 'https://github.com/ktetzlaff/bsl/archive/develop.tar.gz'
  include:
    - '**/src/*.bash'
  stripComponents: 2
```

# Expected behavior:

Extract `*.bash` from `bsl-develop/src/` to `~/.local/lib/bash/bsl`.

# Observed bahavior without this fix:

Nothing will be extracted.

<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer/contributing-changes/

-->
