### PR TITLE
fix: Improve quality of POSIX shell scripts

### DIFF
--- a/assets/scripts/install.sh
+++ b/assets/scripts/install.sh
@@ -93,7 +93,7 @@ main() {
 		install -d "${BINDIR}"
 	fi
 	BINARY="chezmoi${BINSUFFIX}"
-	install -t "${BINDIR}/" "${tmpdir}/${BINARY}"
+	install -- "${tmpdir}/${BINARY}" "${BINDIR}/"
 	log_info "installed ${BINDIR}/${BINARY}"
 
 	if [ -n "${1+n}" ]; then

--- a/assets/scripts/install.sh
+++ b/assets/scripts/install.sh
@@ -7,19 +7,19 @@
 
 set -e
 
-BINDIR=${BINDIR:-./bin}
-CHEZMOI_USER_REPO=${CHEZMOI_USER_REPO:-twpayne/chezmoi}
+BINDIR="${BINDIR:-./bin}"
+CHEZMOI_USER_REPO="${CHEZMOI_USER_REPO:-twpayne/chezmoi}"
 TAGARG=latest
 LOG_LEVEL=2
-EXECARGS=
 
-GITHUB_DOWNLOAD=https://github.com/${CHEZMOI_USER_REPO}/releases/download
+GITHUB_DOWNLOAD="https://github.com/${CHEZMOI_USER_REPO}/releases/download"
 
-tmpdir=$(mktemp -d)
-trap 'rm -rf ${tmpdir}' EXIT
+tmpdir="$(mktemp -d)"
+trap 'rm -rf -- "${tmpdir}"' EXIT
+trap 'exit' INT TERM
 
 usage() {
-	this="$1"
+	this="${1}"
 	cat <<EOF
 ${this}: download chezmoi and optionally run chezmoi
 
@@ -33,13 +33,14 @@ EOF
 }
 
 main() {
-	parse_args "$@"
+	parse_args "${@}"
+	shift "$((OPTIND - 1))"
 
-	GOOS=$(get_goos)
-	GOARCH=$(get_goarch)
+	GOOS="$(get_goos)"
+	GOARCH="$(get_goarch)"
 	check_goos_goarch "${GOOS}/${GOARCH}"
 
-	TAG="$(real_tag $TAGARG)"
+	TAG="$(real_tag "${TAGARG}")"
 	VERSION="${TAG#v}"
 
 	log_info "found version ${VERSION} for ${TAGARG}/${GOOS}/${GOARCH}"
@@ -85,19 +86,18 @@ main() {
 	# verify checksums
 	hash_sha256_verify "${tmpdir}/${TARBALL}" "${tmpdir}/${CHECKSUMS}"
 
-	(cd "${tmpdir}" && untar "${TARBALL}")
+	(cd -- "${tmpdir}" && untar "${TARBALL}")
 
 	# install binary
 	if [ ! -d "${BINDIR}" ]; then
 		install -d "${BINDIR}"
 	fi
 	BINARY="chezmoi${BINSUFFIX}"
-	install "${tmpdir}/${BINARY}" "${BINDIR}/"
+	install -t "${BINDIR}/" "${tmpdir}/${BINARY}"
 	log_info "installed ${BINDIR}/${BINARY}"
 
-	if [ -n "${EXECARGS}" ]; then
-		# shellcheck disable=SC2086
-		exec "${BINDIR}/${BINARY}" $EXECARGS
+	if [ -n "${1+n}" ]; then
+		exec "${BINDIR}/${BINARY}" "${@}"
 	fi
 }
 
@@ -106,23 +106,21 @@ parse_args() {
 		case "${arg}" in
 		b) BINDIR="${OPTARG}" ;;
 		d) LOG_LEVEL=3 ;;
-		h | \?) usage "$0" ;;
+		h | \?) usage "${0}" ;;
 		t) TAGARG="${OPTARG}" ;;
 		*) return 1 ;;
 		esac
 	done
-	shift $((OPTIND - 1))
-	EXECARGS="$*"
 }
 
 get_goos() {
-	os=$(uname -s | tr '[:upper:]' '[:lower:]')
+	os="$(uname -s | tr '[:upper:]' '[:lower:]')"
 	case "${os}" in
 	cygwin_nt*) goos="windows" ;;
 	mingw*) goos="windows" ;;
 	msys_nt*) goos="windows" ;;
 	sunos*)
