### PR TITLE
chore: Ignore virtualenv in website directory

### DIFF
--- a/assets/chezmoi.io/.gitignore
+++ b/assets/chezmoi.io/.gitignore
@@ -2,3 +2,8 @@ __pycache__
 /docs/install.md
 /docs/links/articles-podcasts-and-videos.md
 /site
+
+/.venv
+/.virtualenv
+/venv
+/virtualenv


### PR DESCRIPTION
This should prevent common `virtualenv` directory names (`{.}v{irtual}env`) from showing under `git status` etc. when working on website changes.