### PR TITLE
fix: Fix dump command in the presence of config file templates

### DIFF
--- a/pkg/cmd/dumpcmd.go
+++ b/pkg/cmd/dumpcmd.go
@@ -23,7 +23,7 @@ func (c *Config) newDumpCmd() *cobra.Command {
 		ValidArgsFunction: c.targetValidArgs,
 		RunE:              c.runDumpCmd,
 		Annotations: map[string]string{
-			persistentStateMode:     persistentStateModeEmpty,
+			persistentStateMode:     persistentStateModeReadMockWrite,
 			requiresSourceDirectory: "true",
 		},
 	}

--- a/pkg/cmd/testdata/scripts/issue2092.txt
+++ b/pkg/cmd/testdata/scripts/issue2092.txt
@@ -1,0 +1,29 @@
+[windows] skip 'UNIX only'
+
+# test that chezmoi dump warns when the config file has not been generated
+chezmoi dump
+cmp stdout golden/dump.json
+stderr 'config file template has changed'
+
+# test that chezmoi dump does not return an error when the config file template has been modified
+chezmoi init
+edit $CHEZMOICONFIGDIR${/}chezmoi.toml
+chezmoi dump
+cmp stdout golden/dump.json
+! stderr .
+
+-- golden/dump.json --
+{
+  ".file": {
+    "type": "file",
+    "name": ".file",
+    "contents": "# contents of .file\n",
+    "perm": 420
+  }
+}
+-- home/user/.file --
+# contents of .file
+-- home/user/.local/share/chezmoi/.chezmoi.toml.tmpl --
+[data]
+-- home/user/.local/share/chezmoi/dot_file --
+# contents of .file


### PR DESCRIPTION
Refs #2092.

@VorpalBlade I'm reasonably sure that this fixes the problem you reported. Are you able to test this to confirm?