### PR TITLE
chore: Skip zip tests on Windows

### DIFF
--- a/pkg/cmd/testdata/scripts/archivezip.txt
+++ b/pkg/cmd/testdata/scripts/archivezip.txt
@@ -1,3 +1,4 @@
+[windows] skip 'windows line endings confuse cmp and diff'
 [!exec:unzip] skip 'unzip not found in $PATH'
 
 mksourcedir

--- a/pkg/cmd/testdata/scripts/externalzip.txt
+++ b/pkg/cmd/testdata/scripts/externalzip.txt
@@ -1,3 +1,4 @@
+[windows] skip 'zip may not support the --symlinks option'
 [!exec:zip] skip 'zip not found in $PATH'
 symlink archive/dir/symlink -> file
 exec zip -r --symlinks www/archive.zip archive


### PR DESCRIPTION
Fixes #2169.
Fixes #2171.
Closes #2170.