### PR TITLE
docs: Refactor Windows chassisType template

### DIFF
--- a/assets/chezmoi.io/docs/user-guide/machines/general.md
+++ b/assets/chezmoi.io/docs/user-guide/machines/general.md
@@ -16,6 +16,6 @@ The following template sets the `$chassisType` variable to `"desktop"` or
 {{- else if eq .chezmoi.os "linux" }}
 {{-   $chassisType = (output "hostnamectl" "--json=short" | mustFromJson).Chassis }}
 {{- else if eq .chezmoi.os "windows" }}
-{{-   $chassisType = (output "powershell.exe" "-noprofile" "-command" "if (Get-WmiObject -Class win32_battery -ComputerName localhost) { echo laptop } else { echo desktop }") }}
+{{-   $chassisType = (output "powershell.exe" "-NoProfile" "-NonInteractive" "-Command" "if ((Get-CimInstance -Class Win32_Battery | Measure-Object).Count -gt 0) { Write-Output 'laptop' } else { Write-Output 'desktop' }") | trim }}
 {{- end }}
 ```


### PR DESCRIPTION
- WMI cmdlets have been [deprecated in favor of CIM](https://docs.microsoft.com/en-us/powershell/scripting/learn/ps101/07-working-with-wmi?view=powershell-7.2) for some time now:

    > The WMI cmdlets are deprecated so my recommendation is to use the CIM cmdlets instead of the older WMI ones.

- In PowerShell, `echo` is an alias for `Write-Output`, but it's possible to reassign the alias to something else, so it's better to be explicit.
- `trim` is required to remove the dangling CRLF line ending. Without this, the result is:
    ```toml
    [data]
    chassistype = "desktop\r\n" # or chassistype = "laptop\r\n"
    ```