### PR TITLE
docs: Add CPU cores/threads template

### DIFF
--- a/assets/chezmoi.io/docs/user-guide/machines/general.md
+++ b/assets/chezmoi.io/docs/user-guide/machines/general.md
@@ -19,3 +19,39 @@ The following template sets the `$chassisType` variable to `"desktop"` or
 {{-   $chassisType = (output "powershell.exe" "-NoProfile" "-NonInteractive" "-Command" "if ((Get-CimInstance -Class Win32_Battery | Measure-Object).Count -gt 0) { Write-Output 'laptop' } else { Write-Output 'desktop' }") | trim }}
 {{- end }}
 ```
+
+## Determine how many CPU cores and threads the current machine has
+
+The following template sets the `$cpuCores` and `$cpuThreads` variables to the
+number of CPU cores and threads on the current machine respectively on
+macOS, Linux and Windows.
+
+```
+{{- $cpuCores := 1 }}
+{{- $cpuThreads := 1 }}
+{{- if eq .chezmoi.os "darwin" }}
+{{-   $cpuCores = (output "sysctl" "-n" "hw.physicalcpu_max") | trim | atoi }}
+{{-   $cpuThreads = (output "sysctl" "-n" "hw.logicalcpu_max") | trim | atoi }}
+{{- else if eq .chezmoi.os "linux" }}
+{{-   $cpuCores = (output "sh" "-c" "lscpu --online --parse | grep --invert-match '^#' | sort --field-separator=',' --key='2,4' --unique | wc --lines") | trim | atoi }}
+{{-   $cpuThreads = (output "sh" "-c" "lscpu --online --parse | grep --invert-match '^#' | wc --lines") | trim | atoi }}
+{{- else if eq .chezmoi.os "windows" }}
+{{-   $cpuCores = (output "powershell.exe" "-NoProfile" "-NonInteractive" "-Command" "(Get-CimInstance -ClassName 'Win32_Processor').NumberOfCores") | trim | atoi }}
+{{-   $cpuThreads = (output "powershell.exe" "-NoProfile" "-NonInteractive" "-Command" "(Get-CimInstance -ClassName 'Win32_Processor').NumberOfLogicalProcessors") | trim | atoi }}
+{{- end }}
+```
+
+!!! example
+    ``` title="~/.local/share/chezmoi/chezmoi.toml.tmpl"
+    [data.cpu]
+    cores = {{ $cpuCores }}
+    threads = {{ $cpuThreads }}
+    ```
+
+    ``` title="~/.local/share/chezmoi/is_hyperthreaded.txt.tmpl"
+    {{- if gt .cpu.threads .cpu.cores -}}
+    Hyperthreaded!
+    {{- else -}}
+    Not hyperthreaded!
+    {{- end -}}
+    ```


### PR DESCRIPTION
Tested with:
- 4c/4t desktop (Windows + Linux)
- 2c/4t laptop (Windows + Linux)
- 4c/8t 2015 MacBook Pro (Darwin)