### PR TITLE
chore: Give a more explicit error when target is not in dest dir

### DIFF
--- a/pkg/chezmoi/abspath.go
+++ b/pkg/chezmoi/abspath.go
@@ -151,7 +151,7 @@ func (p AbsPath) TrimDirPrefix(dirPrefixAbsPath AbsPath) (RelPath, error) {
 		dirAbsPath.absPath += "/"
 	}
 	if !strings.HasPrefix(p.absPath, dirAbsPath.absPath) {
-		return EmptyRelPath, &notInAbsDirError{
+		return EmptyRelPath, &NotInAbsDirError{
 			pathAbsPath: p,
 			dirAbsPath:  dirPrefixAbsPath,
 		}

--- a/pkg/chezmoi/errors.go
+++ b/pkg/chezmoi/errors.go
@@ -36,12 +36,12 @@ func (e *inconsistentStateError) Error() string {
 	return fmt.Sprintf("%s: inconsistent state (%s)", e.targetRelPath, strings.Join(e.origins, ", "))
 }
 
-type notInAbsDirError struct {
+type NotInAbsDirError struct {
 	pathAbsPath AbsPath
 	dirAbsPath  AbsPath
 }
 
-func (e *notInAbsDirError) Error() string {
+func (e *NotInAbsDirError) Error() string {
 	return fmt.Sprintf("%s: not in %s", e.pathAbsPath, e.dirAbsPath)
 }
 

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -1023,7 +1023,7 @@ func (c *Config) destAbsPathInfos(
 		if err != nil {
 			return nil, err
 		}
-		if _, err := destAbsPath.TrimDirPrefix(c.DestDirAbsPath); err != nil {
+		if _, err := c.targetRelPath(destAbsPath); err != nil {
 			return nil, err
 		}
 		if options.recursive {
@@ -1940,6 +1940,15 @@ func (c *Config) sourceDirAbsPath() (chezmoi.AbsPath, error) {
 	}
 }
 
+func (c *Config) targetRelPath(absPath chezmoi.AbsPath) (chezmoi.RelPath, error) {
+	relPath, err := absPath.TrimDirPrefix(c.DestDirAbsPath)
+	var notInAbsDirError *chezmoi.NotInAbsDirError
+	if errors.As(err, &notInAbsDirError) {
+		return chezmoi.EmptyRelPath, fmt.Errorf("%s: not in destination directory (%s)", absPath, c.DestDirAbsPath)
+	}
+	return relPath, err
+}
+
 type targetRelPathsOptions struct {
 	mustBeInSourceState bool
 	recursive           bool
@@ -1956,7 +1965,7 @@ func (c *Config) targetRelPaths(
 		if err != nil {
 			return nil, err
 		}
-		targetRelPath, err := argAbsPath.TrimDirPrefix(c.DestDirAbsPath)
+		targetRelPath, err := c.targetRelPath(argAbsPath)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cmd/testdata/scripts/cat.txt
+++ b/pkg/cmd/testdata/scripts/cat.txt
@@ -23,7 +23,7 @@ stderr 'not a file, script, or symlink'
 
 # test that chezmoi cat does not print files outside the destination directory
 ! chezmoi cat ${/}etc${/}passwd
-stderr 'not in'
+stderr 'not in destination directory'
 
 # test that chezmoi cat uses relative paths
 mkdir $HOME/.dir


### PR DESCRIPTION
Fixes #2124.