### PR TITLE
Add `https://` to the `curl` install command

### DIFF
--- a/assets/chezmoi.io/docs/index.md
+++ b/assets/chezmoi.io/docs/index.md
@@ -7,7 +7,7 @@ dotfiles from your GitHub dotfiles repo on a new, empty machine with a single
 command:
 
 ```console
-$ sh -c "$(curl -fsLS chezmoi.io/get)" -- init --apply $GITHUB_USERNAME
+$ sh -c "$(curl -fsLS https://chezmoi.io/get)" -- init --apply $GITHUB_USERNAME
 ```
 
 Updating your dotfiles on any machine is a single command:


### PR DESCRIPTION
This seems to be a bit more secure, and avoids a redirect to https:

```
❯ curl -v -fsLS chezmoi.io/get | head
*   Trying 185.199.110.153:80...
* Connected to chezmoi.io (185.199.110.153) port 80 (#0)
> GET /get HTTP/1.1
> Host: chezmoi.io
> User-Agent: curl/7.79.1
> Accept: */*
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 301 Moved Permanently
< Server: GitHub.com
< Content-Type: text/html
< Location: https://www.chezmoi.io/get
< X-GitHub-Request-Id: A05C:484F:C695C6:D56E92:62C6EB4B
< Content-Length: 162
< Accept-Ranges: bytes
< Date: Thu, 07 Jul 2022 14:18:56 GMT
< Via: 1.1 varnish
< Age: 5
< Connection: keep-alive
< X-Served-By: cache-lcy19224-LCY
< X-Cache: HIT
< X-Cache-Hits: 1
< X-Timer: S1657203537.680928,VS0,VE1
< Vary: Accept-Encoding
< X-Fastly-Request-ID: 93727f48fe6ea2413282d9d4696446a6661a153e
<
* Ignoring the response-body
```