### PR TITLE
fix: Respect .chezmoiroot in source-path command with no arguments

### DIFF
--- a/pkg/cmd/sourcepathcmd.go
+++ b/pkg/cmd/sourcepathcmd.go
@@ -22,7 +22,11 @@ func (c *Config) newSourcePathCmd() *cobra.Command {
 
 func (c *Config) runSourcePathCmd(cmd *cobra.Command, args []string) error {
 	if len(args) == 0 {
-		return c.writeOutputString(c.SourceDirAbsPath.String() + "\n")
+		sourceDirAbsPath, err := c.sourceDirAbsPath()
+		if err != nil {
+			return err
+		}
+		return c.writeOutputString(sourceDirAbsPath.String() + "\n")
 	}
 
 	sourceState, err := c.newSourceState(cmd.Context())

--- a/pkg/cmd/testdata/scripts/issue2380.txt
+++ b/pkg/cmd/testdata/scripts/issue2380.txt
@@ -1,0 +1,6 @@
+# test that chezmoi source-path with no arguments respects .chezmoiroot
+exec chezmoi source-path
+stdout ${CHEZMOISOURCEDIR@R}/home
+
+-- home/user/.local/share/chezmoi/.chezmoiroot --
+home


### PR DESCRIPTION
Fixes #2380.