### PR TITLE
Expose some chezmoi config in env vars

### DIFF
--- a/pkg/chezmoi/realsystem.go
+++ b/pkg/chezmoi/realsystem.go
@@ -126,6 +126,7 @@ func (s *RealSystem) RunScript(scriptname RelPath, dir AbsPath, data []byte, int
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+	cmd.Env = s.env
 
 	return s.RunCmd(cmd)
 }

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -1661,6 +1661,7 @@ func (c *Config) persistentPreRunRootE(cmd *cobra.Command, args []string) error 
 	c.baseSystem = chezmoi.NewRealSystem(c.fileSystem,
 		chezmoi.RealSystemWithSafe(c.Safe),
 		chezmoi.RealSystemWithScriptTempDir(c.ScriptTempDir),
+		chezmoi.RealSystemWithEnv(c.defaultTemplateData()),
 	)
 	if c.debug {
 		systemLogger := c.logger.With().Str(logComponentKey, logComponentValueSystem).Logger()

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -988,6 +988,15 @@ func (c *Config) defaultTemplateData() map[string]any {
 
 	windowsVersion, _ := windowsVersion()
 
+	os.Setenv("CHEZMOI_ARCH", runtime.GOARCH)
+	os.Setenv("CHEZMOI_CACHE_DIR", c.CacheDirAbsPath.String())
+	os.Setenv("CHEZMOI_CONFIG_FILE", c.configFileAbsPath.String())
+	os.Setenv("CHEZMOI_HOME_DIR", c.homeDir)
+	os.Setenv("CHEZMOI_OS", runtime.GOOS)
+	os.Setenv("CHEZMOI_SOURCE_DIR", c.SourceDirAbsPath.String())
+	os.Setenv("CHEZMOI_VERSION", c.versionInfo.Version)
+	os.Setenv("CHEZMOI_WORKING_TREE", c.WorkingTreeAbsPath.String())
+
 	return map[string]any{
 		"chezmoi": map[string]any{
 			"arch":         runtime.GOARCH,


### PR DESCRIPTION
I've been playing with some of the runtime scripts in my configuration and realized that I could change most of them—if not all—from `run_*.sh.tmpl` to just regular shell scripts (so that I can run them without clearing state for things that occasionally get reset by the OS) if Chezmoi exported some of its configuration as environment variables.

The template values that I care about most are `.chezmoi.homeDir` and `.chezmoi.sourceDir`, but other values may be useful as well, so I have set the following values when the configuration object is constructed:

- `CHEZMOI_ARCH`
- `CHEZMOI_CACHE_DIR`
- `CHEZMOI_CONFIG_FILE`
- `CHEZMOI_HOME_DIR`
- `CHEZMOI_OS`
- `CHEZMOI_SOURCE_DIR`
- `CHEZMOI_VERSION`
- `CHEZMOI_WORKING_TREE`

In general, my preference would be to set these *immediately* before `realSystem.RunCommand` using `exec.Command.Env`, but that would require changes to a number of other APIs (the config is not passed to `RunCommand`) and be slower in any case as the variables would need to be set on each script execution.

This *should* work on Windows (it is guaranteed to work on any Unix-like OS), but I don't have a Windows system to verify. I'm uncertain what sort of tests could be run or updated to show this working, but "it works on my system".

<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer/contributing-changes/

-->