-		kernel=$(uname -o | tr '[:upper:]' '[:lower:]')
+		kernel="$(uname -o | tr '[:upper:]' '[:lower:]')"
 		case "${kernel}" in
 		illumos*) goos="illumos" ;;
 		solaris*) goos="solaris" ;;
@@ -131,11 +129,11 @@ get_goos() {
 		;;
 	*) goos="${os}" ;;
 	esac
-	echo "${goos}"
+	printf '%s' "${goos}"
 }
 
 get_goarch() {
-	arch=$(uname -m)
+	arch="$(uname -m)"
 	case "${arch}" in
 	aarch64) goarch="arm64" ;;
 	armv*) goarch="arm" ;;
@@ -146,11 +144,11 @@ get_goarch() {
 	x86_64) goarch="amd64" ;;
 	*) goarch="${arch}" ;;
 	esac
-	echo "${goarch}"
+	printf '%s' "${goarch}"
 }
 
 check_goos_goarch() {
-	case "$1" in
+	case "${1}" in
 	darwin/amd64) return 0 ;;
 	darwin/arm64) return 0 ;;
 	freebsd/386) return 0 ;;
@@ -178,7 +176,7 @@ check_goos_goarch() {
 	windows/amd64) return 0 ;;
 	windows/arm) return 0 ;;
 	*)
-		echo "$1: unsupported platform" 1>&2
+		printf '%s: unsupported platform\n' "${1}" 1>&2
 		return 1
 		;;
 	esac
@@ -187,12 +185,12 @@ check_goos_goarch() {
 get_libc() {
 	if is_command ldd; then
 		case "$(ldd --version 2>&1 | tr '[:upper:]' '[:lower:]')" in
-		*glibc*|"*gnu libc*")
-			echo glibc
+		*glibc*|*"gnu libc"*)
+			printf glibc
 			return
 			;;
 		*musl*)
-			echo musl
+			printf musl
 			return
 			;;
 		esac
@@ -200,7 +198,7 @@ get_libc() {
 	if is_command getconf; then
 		case "$(getconf GNU_LIBC_VERSION 2>&1)" in
 		*glibc*)
-			echo glibc
+			printf glibc
 			return
 			;;
 		esac
