### PR TITLE
Fixed typo in kubeconfig documentation

### DIFF
--- a/assets/chezmoi.io/docs/user-guide/manage-different-types-of-file.md
+++ b/assets/chezmoi.io/docs/user-guide/manage-different-types-of-file.md
@@ -97,7 +97,7 @@ from the `executable_`, `private_`, and `readonly_` attributes. This can be
 used to control a file's permissions without altering its contents.
 
 For example, if you want to ensure that `~/.kube/config` always has permissions
-600 then if you create an empty file called `dot_kube/private_dot_config` in
+600 then if you create an empty file called `dot_kube/private_config` in
 your source state, chezmoi will ensure `~/.kube/config`'s permissions are 0600
 when you run `chezmoi apply` without changing its contents.
 


### PR DESCRIPTION
When describing managing a file's permissions without managing the contents itself, and uses kubeconfig as an example, the docs note to create a file `dot_kube/private_dot_config` in the source directory, when based on the chezmoi source naming scheme, it should be `dot_kube/private_config`. This changes that disparity.

 Signed-off by: Kendall Tauser <kttpsy@gmail.com>

<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer/contributing-changes/

-->
