### PR TITLE
feat: Add passhole password manager support

### DIFF
--- a/assets/chezmoi.io/docs/reference/configuration-file/variables.md.yaml
+++ b/assets/chezmoi.io/docs/reference/configuration-file/variables.md.yaml
@@ -216,6 +216,17 @@ sections:
     command:
       default: "`pass`"
       description: "Pass CLI command"
+  passhole:
+    args:
+      type: "[]string"
+      description: "Extra args to Passhole CLI command"
+    command:
+      default: "`ph`"
+      description: "Passhole CLI command"
+    prompt:
+      type: "bool"
+      default: "`true`"
+      description: "Prompt for password"
   pinentry:
     args:
       type: "[]string"

--- a/assets/chezmoi.io/docs/reference/templates/passhole-functions/index.md
+++ b/assets/chezmoi.io/docs/reference/templates/passhole-functions/index.md
@@ -1,0 +1,4 @@
+# Passhole
+
+chezmoi includes support for [Keepass](https://keepass.info/) using the
+[Passhole CLI](https://github.com/Evidlo/passhole) (`ph`).

--- a/assets/chezmoi.io/docs/reference/templates/passhole-functions/passhole.md
+++ b/assets/chezmoi.io/docs/reference/templates/passhole-functions/passhole.md
@@ -1,0 +1,10 @@
+# passhole *path* *field*
+
+`passhole` returns the *field* of *path* from a [Keepass](https://keypass.info/)
+database using [passhole](https://github.com/Evidlo/passhole)'s `ph` command.
+
+!!! example
+
+    ```
+    {{ passhole "example.com" "password" }}
+    ```

--- a/assets/chezmoi.io/docs/user-guide/password-managers/custom.md
+++ b/assets/chezmoi.io/docs/user-guide/password-managers/custom.md
@@ -16,3 +16,4 @@ way:
 | KeePassXC       | `keepassxc-cli`  | Not possible (interactive command only)            |
 | Keeper          | `keeper`         | `{{ secretJSON "get" "--format=json" "$ID" }}`     |
 | pass            | `pass`           | `{{ secret "show" "$ID" }}`                        |
+| passhole        | `ph`             | `{{ secret "$ID" "password" }}`                    |

--- a/assets/chezmoi.io/docs/user-guide/password-managers/passhole.md
+++ b/assets/chezmoi.io/docs/user-guide/password-managers/passhole.md
@@ -1,0 +1,5 @@
+# Passhole
+
+chezmoi includes support for [KeePass](https://keepass.info/) using the
+[passhole CLI](https://github.com/Evidlo/passhole) (`ph`) to expose data as a
+template function.

--- a/assets/chezmoi.io/docs/what-does-chezmoi-do.md
+++ b/assets/chezmoi.io/docs/what-does-chezmoi-do.md
@@ -42,14 +42,15 @@ FreeBSD, OpenBSD, and Termux.
 Nothing leaves your machine, unless you want it to. Your configuration remains
 in a git repo under your control. You can write the configuration file in the
 format of your choice. chezmoi can retrieve secrets from
-[1Password](https://1password.com/),
-[AWS Secrets Manager](https://aws.amazon.com/secrets-manager/),
+[1Password](https://1password.com/), [AWS Secrets
+Manager](https://aws.amazon.com/secrets-manager/),
 [Bitwarden](https://bitwarden.com/), [gopass](https://www.gopass.pw/),
 [KeePassXC](https://keepassxc.org/), [Keeper](https://www.keepersecurity.com/),
 [LastPass](https://lastpass.com/), [pass](https://www.passwordstore.org/),
+[passhole](https://github.com/Evidlo/passhole),
 [Vault](https://www.vaultproject.io/), Keychain,
-[Keyring](https://wiki.gnome.org/Projects/GnomeKeyring), or any
-command-line utility of your choice. You can encrypt individual files with
+[Keyring](https://wiki.gnome.org/Projects/GnomeKeyring), or any command-line
+utility of your choice. You can encrypt individual files with
 [GnuPG](https://www.gnupg.org) or [age](https://age-encryption.org). You can
 checkout your dotfiles repo on as many machines as you want without revealing
 any secrets to anyone.

--- a/assets/chezmoi.io/mkdocs.yml
+++ b/assets/chezmoi.io/mkdocs.yml
@@ -68,6 +68,7 @@ nav:
     - Keeper: user-guide/password-managers/keeper.md
     - LastPass: user-guide/password-managers/lastpass.md
     - pass: user-guide/password-managers/pass.md
+    - passhole: user-guide/password-managers/passhole.md
     - Vault: user-guide/password-managers/vault.md
     - Custom: user-guide/password-managers/custom.md
   - Encryption:
@@ -245,6 +246,9 @@ nav:
       - pass: reference/templates/pass-functions/pass.md
       - passFields: reference/templates/pass-functions/passFields.md
       - passRaw: reference/templates/pass-functions/passRaw.md
+    - Passhole functions:
+      - reference/templates/passhole-functions/index.md
+      - passhole: reference/templates/passhole-functions/passhole.md
     - Vault functions:
       - vault: reference/templates/vault-functions/vault.md
     - Generic secret functions:

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -100,6 +100,7 @@ type ConfigFile struct {
 	Lastpass          lastpassConfig          `mapstructure:"lastpass"`
 	Onepassword       onepasswordConfig       `mapstructure:"onepassword"`
 	Pass              passConfig              `mapstructure:"pass"`
+	Passhole          passholeConfig          `mapstructure:"passhole"`
 	Secret            secretConfig            `mapstructure:"secret"`
 	Vault             vaultConfig             `mapstructure:"vault"`
 
@@ -295,6 +296,10 @@ func newConfig(options ...configOption) (*Config, error) {
 		Pass: passConfig{
 			Command: "pass",
 		},
+		Passhole: passholeConfig{
+			Command: "ph",
+			Prompt:  true,
+		},
 		Vault: vaultConfig{
 			Command: "vault",
 		},
@@ -458,6 +463,7 @@ func newConfig(options ...configOption) (*Config, error) {
 		"pass":                     c.passTemplateFunc,
 		"passFields":               c.passFieldsTemplateFunc,
 		"passRaw":                  c.passRawTemplateFunc,
+		"passhole":                 c.passholeTemplateFunc,
 		"quoteList":                c.quoteListTemplateFunc,
 		"replaceAllRegex":          c.replaceAllRegexTemplateFunc,
 		"secret":                   c.secretTemplateFunc,

--- a/pkg/cmd/doctorcmd.go
+++ b/pkg/cmd/doctorcmd.go
@@ -352,6 +352,15 @@ func (c *Config) runDoctorCmd(cmd *cobra.Command, args []string) error {
 			versionRx:   regexp.MustCompile(`(?m)=\s*v(\d+\.\d+\.\d+)`),
 		},
 		&binaryCheck{
+			name:        "passhole-command",
+			binaryname:  c.Passhole.Command,
+			ifNotSet:    checkResultWarning,
+			ifNotExist:  checkResultInfo,
+			versionArgs: []string{"--version"},
+			versionRx:   regexp.MustCompile(`^(\d+\.\d+\.\d+)`),
+			minVersion:  &passholeMinVersion,
+		},
+		&binaryCheck{
 			name:        "vault-command",
 			binaryname:  c.Vault.Command,
 			ifNotSet:    checkResultWarning,

--- a/pkg/cmd/passholetemplatefuncs.go
+++ b/pkg/cmd/passholetemplatefuncs.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"os/exec"
+
+	"github.com/coreos/go-semver/semver"
+
+	"github.com/twpayne/chezmoi/v2/pkg/chezmoilog"
+)
+
+type passholeCacheKey struct {
+	path  string
+	field string
+}
+
+type passholeConfig struct {
+	Command  string
+	Args     []string
+	Prompt   bool
+	cache    map[passholeCacheKey]string
+	password string
+}
+
+var passholeMinVersion = semver.Version{Major: 1, Minor: 10, Patch: 0}
+
+func (c *Config) passholeTemplateFunc(path, field string) string {
+	key := passholeCacheKey{
+		path:  path,
+		field: field,
+	}
+	if value, ok := c.Passhole.cache[key]; ok {
+		return value
+	}
+
+	args := append([]string{}, c.Passhole.Args...)
+	var stdin io.Reader
+	if c.Passhole.Prompt {
+		if c.Passhole.password == "" {
+			password, err := c.readPassword("Enter database password: ")
+			if err != nil {
+				panic(err)
+			}
+			c.Passhole.password = password
+		}
+		args = append(args, "--password", "-")
+		stdin = bytes.NewBufferString(c.Passhole.password + "\n")
+	}
+	args = append(args, "show", "--field", field, path)
+	output, err := c.passholeOutput(c.Passhole.Command, args, stdin)
+	if err != nil {
+		panic(err)
+	}
+
+	if c.Passhole.cache == nil {
+		c.Passhole.cache = make(map[passholeCacheKey]string)
+	}
+	c.Passhole.cache[key] = output
+	return output
+}
+
+func (c *Config) passholeOutput(name string, args []string, stdin io.Reader) (string, error) {
+	cmd := exec.Command(name, args...)
+	cmd.Stdin = stdin
+	cmd.Stderr = os.Stderr
+	output, err := chezmoilog.LogCmdOutput(cmd)
+	if err != nil {
+		return "", newCmdOutputError(cmd, output, err)
+	}
+	return string(output), nil
+}

--- a/pkg/cmd/testdata/scripts/doctor_unix.txtar
+++ b/pkg/cmd/testdata/scripts/doctor_unix.txtar
@@ -10,6 +10,7 @@ chmod 755 bin/keeper
 chmod 755 bin/lpass
 chmod 755 bin/op
 chmod 755 bin/pass
+chmod 755 bin/ph
 chmod 755 bin/pinentry
 chmod 755 bin/secret
 chmod 755 bin/shell
@@ -47,6 +48,7 @@ stdout '^ok\s+gopass-command\s+'
 stdout '^ok\s+keepassxc-command\s+'
 stdout '^info\s+keepassxc-db\s+'
 stdout '^ok\s+keeper-command\s+'
+stdout '^ok\s+passhole-command\s+'
 stdout '^ok\s+lastpass-command\s+'
 stdout '^ok\s+pass-command\s+'
 stdout '^ok\s+vault-command\s+'
@@ -128,6 +130,10 @@ echo "=               Jason@zx2c4.com            ="
 echo "=                                          ="
 echo "=      http://www.passwordstore.org/       ="
 echo "============================================"
+-- bin/ph --
+#!/bin/sh
+
+echo 1.10.0
 -- bin/pinentry --
 #!/bin/sh
 

--- a/pkg/cmd/testdata/scripts/passhole.txtar
+++ b/pkg/cmd/testdata/scripts/passhole.txtar
@@ -1,0 +1,33 @@
+[!windows] chmod 755 bin/ph
+[windows] unix2dos bin/ph.cmd
+
+# test passhole template function
+stdin golden/stdin
+exec chezmoi execute-template --no-tty '{{ passhole "example.com" "password" }}'
+stdout examplepassword
+
+-- bin/ph --
+#!/bin/sh
+case "$*" in
+"--version")
+    echo "1.9.9"
+    ;;
+"--password - show --field password example.com")
+    echo "examplepassword"
+    ;;
+*)
+    echo "ph: error: argument command: invalid choice:"
+    exit 1
+esac
+-- bin/ph.cmd --
+@echo off
+IF "%*" == "--version" (
+    echo 1.9.9
+) ELSE IF "%*" == "--password - show --field password example.com" (
+    echo examplepassword
+) ELSE (
+    echo ph: error: argument command: invalid choice:
+    exit /b 1
+)
+-- golden/stdin --
+fakepassword


### PR DESCRIPTION
Co-authored-by: @JackTheMico

Replaces #2301.

This should not be merged until passhole supports reading a password from stdin (which [version 1.9.9 does not support](https://github.com/Evidlo/passhole/blob/v1.9.9/passhole/passhole.py#L370-L388)).