### PR TITLE
fix(docs): merge.md

### DIFF
--- a/assets/chezmoi.io/docs/user-guide/tools/merge.md
+++ b/assets/chezmoi.io/docs/user-guide/tools/merge.md
@@ -12,5 +12,5 @@ state, source state, and target state respectively. For example, to use
 ```toml title="~/.config/chezmoi/chezmoi.toml"
 [merge]
     command = "nvim"
-    args = ["-d", "{{ .Destination }}", "{{ .Source }}", "{{ .Target }}"]
+    args = ["-d"]
 ```


### PR DESCRIPTION
Pardon for not digging too hard here, but when my nvim opened up six windows, three of which that were empty, this was the first fix I tried and it worked perfectly. 

Did the templating behavior change recently?