### PR TITLE
docs: chezmoi_modify_manager

### DIFF
--- a/assets/chezmoi.io/docs/links/related-software.md
+++ b/assets/chezmoi.io/docs/links/related-software.md
@@ -29,3 +29,9 @@ chezmoi plugin for asdf version manager.
 
 An add-on to synchronize your colorschemes across systems and allow easy
 colorscheme switching using chezmoi templates.
+
+### [`github.com/VorpalBlade/chezmoi_modify_manager`](https://github.com/VorpalBlade/chezmoi_modify_manager)
+
+An add-on to deal with config files that contain a mix of settings and
+transient state, such as with GUI program settings files also containing
+recently used files and window positions.

--- a/assets/chezmoi.io/docs/links/related-software.md
+++ b/assets/chezmoi.io/docs/links/related-software.md
@@ -1,27 +1,31 @@
 # Related software
 
-## [`github.com/alker0/chezmoi.vim`](https://github.com/alker0/chezmoi.vim)
+## Editor integration
+
+### [`github.com/alker0/chezmoi.vim`](https://github.com/alker0/chezmoi.vim)
 
 Intelligent VIM syntax highlighting when editing files in your source directory.
 Works with both `chezmoi edit` and editing files directly.
 
-## [`github.com/hussainweb/ansible-role-chezmoi`](https://github.com/hussainweb/ansible-role-chezmoi)
-
-Installs chezmoi on Ubuntu and Debian servers.
-
-## [`github.com/joke/asdf-chezmoi`](https://github.com/joke/asdf-chezmoi)
-
-chezmoi plugin for asdf version manager.
-
-## [`github.com/tcaxle/drapeau`](https://github.com/tcaxle/drapeau)
-
-An add-on to synchronize your colorschemes across systems and allow easy
-colorscheme switching using chezmoi templates.
-
-## [`github.com/tuh8888/chezmoi.el`](https://github.com/tuh8888/chezmoi.el)
+### [`github.com/tuh8888/chezmoi.el`](https://github.com/tuh8888/chezmoi.el)
 
 Convenience functions for interacting with chezmoi in Emacs.
 
-## [`github.com/Lilja/vim-chezmoi`](https://github.com/Lilja/vim-chezmoi)
+### [`github.com/Lilja/vim-chezmoi`](https://github.com/Lilja/vim-chezmoi)
 
 A plugin for VIM to apply the dotfile you are editing on `:w`.
+
+## Other
+
+### [`github.com/hussainweb/ansible-role-chezmoi`](https://github.com/hussainweb/ansible-role-chezmoi)
+
+Installs chezmoi on Ubuntu and Debian servers.
+
+### [`github.com/joke/asdf-chezmoi`](https://github.com/joke/asdf-chezmoi)
+
+chezmoi plugin for asdf version manager.
+
+### [`github.com/tcaxle/drapeau`](https://github.com/tcaxle/drapeau)
+
+An add-on to synchronize your colorschemes across systems and allow easy
+colorscheme switching using chezmoi templates.

--- a/assets/chezmoi.io/docs/user-guide/manage-different-types-of-file.md
+++ b/assets/chezmoi.io/docs/user-guide/manage-different-types-of-file.md
@@ -80,6 +80,15 @@ substituted with:
 current-context: {{ output "kubectl" "config" "current-context" | trim }}
 ```
 
+!!! hint
+
+    For managing ini files with a mix of settings and state (such as recently
+    used files or window positions), there is a third party tool called
+    `chezmoi_modify_manager` that builds upon `modify_` scripts. See
+    [related software](../links/related-software.md#githubcomvorpalbladechezmoi_modify_manager)
+    for more information.
+
+
 ## Manage a file's permissions, but not its contents
 
 chezmoi's `create_` attributes allows you to tell chezmoi to create a file if


### PR DESCRIPTION
Add a hint in the section on `modify` as well as in related software.

Also in a separate commit I organized related software page into sub-sections. So far I only added a separate section for Editor integration. In the future, as there is more software it may also make sense to split "Other" into further sections.

<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer/contributing-changes/

-->
