### PR TITLE
Add tests for multiple GPG encryption recipients

### DIFF
--- a/pkg/chezmoi/gpgencryption_test.go
+++ b/pkg/chezmoi/gpgencryption_test.go
@@ -47,3 +47,51 @@ func TestGPGEncryption(t *testing.T) {
 		})
 	}
 }
+
+func TestGPGEncryptionMultipleRecipients(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping gpg tests on Windows")
+	}
+	command := lookPathOrSkip(t, "gpg")
+
+	tempDir := t.TempDir()
+
+	// Generate two GPG private keys for testing in the same GNUPGHOME.
+	// NOTE: GPGGenerateKey returns a fixed password, so using the same variable for both keys is acceptable.
+	key1, passphrase, err1 := chezmoitest.GPGGenerateKey(command, tempDir)
+	require.NoError(t, err1)
+
+	key2, _, err2 := chezmoitest.GPGGenerateKey(command, tempDir)
+	require.NoError(t, err2)
+
+	for _, tc := range []struct {
+		name      string
+		symmetric bool
+	}{
+		{
+			name:      "asymmetric",
+			symmetric: false,
+		},
+		{
+			name:      "symmetric",
+			symmetric: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			testEncryption(t, &GPGEncryption{
+				Command: command,
+				Args: []string{
+					"--homedir", tempDir,
+					"--no-tty",
+					"--passphrase", passphrase,
+					"--pinentry-mode", "loopback",
+				},
+				Recipients: []string{
+					key1,
+					key2,
+				},
+				Symmetric: tc.symmetric,
+			})
+		})
+	}
+}

--- a/pkg/chezmoitest/chezmoitest.go
+++ b/pkg/chezmoitest/chezmoitest.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/twpayne/go-vfs/v4"
 	"github.com/twpayne/go-vfs/v4/vfst"
@@ -38,7 +39,8 @@ func AgeGenerateKey(identityFile string) (string, error) {
 // GPGGenerateKey generates GPG key in homeDir and returns the key and the
 // passphrase.
 func GPGGenerateKey(command, homeDir string) (key, passphrase string, err error) {
-	key = "chezmoi-test-gpg-key"
+	// Append a random string (in the form of a UUID) to ensure unique key identifiers during multi-recipient tests
+	key = fmt.Sprintf("chezmoi-test-gpg-key_%s", uuid.New())
 	//nolint:gosec
 	passphrase = "chezmoi-test-gpg-passphrase"
 	cmd := exec.Command(


### PR DESCRIPTION
As a followup to #2140 this adds a unit test for a configuration with 2 active GPG keys listed in `gpg.recipients`.

Please feel free to refactor this, I am not nor do I currently pretend to be a Go developer, so if duplicating the entire test function wasn't the best approach I understand. :)

**Testing done/passed:**
- [x] `go build`
- [x] `go test ./...`
- [x] `make smoketest`