### PR TITLE
Add arguments to "chezmoi unmanaged" and "chezmoi managed"

### DIFF
--- a/assets/chezmoi.io/docs/reference/commands/managed.md
+++ b/assets/chezmoi.io/docs/reference/commands/managed.md
@@ -1,6 +1,8 @@
-# `managed`
+# `managed` [*target*...]
 
-List all managed entries in the destination directory in alphabetical order.
+List all managed entries in the destination directory under all *target*s in
+alphabetical order.  When no *target*s are supplied, list all managed entries in
+the destination directory in alphabetical order.
 
 ## `-i`, `--include` *types*
 
@@ -14,4 +16,5 @@ Only include entries of type *types*.
     $ chezmoi managed --include=files,symlinks
     $ chezmoi managed -i dirs
     $ chezmoi managed -i dirs,files
+    $ chezmoi managed -i files ~/.config
     ```

--- a/assets/chezmoi.io/docs/reference/commands/unmanaged.md
+++ b/assets/chezmoi.io/docs/reference/commands/unmanaged.md
@@ -1,9 +1,13 @@
-# `unmanaged`
+# `unmanaged` [*target*...]
 
-List all unmanaged files in the destination directory.
+List all unmanaged files in *target*s.  When no *target*s are supplied, list all
+unmanaged files in the destination directory.
+
+It is an error to supply *target*s that are not found on the filesystem.
 
 !!! example
 
     ```console
     $ chezmoi unmanaged