@@ -210,15 +208,15 @@ get_libc() {
 }
 
 real_tag() {
-	tag=$1
+	tag="${1}"
 	log_debug "checking GitHub for tag ${tag}"
 	release_url="https://github.com/${CHEZMOI_USER_REPO}/releases/${tag}"
-	json=$(http_get "${release_url}" "Accept: application/json")
+	json="$(http_get "${release_url}" "Accept: application/json")"
 	if [ -z "${json}" ]; then
 		log_err "real_tag error retrieving GitHub release ${tag}"
 		return 1
 	fi
-	real_tag=$(echo "${json}" | tr -s '\n' ' ' | sed 's/.*"tag_name":"//' | sed 's/".*//')
+	real_tag="$(printf '%s\n' "${json}" | tr -s '\n' ' ' | sed 's/.*"tag_name":"//' | sed 's/".*//')"
 	if [ -z "${real_tag}" ]; then
 		log_err "real_tag error determining real tag of GitHub release ${tag}"
 		return 1
@@ -227,25 +225,25 @@ real_tag() {
 		return 1
 	fi
 	log_debug "found tag ${real_tag} for ${tag}"
-	echo "${real_tag}"
+	printf '%s' "${real_tag}"
 }
 
 http_get() {
-	tmpfile=$(mktemp)
-	http_download "${tmpfile}" "$1" "$2" || return 1
-	body=$(cat "${tmpfile}")
+	tmpfile="$(mktemp)"
+	http_download "${tmpfile}" "${1}" "${2}" || return 1
+	body="$(cat "${tmpfile}")"
 	rm -f "${tmpfile}"
-	echo "${body}"
+	printf '%s\n' "${body}"
 }
 
 http_download_curl() {
-	local_file=$1
-	source_url=$2
-	header=$3
+	local_file="${1}"
+	source_url="${2}"
+	header="${3}"
 	if [ -z "${header}" ]; then
-		code=$(curl -w '%{http_code}' -sL -o "${local_file}" "${source_url}")
+		code="$(curl -w '%{http_code}' -sL -o "${local_file}" "${source_url}")"
 	else
-		code=$(curl -w '%{http_code}' -sL -H "${header}" -o "${local_file}" "${source_url}")
+		code="$(curl -w '%{http_code}' -sL -H "${header}" -o "${local_file}" "${source_url}")"
 	fi
 	if [ "${code}" != "200" ]; then
 		log_debug "http_download_curl received HTTP status ${code}"
@@ -255,9 +253,9 @@ http_download_curl() {
 }
 
 http_download_wget() {
-	local_file=$1
-	source_url=$2
-	header=$3
+	local_file="${1}"
+	source_url="${2}"
+	header="${3}"
 	if [ -z "${header}" ]; then
 		wget -q -O "${local_file}" "${source_url}" || return 1
 	else
@@ -266,12 +264,12 @@ http_download_wget() {
 }
 
 http_download() {
-	log_debug "http_download $2"
+	log_debug "http_download ${2}"
 	if is_command curl; then
-		http_download_curl "$@" || return 1
+		http_download_curl "${@}" || return 1
 		return
 	elif is_command wget; then
-		http_download_wget "$@" || return 1
+		http_download_wget "${@}" || return 1
 		return
 	fi
 	log_crit "http_download unable to find wget or curl"
@@ -279,19 +277,19 @@ http_download() {
 }
 
 hash_sha256() {
-	target=$1
+	target="${1}"
 	if is_command sha256sum; then
-		hash=$(sha256sum "${target}") || return 1
-		echo "${hash}" | cut -d ' ' -f 1
+		hash="$(sha256sum "${target}")" || return 1
+		printf '%s' "${hash}" | cut -d ' ' -f 1
 	elif is_command shasum; then
-		hash=$(shasum -a 256 "${target}" 2>/dev/null) || return 1
-		echo "${hash}" | cut -d ' ' -f 1
+		hash="$(shasum -a 256 "${target}" 2>/dev/null)" || return 1
+		printf '%s' "${hash}" | cut -d ' ' -f 1
 	elif is_command sha256; then
-		hash=$(sha256 -q "${target}" 2>/dev/null) || return 1
-		echo "${hash}" | cut -d ' ' -f 1
+		hash="$(sha256 -q "${target}" 2>/dev/null)" || return 1
+		printf '%s' "${hash}" | cut -d ' ' -f 1
 	elif is_command openssl; then
-		hash=$(openssl dgst -sha256 "${target}") || return 1
-		echo "${hash}" | cut -d ' ' -f a
+		hash="$(openssl dgst -sha256 "${target}")" || return 1
+		printf '%s' "${hash}" | cut -d ' ' -f a
 	else
 		log_crit "hash_sha256 unable to find command to compute SHA256 hash"
 		return 1
@@ -299,17 +297,17 @@ hash_sha256() {
 }
 
 hash_sha256_verify() {
-	target=$1
-	checksums=$2
-	basename=${target##*/}
+	target="${1}"
+	checksums="${2}"
+	basename="${target##*/}"
 
-	want=$(grep "${basename}" "${checksums}" 2>/dev/null | tr '\t' ' ' | cut -d ' ' -f 1)
+	want="$(grep "${basename}" "${checksums}" 2>/dev/null | tr '\t' ' ' | cut -d ' ' -f 1)"
 	if [ -z "${want}" ]; then
 		log_err "hash_sha256_verify unable to find checksum for ${target} in ${checksums}"
 		return 1
 	fi
 
-	got=$(hash_sha256 "${target}")
+	got="$(hash_sha256 "${target}")"
 	if [ "${want}" != "${got}" ]; then
 		log_err "hash_sha256_verify checksum for ${target} did not verify ${want} vs ${got}"
 		return 1
@@ -317,11 +315,11 @@ hash_sha256_verify() {
 }
 
 untar() {
-	tarball=$1
+	tarball="${1}"
 	case "${tarball}" in
 	*.tar.gz | *.tgz) tar -xzf "${tarball}" ;;
 	*.tar) tar -xf "${tarball}" ;;
-	*.zip) unzip "${tarball}" ;;
+	*.zip) unzip -- "${tarball}" ;;
 	*)
 		log_err "untar unknown archive format for ${tarball}"
 		return 1
@@ -330,27 +328,27 @@ untar() {
 }
 
 is_command() {
-	command -v "$1" >/dev/null
+	type "${1}" >/dev/null 2>&1
 }
 
 log_debug() {
 	[ 3 -le "${LOG_LEVEL}" ] || return 0
-	echo debug "$@" 1>&2
+	printf 'debug %s\n' "${*}" 1>&2
 }
 
 log_info() {
 	[ 2 -le "${LOG_LEVEL}" ] || return 0
-	echo info "$@" 1>&2
+	printf 'info %s\n' "${*}" 1>&2
 }
 
 log_err() {
 	[ 1 -le "${LOG_LEVEL}" ] || return 0
-	echo error "$@" 1>&2
+	printf 'error %s\n' "${*}" 1>&2
 }
 
 log_crit() {
 	[ 0 -le "${LOG_LEVEL}" ] || return 0
-	echo critical "$@" 1>&2
+	printf 'critical %s\n' "${*}" 1>&2
 }
 
-main "$@"
+main "${@}"

--- a/assets/scripts/stow-to-chezmoi.sh
+++ b/assets/scripts/stow-to-chezmoi.sh
@@ -1,29 +1,31 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 
-BASEDIR="${1:-$HOME}"
+BASEDIR="${1:-${HOME}}"
 STOWDIR="${2:-dotfiles}"
 
 BASEDIR="$(
-	unset CDPATH
-	cd "${BASEDIR}" >/dev/null 2>&1
-	pwd
+	unset -v CDPATH
+	cd -- "${BASEDIR}" >/dev/null 2>&1
+	pwd && printf .
 )"
+BASEDIR="${BASEDIR%??}"
 
 # if we have greadlink, use that
-READLINK="$(which greadlink 2>/dev/null || which readlink)"
+READLINK="$(command -v greadlink 2>/dev/null || command -v readlink)"
 
 removelink() {
-	[ -L "$1" ] && (
-		LINK_DEST="$($READLINK -f "$1")"
-		rm "$1"
-		echo -ne "${LINK_DEST} ==> $1\t"
-		if cp -R "${LINK_DEST}" "$1"; then
-			echo "Done"
+	[ -h "${1}" ] && (
+		LINK_DEST="$("${READLINK}" -f -- "${1}" && printf .)"
+		LINK_DEST="${LINK_DEST%??}"
+		rm -- "${1}"
+		printf '%s ==> %s\t' "${LINK_DEST}" "${1}" >&2
+		if cp -r -- "${LINK_DEST}" "${1}"; then
+			printf 'Done\n' >&2
 		else
-			echo "FAILED"
-			return 1
+			printf 'FAILED\n' >&2
+			exit 1
 		fi
 	)
 }
@@ -31,32 +33,37 @@ removelink() {
 work_file="$(mktemp)"
 act_file="$(mktemp)"
 
-trap 'rm -f ${work_file} ${act_file}' EXIT
+# attempt to clean up temporary files on exit
+trap 'rm -f -- "${work_file}" "${act_file}"' EXIT
+trap 'exit' INT TERM
 
-find "${BASEDIR}" -not -path "${BASEDIR}/${STOWDIR}*" -type l >"${work_file}" || echo "Find skipped some files"
+find "${BASEDIR}" \! -path '*
+*' \! -path "${BASEDIR}/${STOWDIR}*" -type l >"${work_file}" || \
+	printf "Find skipped some files\n" >&2
 
 while read -r f; do
-	target="$($READLINK -f "${f}" || echo '')"
-	if [[ "${target}" == "${BASEDIR}/${STOWDIR}/"* ]]; then
-		echo "Add $f"
-		echo "${f}" >>"${act_file}"
-	fi
+	target="$("${READLINK}" -f -- "${f}" || :)"
+	case "${target}" in
+		"${BASEDIR}/${STOWDIR}/"*)
+			printf 'Add %s\n' "${f}" >&2
+			printf '%s\n' "${f}" >>"${act_file}"
+			;;
+	esac
 done <"${work_file}"
 
-read -p "Migrate the above to chezmoi? y/N" -r migrate
+printf 'Migrate the above to chezmoi? y/N ' >&2
+read -r migrate
 case "${migrate}" in
-[Yy]*)
-	echo "Migrating..."
-	;;
-*) exit 1 ;;
+	[Yy]*) printf 'Migrating...\n' >&2 ;;
+	*) exit 1 ;;
 esac
 
