### PR TITLE
2181: make install creates bin/ dir and uses unambiguous --target-directory install syntax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,8 @@ endif
 
 .PHONY: install
 install: build
-	install -m 755 chezmoi "${DESTDIR}${PREFIX}/bin"
+	mkdir -p "${DESTDIR}${PREFIX}/bin" && \
+	install -m 755 --target-directory "${DESTDIR}${PREFIX}/bin" chezmoi
 
 .PHONY: install-from-git-working-copy
 install-from-git-working-copy:


### PR DESCRIPTION
Resolves #2181. See this issue for detailed description.

I confirmed that even with the `--target-directory` option specified, `install` will not create the target directory, it must pre-exist. So I've modified the `install` target thusly:

```
   install: build
  -  install -m 755 chezmoi "${DESTDIR}${PREFIX}/bin"
  +  mkdir -p "${DESTDIR}${PREFIX}/bin" && \
  +  install -m 755 --target-directory "${DESTDIR}${PREFIX}/bin" chezmoi
```

and tested it and it works as expected. Note that this will also create any non-existent intermediate paths ($DESTDIR/$PREFIX) however, this seems desirable as well.

`make test/format/lint` all succeed, and `make generate` creates nothing to commit.

<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer/contributing-changes/

-->