+    $ chezmoi unmanaged ~/.config/chezmoi ~/.ssh
     ```

--- a/pkg/cmd/testdata/scripts/managed.txt
+++ b/pkg/cmd/testdata/scripts/managed.txt
@@ -24,6 +24,22 @@ cmp stdout golden/managed-symlinks
 chezmoi managed --exclude=files
 cmp stdout golden/managed-except-files
 
+# test chezmoi managed with arguments
+chezmoi managed $HOME${/}.dir $HOME${/}.create
+cmp stdout golden/managed-with-args
+
+# test chezmoi managed with child of managed dir as argument
+chezmoi managed $HOME${/}.dir/subdir
+cmp stdout golden/managed-in-managed
+
+# test chezmoi managed --exclude=dir with arguments
+chezmoi managed --exclude=dirs $HOME${/}.dir $HOME${/}.create
+cmp stdout golden/managed-with-nodir-args
+
+# test chezmoi managed with absent arguments
+chezmoi managed $HOME${/}.dir $HOME${/}.non-exist
+cmp stdout golden/managed-with-absent-args
+
 chhome home2/user
 
 # test that chezmoi managed does not evaluate templates
@@ -84,6 +100,24 @@ cmp stdout golden/managed2
 .symlink
 .template
 script
+-- golden/managed-with-args --
+.create
+.dir
+.dir/file
+.dir/subdir
+.dir/subdir/file
+-- golden/managed-in-managed --
+.dir/subdir
+.dir/subdir/file
+-- golden/managed-with-nodir-args --
+.create
+.dir/file
+.dir/subdir/file
+-- golden/managed-with-absent-args --
+.dir
+.dir/file
+.dir/subdir
+.dir/subdir/file
 -- home/user/.local/share/chezmoi/.chezmoiremove --
 .remove
 -- home2/user/.local/share/chezmoi/create_dot_create.tmpl --

--- a/pkg/cmd/testdata/scripts/unmanaged.txt
+++ b/pkg/cmd/testdata/scripts/unmanaged.txt
@@ -12,6 +12,21 @@ rm $CHEZMOISOURCEDIR/dot_file
 chezmoi unmanaged
 cmp stdout golden/unmanaged-dir-file
 
+# test chezmoi unmanaged with arguments
+chezmoi unmanaged $HOME${/}.dir $HOME${/}.file
+cmp stdout golden/unmanaged-with-args
+
+# test chezmoi unmanaged, with child of unmanaged dir as argument
+chezmoi unmanaged $HOME${/}.dir/subdir
+cmp stdout golden/unmanaged-inside-unmanaged
+
+# test chezmoi unmanaged with managed arguments
+chezmoi unmanaged $HOME${/}.create $HOME${/}.file
+cmp stdout golden/unmanaged-with-some-managed
+
+# test that chezmoi unmanaged with absent paths should fail
+! chezmoi unmanaged $HOME${/}absent-path
+
 -- golden/unmanaged --
 .local
 -- golden/unmanaged-dir --
@@ -21,3 +36,10 @@ cmp stdout golden/unmanaged-dir-file
 .dir
 .file
 .local
+-- golden/unmanaged-with-args --
+.dir
+.file
+-- golden/unmanaged-inside-unmanaged --
+.dir/subdir
+-- golden/unmanaged-with-some-managed --
+.file

--- a/pkg/cmd/unmanagedcmd.go
+++ b/pkg/cmd/unmanagedcmd.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"io/fs"
+	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -12,11 +13,11 @@ import (
 
 func (c *Config) newUnmanagedCmd() *cobra.Command {
 	unmanagedCmd := &cobra.Command{
-		Use:     "unmanaged",
+		Use:     "unmanaged [paths]...",
 		Short:   "List the unmanaged files in the destination directory",
 		Long:    mustLongHelp("unmanaged"),
 		Example: example("unmanaged"),
-		Args:    cobra.NoArgs,
+		Args:    cobra.ArbitraryArgs,
 		RunE:    c.makeRunEWithSourceState(c.runUnmanagedCmd),
 	}
 
@@ -24,7 +25,8 @@ func (c *Config) newUnmanagedCmd() *cobra.Command {
 }
 
 func (c *Config) runUnmanagedCmd(cmd *cobra.Command, args []string, sourceState *chezmoi.SourceState) error {
-	builder := strings.Builder{}
+	// the set of discovered, unmanaged items
+	unmanaged := map[string]bool{}
 	walkFunc := func(destAbsPath chezmoi.AbsPath, fileInfo fs.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -32,20 +34,59 @@ func (c *Config) runUnmanagedCmd(cmd *cobra.Command, args []string, sourceState 
 		if destAbsPath == c.DestDirAbsPath {
 			return nil
 		}
-		targeRelPath := destAbsPath.MustTrimDirPrefix(c.DestDirAbsPath)
-		managed := sourceState.Contains(targeRelPath)
-		ignored := sourceState.Ignore(targeRelPath)
+		targetRelPath, err := destAbsPath.TrimDirPrefix(c.DestDirAbsPath)
+		if err != nil {
+			return err
+		}
+		managed := sourceState.Contains(targetRelPath)
+		ignored := sourceState.Ignore(targetRelPath)
 		if !managed && !ignored {
-			builder.WriteString(targeRelPath.String())
-			builder.WriteByte('\n')
+			unmanaged[targetRelPath.String()] = true
 		}
 		if fileInfo.IsDir() && (!managed || ignored) {
 			return vfs.SkipDir
 		}
 		return nil
 	}
-	if err := chezmoi.Walk(c.destSystem, c.DestDirAbsPath, walkFunc); err != nil {
-		return err
+
+	// Build queued paths. When no arguments, start from root; otherwise start
+	// from arguments.	The paths are deduplicated and sorted.
+	paths := make([]chezmoi.AbsPath, 0, len(args)) // (lsttype, size, capacity)
+	if len(args) == 0 {
+		paths = append(paths, c.DestDirAbsPath)
+	} else {
+		qPaths := make(map[chezmoi.AbsPath]bool, len(args)) // (map, capacity)
+		for _, arg := range args {
+			p, err := chezmoi.NormalizePath(arg)
+			if err != nil {
+				return err
+			}
+			qPaths[p] = true
+		}
+		for path := range qPaths {
+			paths = append(paths, path)
+		}
+		sort.Slice(paths,
+			func(i, j int) bool { return paths[i].Less(paths[j]) })
+	}
+
+	for _, path := range paths {
+		if err := chezmoi.Walk(c.destSystem, path, walkFunc); err != nil {
+			return err
+		}
+	}
+
+	// collect the keys and sort
+	builder := strings.Builder{}
+	unmPaths := make([]string, 0, len(unmanaged))
+	for path := range unmanaged {
+		unmPaths = append(unmPaths, path)
+	}
+	sort.Strings(unmPaths)
+
+	for _, path := range unmPaths {
+		builder.WriteString(path)
+		builder.WriteByte('\n')
 	}
 	return c.writeOutputString(builder.String())
 }


### PR DESCRIPTION
Fixes twpayne/chezmoi#1985.

Allow arguments on chezmoi managed and unmanaged.  Per recommendations on twpayne/chezmoi#1985, no additional flags are added to either commands, and behaviors are very similar to the respective commands without arguments (such as not recursing into directories).


``` console
$ chezmoi unmanaged ~/.ssh ~/.gnupg
(list unmanaged files under the arguments)
$ chezmoi managed ~/.config/git ~/scripts
(list managed files under the arguments)
```

Note that in consideration of duplicated arguments and outputs, sorting and deduplication is done on both the arguments and the outputs for unmanaged, and on the outputs for managed.  This helps with the following hypothetical situation (exaggerated to hopefully convey the idea more clearly):

``` console
$ chezmoi unmanaged ~/{,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,}
(extremely duplicated lines of output)
$ chezmoi unmanaged ~/.config/{,a,b,c,d,e,f,g,h,*}
(outputs for a..h are duplicated many times)
```


<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer/contributing-changes/

-->