-mkdir -p "${BASEDIR}/.local/share"
+mkdir -p -- "${BASEDIR}/.local/share"
 
 while read -r f; do
 	if removelink "${f}"; then
-		chezmoi --source "${BASEDIR}/.local/share/chezmoi" --destination "${BASEDIR}" add "${f}"
+		chezmoi --source "${BASEDIR}/.local/share/chezmoi" --destination "${BASEDIR}" add -- "${f}"
 	else
-		echo "Unable to move: $f"
+		printf 'Unable to move: %s\n' "${f}" >&2
 	fi
 done <"${act_file}"

--- a/internal/cmds/generate-install.sh/install.sh.tmpl
+++ b/internal/cmds/generate-install.sh/install.sh.tmpl
@@ -7,19 +7,19 @@
 
 set -e
 
-BINDIR=${BINDIR:-./bin}
-CHEZMOI_USER_REPO=${CHEZMOI_USER_REPO:-twpayne/chezmoi}
+BINDIR="${BINDIR:-./bin}"
+CHEZMOI_USER_REPO="${CHEZMOI_USER_REPO:-twpayne/chezmoi}"
 TAGARG=latest
 LOG_LEVEL=2
-EXECARGS=
 
-GITHUB_DOWNLOAD=https://github.com/${CHEZMOI_USER_REPO}/releases/download
+GITHUB_DOWNLOAD="https://github.com/${CHEZMOI_USER_REPO}/releases/download"
 
