### PR TITLE
docs: Fix a coloring issue that lines and texts in Mermaid diagrams are hardly visible in dark mode

### DIFF
--- a/assets/chezmoi.io/docs/extra/refresh_on_toggle_dark_light.js
+++ b/assets/chezmoi.io/docs/extra/refresh_on_toggle_dark_light.js
@@ -1,0 +1,10 @@
+var paletteSwitcher1 = document.getElementById("__palette_1");
+var paletteSwitcher2 = document.getElementById("__palette_2");
+
+paletteSwitcher1.addEventListener("change", function () {
+  location.reload();
+});
+
+paletteSwitcher2.addEventListener("change", function () {
+  location.reload();
+});

--- a/assets/chezmoi.io/mkdocs.yml
+++ b/assets/chezmoi.io/mkdocs.yml
@@ -280,7 +280,11 @@ markdown_extensions:
     alternate_style: true
 
 plugins:
-- mermaid2
+- mermaid2:
+    arguments:
+      # test if its __palette_1 (dark) or __palette_2 (light)
+      theme: |
+        ^(JSON.parse(__md_get("__palette").index == 1)) ? 'dark' : 'light'
 - mkdocs-simple-hooks:
     hooks:
       on_pre_build: "docs.hooks:on_pre_build"
@@ -301,3 +305,6 @@ plugins:
       docs/security.md: developer/security.md
       docs/templating.md: user-guide/templating.md
 - search
+
+extra_javascript:
+- extra/refresh_on_toggle_dark_light.js


### PR DESCRIPTION
Mermaid diagrams in the documentation are currently hardly visible in dark mode.
It is because they are not switched on the fly between light and dark mode and hence they are displayed using light mode colors in both mode.

This PR fixes that issue, thanks to descriptions and instructions in [mkdocs-mermaid2-plugin's README](https://github.com/fralau/mkdocs-mermaid2-plugin/blob/master/README.md#material-theme-switching-the-mermaid-diagram-on-the-fly-between-light-and-dark-mode).