### PR TITLE
fix: Treat git-repo externals as directories of include/exclude purposes

### DIFF
--- a/pkg/chezmoi/entrytypeset.go
+++ b/pkg/chezmoi/entrytypeset.go
@@ -98,7 +98,7 @@ func (s *EntryTypeSet) IncludeTargetStateEntry(targetStateEntry TargetStateEntry
 	case *TargetStateFile:
 		return s.bits&EntryTypeFiles != 0
 	case *TargetStateModifyDirWithCmd:
-		return s.bits&EntryTypeScripts != 0
+		return s.bits&EntryTypeDirs != 0
 	case *TargetStateRemove:
 		return s.bits&EntryTypeRemove != 0
 	case *TargetStateScript:

--- a/pkg/cmd/testdata/scripts/externalgitrepo.txtar
+++ b/pkg/cmd/testdata/scripts/externalgitrepo.txtar
@@ -4,6 +4,10 @@
 mkgitconfig
 expandenv $WORK/home/user/.local/share/chezmoi/.chezmoiexternal.toml
 
+# test that chezmoi managed lists the directory
+exec chezmoi managed
+stdout ^\.dir$
+
 # create a git repo
 cd $WORK/repo
 exec git init


### PR DESCRIPTION
Fixes #2346.