-tmpdir=$(mktemp -d)
-trap 'rm -rf ${tmpdir}' EXIT
+tmpdir="$(mktemp -d)"
+trap 'rm -rf -- "${tmpdir}"' EXIT
+trap 'exit' INT TERM
 
 usage() {
-	this="$1"
+	this="${1}"
 	cat <<EOF
 ${this}: download chezmoi and optionally run chezmoi
 
@@ -33,13 +33,14 @@ EOF
 }
 
 main() {
-	parse_args "$@"
+	parse_args "${@}"
+	shift "$((OPTIND - 1))"
 
-	GOOS=$(get_goos)
-	GOARCH=$(get_goarch)
+	GOOS="$(get_goos)"
+	GOARCH="$(get_goarch)"
 	check_goos_goarch "${GOOS}/${GOARCH}"
 
-	TAG="$(real_tag $TAGARG)"
+	TAG="$(real_tag "${TAGARG}")"
 	VERSION="${TAG#v}"
 
 	log_info "found version ${VERSION} for ${TAGARG}/${GOOS}/${GOARCH}"
@@ -85,19 +86,18 @@ main() {
 	# verify checksums
 	hash_sha256_verify "${tmpdir}/${TARBALL}" "${tmpdir}/${CHECKSUMS}"
 
-	(cd "${tmpdir}" && untar "${TARBALL}")
+	(cd -- "${tmpdir}" && untar "${TARBALL}")
 
 	# install binary
 	if [ ! -d "${BINDIR}" ]; then
 		install -d "${BINDIR}"
 	fi
 	BINARY="chezmoi${BINSUFFIX}"
-	install "${tmpdir}/${BINARY}" "${BINDIR}/"
+	install -t "${BINDIR}/" "${tmpdir}/${BINARY}"
 	log_info "installed ${BINDIR}/${BINARY}"
 
-	if [ -n "${EXECARGS}" ]; then
-		# shellcheck disable=SC2086
-		exec "${BINDIR}/${BINARY}" $EXECARGS
+	if [ -n "${1+n}" ]; then
+		exec "${BINDIR}/${BINARY}" "${@}"
 	fi
 }
 
@@ -106,23 +106,21 @@ parse_args() {
 		case "${arg}" in
 		b) BINDIR="${OPTARG}" ;;
 		d) LOG_LEVEL=3 ;;
