### PR TITLE
docs: Add example of extracting selected files from external archive

### DIFF
--- a/assets/chezmoi.io/docs/reference/special-files-and-directories/chezmoiexternal-format.md
+++ b/assets/chezmoi.io/docs/reference/special-files-and-directories/chezmoiexternal-format.md
@@ -118,3 +118,6 @@ re-download unless forced. To force chezmoi to re-download URLs, pass the
         stripComponents = 2
         include = ["*/plugins/**"]
     ```
+
+    Some more examples can be found in the
+    [user guide](/user-guide/include-files-from-elsewhere/).

--- a/assets/chezmoi.io/docs/reference/special-files-and-directories/chezmoiexternal-format.md
+++ b/assets/chezmoi.io/docs/reference/special-files-and-directories/chezmoiexternal-format.md
@@ -116,5 +116,5 @@ re-download unless forced. To force chezmoi to re-download URLs, pass the
         url = "https://api.github.com/repos/vrana/adminer/tarball"
         refreshPeriod = "744h"
         stripComponents = 2
-        include = ["*", "*/plugins", "*/plugins/**"]
+        include = ["*/plugins/**"]
     ```

--- a/assets/chezmoi.io/docs/user-guide/include-files-from-elsewhere.md
+++ b/assets/chezmoi.io/docs/user-guide/include-files-from-elsewhere.md
@@ -1,5 +1,9 @@
 # Include dotfiles from elsewhere
 
+The sections below contain examples of how to use `.chezmoiexternal.toml` to
+include files from external sources. For more details, check the [reference
+manual](/reference/special-files-and-directories/chezmoiexternal-format/) .
+
 ## Include a subdirectory from a URL
 
 To include a subdirectory from another repository, e.g. [Oh My

--- a/assets/chezmoi.io/docs/user-guide/include-files-from-elsewhere.md
+++ b/assets/chezmoi.io/docs/user-guide/include-files-from-elsewhere.md
@@ -69,6 +69,27 @@ When using Oh My Zsh, make sure you disable auto-updates by setting
 `~/.oh-my-zsh` directory to drift out of sync with chezmoi's source state. To
 update Oh My Zsh and its plugins, refresh the downloaded archives.
 
+## Include a subdirectory with selected files from a URL
+
+Use `include` pattern filters to include only selected files from an archive
+URL.
+
+For example, to import just the required source files of the
+[zsh-syntax-highlighting
+plugin](https://github.com/zsh-users/zsh-syntax-highlighting) in the example
+above, add in `include` filter to the `zsh-syntax-highlighting` section as shown
+below:
+
+```toml title="~/.local/share/chezmoi/.chezmoiexternal.toml"
+[".oh-my-zsh/custom/plugins/zsh-syntax-highlighting"]
+    type = "archive"
+    url = "https://github.com/zsh-users/zsh-syntax-highlighting/archive/master.tar.gz"
+    exact = true
+    stripComponents = 1
+    refreshPeriod = "168h"
+    include = ["*/*.zsh", "*/.version", "*/.revision-hash", "*/highlighters/**"]
+```
+
 ## Include a single file from a URL
 
 Including single files uses the same mechanism as including a subdirectory

--- a/pkg/chezmoi/sourcestate.go
+++ b/pkg/chezmoi/sourcestate.go
@@ -1889,7 +1889,7 @@ func (s *SourceState) readExternalArchive(
 		// otherwise it is not possible to differentiate between
 		// identically-named files at the same level.
 		if patternSet.match(name) == patternSetMatchExclude {
-			// In case that `name` is a directory tree which matched an explicit
+			// In case that `name` is a directory which matched an explicit
 			// exclude pattern, return fs.SkipDir to exclude not just the
 			// directory itself but also everything it contains (recursively).
 			if fileInfo.IsDir() && len(patternSet.excludePatterns) > 0 {


### PR DESCRIPTION
This is an add on to the previous fix for #2056 which adds an example of
how to use `input` filters in `.chezmoiexternal.toml` to the
user guide (`docs/user-guide/include-files-from-elsewhere.md`).

The first commit also includes an update to
`docs/reference/special-files-and-directories/chezmoiexternal-format.md`
which uses the new simplified `input` filter syntax and makes a minor
change to the comment about excluded directory trees in
`pkg/chezmoi/sourcestate.go`.

A second commit adds a link from the `chezmoiexternal` related page in the *user-guide* to the corresponding page in the *reference* docs (and vice versa).

~~I haven't checked the HTML output of the markdown changes (I couldn't figure out how to build it). Is there a way to look at the output of the `build-website` job of the *github actions*?~~

Found it (https://www.chezmoi.io/developer/website) - looks ok.