### PR TITLE
docs: change remote origin - from ssh to https

### DIFF
--- a/assets/chezmoi.io/docs/quick-start.md
+++ b/assets/chezmoi.io/docs/quick-start.md
@@ -74,7 +74,7 @@ $ git commit -m "Initial commit"
 and then push your repo:
 
 ```console
-$ git remote add origin git@github.com:username/dotfiles.git
+$ git remote add origin https://github.com/username/dotfiles.git
 $ git branch -M main
 $ git push -u origin main
 ```


### PR DESCRIPTION
i have setup already my git to use with https - i got authentification errors when i used this settings. i have to find out why my authentification fails.

also GitHub recommends the https version

PS: maybe we show both variants here