-		h | \?) usage "$0" ;;
+		h | \?) usage "${0}" ;;
 		t) TAGARG="${OPTARG}" ;;
 		*) return 1 ;;
 		esac
 	done
-	shift $((OPTIND - 1))
-	EXECARGS="$*"
 }
 
 get_goos() {
-	os=$(uname -s | tr '[:upper:]' '[:lower:]')
+	os="$(uname -s | tr '[:upper:]' '[:lower:]')"
 	case "${os}" in
 	cygwin_nt*) goos="windows" ;;
 	mingw*) goos="windows" ;;
 	msys_nt*) goos="windows" ;;
 	sunos*)
-		kernel=$(uname -o | tr '[:upper:]' '[:lower:]')
+		kernel="$(uname -o | tr '[:upper:]' '[:lower:]')"
 		case "${kernel}" in
 		illumos*) goos="illumos" ;;
 		solaris*) goos="solaris" ;;
@@ -131,11 +129,11 @@ get_goos() {
 		;;
 	*) goos="${os}" ;;
 	esac
-	echo "${goos}"
+	printf '%s' "${goos}"
 }
 
 get_goarch() {
-	arch=$(uname -m)
+	arch="$(uname -m)"
 	case "${arch}" in
 	aarch64) goarch="arm64" ;;
 	armv*) goarch="arm" ;;
@@ -146,16 +144,16 @@ get_goarch() {
 	x86_64) goarch="amd64" ;;
 	*) goarch="${arch}" ;;
 	esac
-	echo "${goarch}"
+	printf '%s' "${goarch}"
 }
 
 check_goos_goarch() {
-	case "$1" in
+	case "${1}" in
 {{- range .Platforms }}
 	{{ .GOOS }}/{{ .GOARCH }}) return 0 ;;
 {{- end }}
 	*)
-		echo "$1: unsupported platform" 1>&2
+		printf '%s: unsupported platform\n' "${1}" 1>&2
 		return 1
 		;;
 	esac
@@ -164,12 +162,12 @@ check_goos_goarch() {
 get_libc() {
 	if is_command ldd; then
 		case "$(ldd --version 2>&1 | tr '[:upper:]' '[:lower:]')" in
-		*glibc*|"*gnu libc*")
-			echo glibc
+		*glibc*|*"gnu libc"*)
+			printf glibc
 			return
 			;;
 		*musl*)
-			echo musl
+			printf musl
 			return
 			;;
 		esac
@@ -177,7 +175,7 @@ get_libc() {
 	if is_command getconf; then
 		case "$(getconf GNU_LIBC_VERSION 2>&1)" in
 		*glibc*)
-			echo glibc
+			printf glibc
 			return
 			;;
 		esac
