### PR TITLE
add documentation for muting gpg output

### DIFF
--- a/assets/chezmoi.io/docs/user-guide/encryption/gpg.md
+++ b/assets/chezmoi.io/docs/user-guide/encryption/gpg.md
@@ -83,3 +83,14 @@ encryption = "gpg"
 
 This will prompt you for the passphrase the first time you run `chezmoi init` on
 a new machine, and then remember the passphrase in your configuration file.
+
+## Muting gpg output
+
+Since gpg sends some info messages to stderr instead of stdout, you will see some output even if you redirect stdout to to `/dev/null`.
+
+You can mute this by adding `"--quiet"` to the `gpg.args` key in your configuration:
+
+``` title="~/.local/share/chezmoi/.chezmoi.toml.tmpl"
+[gpg]
+    args = ["--quiet"]
+```


### PR DESCRIPTION
gpg sends some info messages to stderr instead of stdout. This commit
adds documentation on how to mute this output.

Closes #2192

<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer/contributing-changes/

-->