@@ -187,15 +185,15 @@ get_libc() {
 }
 
 real_tag() {
-	tag=$1
+	tag="${1}"
 	log_debug "checking GitHub for tag ${tag}"
 	release_url="https://github.com/${CHEZMOI_USER_REPO}/releases/${tag}"
-	json=$(http_get "${release_url}" "Accept: application/json")
+	json="$(http_get "${release_url}" "Accept: application/json")"
 	if [ -z "${json}" ]; then
 		log_err "real_tag error retrieving GitHub release ${tag}"
 		return 1
 	fi
-	real_tag=$(echo "${json}" | tr -s '\n' ' ' | sed 's/.*"tag_name":"//' | sed 's/".*//')
+	real_tag="$(printf '%s\n' "${json}" | tr -s '\n' ' ' | sed 's/.*"tag_name":"//' | sed 's/".*//')"
 	if [ -z "${real_tag}" ]; then
 		log_err "real_tag error determining real tag of GitHub release ${tag}"
 		return 1
@@ -204,25 +202,25 @@ real_tag() {
 		return 1
 	fi
 	log_debug "found tag ${real_tag} for ${tag}"
-	echo "${real_tag}"
+	printf '%s' "${real_tag}"
 }
 
 http_get() {
-	tmpfile=$(mktemp)
-	http_download "${tmpfile}" "$1" "$2" || return 1
-	body=$(cat "${tmpfile}")
+	tmpfile="$(mktemp)"
+	http_download "${tmpfile}" "${1}" "${2}" || return 1
+	body="$(cat "${tmpfile}")"
 	rm -f "${tmpfile}"
-	echo "${body}"
+	printf '%s\n' "${body}"
 }
 
 http_download_curl() {
-	local_file=$1
-	source_url=$2
-	header=$3
+	local_file="${1}"
+	source_url="${2}"
+	header="${3}"
 	if [ -z "${header}" ]; then
-		code=$(curl -w '%{http_code}' -sL -o "${local_file}" "${source_url}")
+		code="$(curl -w '%{http_code}' -sL -o "${local_file}" "${source_url}")"
 	else
-		code=$(curl -w '%{http_code}' -sL -H "${header}" -o "${local_file}" "${source_url}")
+		code="$(curl -w '%{http_code}' -sL -H "${header}" -o "${local_file}" "${source_url}")"
 	fi
 	if [ "${code}" != "200" ]; then
 		log_debug "http_download_curl received HTTP status ${code}"
@@ -232,9 +230,9 @@ http_download_curl() {
 }
 
 http_download_wget() {
-	local_file=$1
-	source_url=$2
-	header=$3
+	local_file="${1}"
+	source_url="${2}"
+	header="${3}"
 	if [ -z "${header}" ]; then
 		wget -q -O "${local_file}" "${source_url}" || return 1
 	else
@@ -243,12 +241,12 @@ http_download_wget() {
 }
 
 http_download() {
-	log_debug "http_download $2"
+	log_debug "http_download ${2}"
 	if is_command curl; then
-		http_download_curl "$@" || return 1
+		http_download_curl "${@}" || return 1
 		return
 	elif is_command wget; then
-		http_download_wget "$@" || return 1
+		http_download_wget "${@}" || return 1
 		return
 	fi
 	log_crit "http_download unable to find wget or curl"
@@ -256,19 +254,19 @@ http_download() {
 }
 
 hash_sha256() {
-	target=$1
+	target="${1}"
 	if is_command sha256sum; then
-		hash=$(sha256sum "${target}") || return 1
-		echo "${hash}" | cut -d ' ' -f 1
+		hash="$(sha256sum "${target}")" || return 1
+		printf '%s' "${hash}" | cut -d ' ' -f 1
 	elif is_command shasum; then
-		hash=$(shasum -a 256 "${target}" 2>/dev/null) || return 1
-		echo "${hash}" | cut -d ' ' -f 1
+		hash="$(shasum -a 256 "${target}" 2>/dev/null)" || return 1
+		printf '%s' "${hash}" | cut -d ' ' -f 1
 	elif is_command sha256; then
-		hash=$(sha256 -q "${target}" 2>/dev/null) || return 1
-		echo "${hash}" | cut -d ' ' -f 1
+		hash="$(sha256 -q "${target}" 2>/dev/null)" || return 1
+		printf '%s' "${hash}" | cut -d ' ' -f 1
 	elif is_command openssl; then
-		hash=$(openssl dgst -sha256 "${target}") || return 1
-		echo "${hash}" | cut -d ' ' -f a
+		hash="$(openssl dgst -sha256 "${target}")" || return 1
+		printf '%s' "${hash}" | cut -d ' ' -f a
 	else
 		log_crit "hash_sha256 unable to find command to compute SHA256 hash"
 		return 1
@@ -276,17 +274,17 @@ hash_sha256() {
 }
 
 hash_sha256_verify() {
-	target=$1
-	checksums=$2
-	basename=${target##*/}
+	target="${1}"
+	checksums="${2}"
+	basename="${target##*/}"
 
-	want=$(grep "${basename}" "${checksums}" 2>/dev/null | tr '\t' ' ' | cut -d ' ' -f 1)
+	want="$(grep "${basename}" "${checksums}" 2>/dev/null | tr '\t' ' ' | cut -d ' ' -f 1)"
 	if [ -z "${want}" ]; then
 		log_err "hash_sha256_verify unable to find checksum for ${target} in ${checksums}"
 		return 1
 	fi
 
-	got=$(hash_sha256 "${target}")
+	got="$(hash_sha256 "${target}")"
 	if [ "${want}" != "${got}" ]; then
 		log_err "hash_sha256_verify checksum for ${target} did not verify ${want} vs ${got}"
 		return 1
@@ -294,11 +292,11 @@ hash_sha256_verify() {
 }
 
 untar() {
-	tarball=$1
+	tarball="${1}"
 	case "${tarball}" in
 	*.tar.gz | *.tgz) tar -xzf "${tarball}" ;;
 	*.tar) tar -xf "${tarball}" ;;
-	*.zip) unzip "${tarball}" ;;
+	*.zip) unzip -- "${tarball}" ;;
 	*)
 		log_err "untar unknown archive format for ${tarball}"
 		return 1
@@ -307,27 +305,27 @@ untar() {
 }
 
 is_command() {
-	command -v "$1" >/dev/null
+	type "${1}" >/dev/null 2>&1
 }
 
 log_debug() {
 	[ 3 -le "${LOG_LEVEL}" ] || return 0
-	echo debug "$@" 1>&2
+	printf 'debug %s\n' "${*}" 1>&2
 }
 
 log_info() {
 	[ 2 -le "${LOG_LEVEL}" ] || return 0
-	echo info "$@" 1>&2
+	printf 'info %s\n' "${*}" 1>&2
 }
 
 log_err() {
 	[ 1 -le "${LOG_LEVEL}" ] || return 0
-	echo error "$@" 1>&2
+	printf 'error %s\n' "${*}" 1>&2
 }
 
 log_crit() {
 	[ 0 -le "${LOG_LEVEL}" ] || return 0
-	echo critical "$@" 1>&2
+	printf 'critical %s\n' "${*}" 1>&2
 }
 
-main "$@"
+main "${@}"

--- a/internal/cmds/generate-install.sh/install.sh.tmpl
+++ b/internal/cmds/generate-install.sh/install.sh.tmpl
@@ -93,7 +93,7 @@ main() {
 		install -d "${BINDIR}"
 	fi
 	BINARY="chezmoi${BINSUFFIX}"
-	install -t "${BINDIR}/" "${tmpdir}/${BINARY}"
+	install -- "${tmpdir}/${BINARY}" "${BINDIR}/"
 	log_info "installed ${BINDIR}/${BINARY}"
 
 	if [ -n "${1+n}" ]; then


### PR DESCRIPTION
Hello, I've made some improvements to `install.sh` and `stow-to-chezmoi.sh`. I've made sure to update `install.sh.tmpl` and committed the output of generating that.

General improvements:
 * Use `${N}` syntax for all parameter expansions.
 * Supply `--` to commands whose positional arguments are based on environment variables, output of system utilities, or user input. This protects against an argument being interpreted as an option by a command.
 * Avoid use of `echo` which behaves inconsistently between shells and platforms.
 * Clean up temporary files when interrupted by `SIGINT` or `SIGTERM`.

`install.sh` improvements:
 * Quote all variable assignments that involve parameter expansion or command substitution to protect them from pathname expansion and quote removal.
 * Quote parameter expansions that occur within command substitutions.
 * Use `install -t <directory> <file>` instead of `install <file> <hopefully_directory_but_maybe_file>`.
 * Fixed usage of colon in unquoted word (this is unspecified behavior).
 * Rather than relying on unquoted parameter expansion of `${EXECARGS}`, run `shift "$((OPTIND - 1))"` in `main` to and use `"${@}"` to expand parameters as-is. This makes parameters safe from field splitting, quote removal, and pathname expansion, and fixes a suppressed shellcheck warning.

`stow-to-chezmoi.sh` improvements:
 * Change shebang from `/usr/bin/env bash` to `/bin/sh`. I'm fairly certain there was only one bashism in the entire script (there was also a nonstandard `echo` option, but `dash` has this too; still, `printf` is better).
 * Replace unnecessary `which` command with `command -v` (a standard shell builtin). This fixes a shellcheck warning.
 * Account for trailing whitespace in resolved symbolic links.
 * Filter out paths that contain line feeds to avoid confusing the `read` builtin.
 * Replace usage of nonstandard `read -p` by instead printing the prompt with `printf`.