### PR TITLE
feat: 1Password account lookup table

### DIFF
--- a/assets/chezmoi.io/docs/reference/templates/1password-functions/index.md
+++ b/assets/chezmoi.io/docs/reference/templates/1password-functions/index.md
@@ -2,16 +2,50 @@
 
 The `onepassword*` template functions return structured data from
 [1Password](https://1password.com/) using the [1Password
-CLI](https://support.1password.com/command-line-getting-started/) (`op`).
+CLI](https://developer.1password.com/docs/cli) (`op`).
 
 !!! warning
 
-    When using 1Password CLI 2.0, there may be an issue with pre-authenticating
-    `op` because the environment variable used to store the session key has
-    changed from `OP_SESSION_account` to `OP_SESSION_accountUUID`. Instead of
-    using *account-name*, it is recommended that you use the *account-uuid*.
-    This can be found using `op account list`.
+    When using 1Password CLI v2 with biometric authentication, account shorthand
+    names are not available. In order to assist with this, chezmoi supports
+    multiple derived values from `op account list` that can be changed into the
+    appropriate 1Password *account-uuid*.
 
-    This issue does not occur when using biometric authentication and 1Password
-    8, or if you allow chezmoi to prompt you for 1Password authentication
-    (`1password.prompt = true`).
+    ### Example
+
+    If `op account list --format=json` returns the following structure:
+
+    ```json
+    [
+      {
+        "url": "account1.1password.ca",
+        "email": "my@email.com",
+        "user_uuid": "some-user-uuid",
+        "account_uuid": "some-account-uuid"
+      }
+    ]
+    ```
+
+    The following values can be used in the `account` parameter and the value
+    `some-account-uuid` will be passed as the `--account` parameter to `op`.
+
+    - `some-account-uuid`
+    - `some-user-uuid`
+    - `account1.1password.ca`
+    - `account1`
+    - `my@email.com`
+    - `my`
+    - `my@account1.1password.ca`
+    - `my@account1`
+
+    If there are multiple accounts and _any_ value exists more than once, that
+    value will be removed from the account mapping. That is, if you are signed
+    into `my@email.com` and `your@email.com` for `account1.1password.ca`, then
+    `account1.1password.ca` will not be a valid lookup value, but `my@account1`,
+    `my@account1.1password.ca`, `your@account1`, and
+    `your@account1.1password.ca` would all be valid lookups.
+
+!!! warning
+
+    Support for 1Password CLI v1 will be removed with the next major release of
+    chezmoi.

--- a/assets/chezmoi.io/docs/reference/templates/1password-functions/onepasswordDetailsFields.md
+++ b/assets/chezmoi.io/docs/reference/templates/1password-functions/onepasswordDetailsFields.md
@@ -1,22 +1,23 @@
-# `onepasswordDetailsFields` *uuid* [*vault-uuid* [*account-name*]]
+# `onepasswordDetailsFields` _uuid_ [_vault-uuid_ [*account-name*]]
 
 `onepasswordDetailsFields` returns structured data from
 [1Password](https://1password.com/) using the [1Password
 CLI](https://support.1password.com/command-line-getting-started/) (`op`).
-*uuid* is passed to `op get item $UUID`, the output from `op` is parsed as
+_uuid_ is passed to `op get item $UUID`, the output from `op` is parsed as
 JSON, and elements of `details.fields` are returned as a map indexed by each
-field's `id` (if set) or `label` (if set and `id` is not present). If there is
-no valid session in the environment, by default you will be interactively
-prompted to sign in.
+field's `id` (if set) or `label` (if set and `id` is not present).
+
+If there is no valid session in the environment, by default you will be
+interactively prompted to sign in.
 
 !!! info
 
     For 1Password CLI 1.x, the map is indexed by each field's `designation`.
 
 The output from `op` is cached so calling `onepasswordDetailsFields` multiple
-times with the same *uuid* will only invoke `op` once. If the optional
-*vault-uuid* is supplied, it will be passed along to the `op get` call, which
-can significantly improve performance. If the optional *account-name* is
+times with the same _uuid_ will only invoke `op` once. If the optional
+_vault-uuid_ is supplied, it will be passed along to the `op get` call, which
+can significantly improve performance. If the optional _account-name_ is
 supplied, it will be passed along to the `op get` call, which will help it look
 in the right account, in case you have multiple accounts (e.g. personal and
 work accounts).
@@ -77,13 +78,14 @@ work accounts).
 
 !!! warning
 
-    When using [1Password CLI 2.0](https://developer.1password.com/), note that
-    the structure of the data returned by the `onepasswordDetailsFields`
-    template function is different and your templates will need updating.
+    When using [1Password CLI 2.0](https://developer.1password.com/docs/cli),
+    note that the structure of the data returned by the
+    `onepasswordDetailsFields` template function is different and your templates
+    will need updating.
 
-    You may wish to use `onepassword` or `onepasswordItemFields` instead of this
-    function, as it may not return expected values. Testing the output of this
-    function is recommended:
+    You may wish to use `onepassword`, `onepasswordItemFields`, or
+    `onepasswordRead` instead of this function, as it may not return expected
+    values. Testing the output of this function is recommended:
 
     ```console
     $ chezmoi execute-template "{{ onepasswordDetailsFields \"$UUID\" | toJson }}" | jq .

--- a/assets/chezmoi.io/docs/reference/templates/1password-functions/onepasswordDocument.md
+++ b/assets/chezmoi.io/docs/reference/templates/1password-functions/onepasswordDocument.md
@@ -1,17 +1,18 @@
-# `onepasswordDocument` *uuid* [*vault-uuid* [*account-name*]]
+# `onepasswordDocument` _uuid_ [_vault-uuid_ [*account-name*]]
 
 `onepasswordDocument` returns a document from
 [1Password](https://1password.com/) using the [1Password
-CLI](https://support.1password.com/command-line-getting-started/) (`op`).
-*uuid* is passed to `op get document $UUID` and the output from `op` is
-returned. The output from `op` is cached so calling `onepasswordDocument`
-multiple times with the same *uuid* will only invoke `op` once. If the optional
-*vault-uuid* is supplied, it will be passed along to the `op get` call, which
-can significantly improve performance. If the optional *account-name* is
-supplied, it will be passed along to the `op get` call, which will help it look
-in the right account, in case you have multiple accounts (e.g., personal and
-work accounts). If there is no valid session in the environment, by default you
-will be interactively prompted to sign in.
+CLI](https://developer.1password.com/docs/cli) (`op`). _uuid_ is passed to
+`op get document $UUID` and the output from `op` is returned. The output from
+`op` is cached so calling `onepasswordDocument` multiple times with the same
+_uuid_ will only invoke `op` once. If the optional _vault-uuid_ is supplied, it
+will be passed along to the `op get` call, which can significantly improve
+performance. If the optional _account-name_ is supplied, it will be passed along
+to the `op get` call, which will help it look in the right account, in case you
+have multiple accounts (e.g., personal and work accounts).
+
+If there is no valid session in the environment, by default you will be
+interactively prompted to sign in.
 
 !!! example
 

--- a/assets/chezmoi.io/docs/reference/templates/1password-functions/onepasswordItemFields.md
+++ b/assets/chezmoi.io/docs/reference/templates/1password-functions/onepasswordItemFields.md
@@ -1,8 +1,8 @@
-# `onepasswordItemFields` *uuid* [*vault-uuid* [*account-name*]]
+# `onepasswordItemFields` _uuid_ [_vault-uuid_ [*account-name*]]
 
 `onepasswordItemFields` returns structured data from
 [1Password](https://1password.com/) using the [1Password
-CLI](https://support.1password.com/command-line-getting-started/) (`op`). *uuid*
+CLI](https://support.1password.com/command-line-getting-started/) (`op`). _uuid_
 is passed to `op item get $UUID --format json`, the output from `op` is parsed
 as JSON, and each element of `details.sections` are iterated over and any
 `fields` are returned as a map indexed by each field's `n`.
@@ -39,6 +39,7 @@ interactively prompted to sign in.
         ```console
         $ op get item abcdefghijklmnopqrstuvwxyz --fields exampleLabel
         ```
+
 !!! example
 
     Given the output from `op`:
@@ -130,13 +131,13 @@ interactively prompted to sign in.
 
 !!! warning
 
-    When using [1Password CLI 2.0](https://developer.1password.com/), note that
-    the structure of the data returned by the `onepasswordItemFields` template
-    function is different and your templates will need updating.
+    When using [1Password CLI 2.0](https://developer.1password.com/docs/cli),
+    note that the structure of the data returned by the `onepasswordItemFields`
+    template function is different and your templates will need updating.
 
-    You may wish to use `onepassword` or `onepasswordDetailsFields` instead of
-    this function, as it may not return expected values. Testing the output of
-    this function is recommended:
+    You may wish to use `onepassword`, `onepasswordDetailsFields`, or
+    `onepasswordRead` instead of this function, as it may not return expected
+    values. Testing the output of this function is recommended:
 
     ```console
     $ chezmoi execute-template "{{ onepasswordItemFields \"$UUID\" | toJson }}" | jq .

--- a/assets/chezmoi.io/docs/reference/templates/1password-functions/onepasswordRead.md
+++ b/assets/chezmoi.io/docs/reference/templates/1password-functions/onepasswordRead.md
@@ -1,9 +1,8 @@
-# `onepasswordRead` *url* [*account*]
+# `onepasswordRead` _url_ [*account*]
 
 `onepasswordRead` returns data from [1Password](https://1password.com/) using
-the [1Password
-CLI](https://support.1password.com/command-line-getting-started/) (`op`). *url*
-is passed to `op read $URL`. If *account* is specified, the extra arguments
+the [1Password CLI](https://developer.1password.com/docs/cli) (`op`). _url_ is
+passed to `op read $URL`. If _account_ is specified, the extra arguments
 `--account $ACCOUNT` are passed to `op`.
 
 If there is no valid session in the environment, by default you will be

--- a/assets/chezmoi.io/docs/user-guide/password-managers/1password.md
+++ b/assets/chezmoi.io/docs/user-guide/password-managers/1password.md
@@ -187,6 +187,6 @@ available. If you'd like to restore this behavior, set the the
 
 !!! danger
 
-    Do not use the prompt on shared machines. A session token verified or
-    acquired interactively will be passed to the 1Password CLI through a
-    command line parameter, which is visible to other users of the same system.
+    Do not use prompt on shared machines. A session token verified or acquired
+    interactively will be passed to the 1Password CLI through a command line
+    parameter, which is visible to other users of the same system.

--- a/pkg/cmd/testdata/scripts/onepassword2.txtar
+++ b/pkg/cmd/testdata/scripts/onepassword2.txtar
@@ -13,6 +13,10 @@ stdout '^wxcplh5udshnonkzg2n4qx262y$'
 exec chezmoi execute-template '{{ (onepassword "ExampleLogin" "" "account").id }}'
 stdout '^wxcplh5udshnonkzg2n4qx262y$'
 
+# test onepassword template function with account alias
+exec chezmoi execute-template '{{ (onepassword "ExampleLogin" "" "chezmoi").id }}'
+stdout '^wxcplh5udshnonkzg2n4qx262y$'
+
 # test onepasswordDetailsFields template function
 exec chezmoi execute-template '{{ (onepasswordDetailsFields "ExampleLogin").password.value }}'
 stdout '^L8rm1JXJIE1b8YUDWq7h$'
@@ -28,10 +32,13 @@ case "$*" in
 "--version")
     echo 2.0.0
     ;;
-"item get --format json ExampleLogin" | "item get --format json ExampleLogin --vault vault --account account" | "--session thisIsAFakeSessionToken item get --format json ExampleLogin" | "--session thisIsAFakeSessionToken item get --format json ExampleLogin --vault vault --account account" | "--session thisIsAFakeSessionToken item get --format json ExampleLogin --account account")
+"item get --format json ExampleLogin" | "item get --format json ExampleLogin --vault vault --account account_uuid" | "--session thisIsAFakeSessionToken item get --format json ExampleLogin" | "--session thisIsAFakeSessionToken item get --format json ExampleLogin --vault vault --account account_uuid" | "--session thisIsAFakeSessionToken item get --format json ExampleLogin --account account_uuid")
     echo '{"id":"wxcplh5udshnonkzg2n4qx262y","title":"ExampleLogin","version":1,"vault":{"id":"tscpxgi6s7c662jtqn3vmw4n5a"},"category":"LOGIN","last_edited_by":"YO4UTYPAD3ZFBNZG5DVAZFBNZM","created_at":"2022-01-17T01:53:50Z","updated_at":"2022-01-17T01:55:35Z","sections":[{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"}],"fields":[{"id":"username","type":"STRING","purpose":"USERNAME","label":"username","value":"exampleuser "},{"id":"password","type":"CONCEALED","purpose":"PASSWORD","label":"password","value":"L8rm1JXJIE1b8YUDWq7h","password_details":{"strength":"EXCELLENT"}},{"id":"notesPlain","type":"STRING","purpose":"NOTES","label":"notesPlain"},{"id":"cqn7oda7wkcsar7rzcr52i2m3u","section":{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"},"type":"STRING","label":"exampleLabel","value":"exampleValue"}],"urls":[{"primary":true,"href":"https://www.example.com/"}]}'
     ;;
-"signin --raw" | "signin --account account --raw")
+"account list --format=json")
+    echo '[{"url":"account.1password.com","email":"chezmoi@chezmoi.org","user_uuid":"user_uuid","account_uuid":"account_uuid"}]'
+    ;;
+"signin --raw" | "signin --account account_uuid --raw")
     echo 'thisIsAFakeSessionToken'
     ;;
 *)
@@ -44,19 +51,21 @@ IF "%*" == "--version" (
     echo 2.0.0
 ) ELSE IF "%*" == "item get --format json ExampleLogin" (
     echo.{"id":"wxcplh5udshnonkzg2n4qx262y","title":"ExampleLogin","version":1,"vault":{"id":"tscpxgi6s7c662jtqn3vmw4n5a"},"category":"LOGIN","last_edited_by":"YO4UTYPAD3ZFBNZG5DVAZFBNZM","created_at":"2022-01-17T01:53:50Z","updated_at":"2022-01-17T01:55:35Z","sections":[{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"}],"fields":[{"id":"username","type":"STRING","purpose":"USERNAME","label":"username","value":"exampleuser "},{"id":"password","type":"CONCEALED","purpose":"PASSWORD","label":"password","value":"L8rm1JXJIE1b8YUDWq7h","password_details":{"strength":"EXCELLENT"}},{"id":"notesPlain","type":"STRING","purpose":"NOTES","label":"notesPlain"},{"id":"cqn7oda7wkcsar7rzcr52i2m3u","section":{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"},"type":"STRING","label":"exampleLabel","value":"exampleValue"}],"urls":[{"primary":true,"href":"https://www.example.com/"}]}
-) ELSE IF "%*" == "item get --format json ExampleLogin --vault vault --account account" (
+) ELSE IF "%*" == "item get --format json ExampleLogin --vault vault --account account_uuid" (
     echo.{"id":"wxcplh5udshnonkzg2n4qx262y","title":"ExampleLogin","version":1,"vault":{"id":"tscpxgi6s7c662jtqn3vmw4n5a"},"category":"LOGIN","last_edited_by":"YO4UTYPAD3ZFBNZG5DVAZFBNZM","created_at":"2022-01-17T01:53:50Z","updated_at":"2022-01-17T01:55:35Z","sections":[{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"}],"fields":[{"id":"username","type":"STRING","purpose":"USERNAME","label":"username","value":"exampleuser "},{"id":"password","type":"CONCEALED","purpose":"PASSWORD","label":"password","value":"L8rm1JXJIE1b8YUDWq7h","password_details":{"strength":"EXCELLENT"}},{"id":"notesPlain","type":"STRING","purpose":"NOTES","label":"notesPlain"},{"id":"cqn7oda7wkcsar7rzcr52i2m3u","section":{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"},"type":"STRING","label":"exampleLabel","value":"exampleValue"}],"urls":[{"primary":true,"href":"https://www.example.com/"}]}
-) ELSE IF "%*" == "item get --format json ExampleLogin --account account" (
+) ELSE IF "%*" == "item get --format json ExampleLogin --account account_uuid" (
     echo.{"id":"wxcplh5udshnonkzg2n4qx262y","title":"ExampleLogin","version":1,"vault":{"id":"tscpxgi6s7c662jtqn3vmw4n5a"},"category":"LOGIN","last_edited_by":"YO4UTYPAD3ZFBNZG5DVAZFBNZM","created_at":"2022-01-17T01:53:50Z","updated_at":"2022-01-17T01:55:35Z","sections":[{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"}],"fields":[{"id":"username","type":"STRING","purpose":"USERNAME","label":"username","value":"exampleuser "},{"id":"password","type":"CONCEALED","purpose":"PASSWORD","label":"password","value":"L8rm1JXJIE1b8YUDWq7h","password_details":{"strength":"EXCELLENT"}},{"id":"notesPlain","type":"STRING","purpose":"NOTES","label":"notesPlain"},{"id":"cqn7oda7wkcsar7rzcr52i2m3u","section":{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"},"type":"STRING","label":"exampleLabel","value":"exampleValue"}],"urls":[{"primary":true,"href":"https://www.example.com/"}]}
 ) ELSE IF "%*" == "--session thisIsAFakeSessionToken item get --format json ExampleLogin" (
     echo.{"id":"wxcplh5udshnonkzg2n4qx262y","title":"ExampleLogin","version":1,"vault":{"id":"tscpxgi6s7c662jtqn3vmw4n5a"},"category":"LOGIN","last_edited_by":"YO4UTYPAD3ZFBNZG5DVAZFBNZM","created_at":"2022-01-17T01:53:50Z","updated_at":"2022-01-17T01:55:35Z","sections":[{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"}],"fields":[{"id":"username","type":"STRING","purpose":"USERNAME","label":"username","value":"exampleuser "},{"id":"password","type":"CONCEALED","purpose":"PASSWORD","label":"password","value":"L8rm1JXJIE1b8YUDWq7h","password_details":{"strength":"EXCELLENT"}},{"id":"notesPlain","type":"STRING","purpose":"NOTES","label":"notesPlain"},{"id":"cqn7oda7wkcsar7rzcr52i2m3u","section":{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"},"type":"STRING","label":"exampleLabel","value":"exampleValue"}],"urls":[{"primary":true,"href":"https://www.example.com/"}]}
-) ELSE IF "%*" == "--session thisIsAFakeSessionToken item get --format json ExampleLogin --vault vault --account account" (
+) ELSE IF "%*" == "--session thisIsAFakeSessionToken item get --format json ExampleLogin --vault vault --account account_uuid" (
     echo.{"id":"wxcplh5udshnonkzg2n4qx262y","title":"ExampleLogin","version":1,"vault":{"id":"tscpxgi6s7c662jtqn3vmw4n5a"},"category":"LOGIN","last_edited_by":"YO4UTYPAD3ZFBNZG5DVAZFBNZM","created_at":"2022-01-17T01:53:50Z","updated_at":"2022-01-17T01:55:35Z","sections":[{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"}],"fields":[{"id":"username","type":"STRING","purpose":"USERNAME","label":"username","value":"exampleuser "},{"id":"password","type":"CONCEALED","purpose":"PASSWORD","label":"password","value":"L8rm1JXJIE1b8YUDWq7h","password_details":{"strength":"EXCELLENT"}},{"id":"notesPlain","type":"STRING","purpose":"NOTES","label":"notesPlain"},{"id":"cqn7oda7wkcsar7rzcr52i2m3u","section":{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"},"type":"STRING","label":"exampleLabel","value":"exampleValue"}],"urls":[{"primary":true,"href":"https://www.example.com/"}]}
-) ELSE IF "%*" == "--session thisIsAFakeSessionToken item get --format json ExampleLogin --account account" (
+) ELSE IF "%*" == "--session thisIsAFakeSessionToken item get --format json ExampleLogin --account account_uuid" (
     echo.{"id":"wxcplh5udshnonkzg2n4qx262y","title":"ExampleLogin","version":1,"vault":{"id":"tscpxgi6s7c662jtqn3vmw4n5a"},"category":"LOGIN","last_edited_by":"YO4UTYPAD3ZFBNZG5DVAZFBNZM","created_at":"2022-01-17T01:53:50Z","updated_at":"2022-01-17T01:55:35Z","sections":[{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"}],"fields":[{"id":"username","type":"STRING","purpose":"USERNAME","label":"username","value":"exampleuser "},{"id":"password","type":"CONCEALED","purpose":"PASSWORD","label":"password","value":"L8rm1JXJIE1b8YUDWq7h","password_details":{"strength":"EXCELLENT"}},{"id":"notesPlain","type":"STRING","purpose":"NOTES","label":"notesPlain"},{"id":"cqn7oda7wkcsar7rzcr52i2m3u","section":{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"},"type":"STRING","label":"exampleLabel","value":"exampleValue"}],"urls":[{"primary":true,"href":"https://www.example.com/"}]}
+) ELSE IF "%*" == "account list --format=json" (
+    echo.[{"url":"account.1password.com","email":"chezmoi@chezmoi.org","user_uuid":"user_uuid","account_uuid":"account_uuid"}]
 ) ELSE IF "%*" == "signin --raw" (
     echo thisIsAFakeSessionToken
-) ELSE IF "%*" == "signin --account account --raw" (
+) ELSE IF "%*" == "signin --account account_uuid --raw" (
     echo thisIsAFakeSessionToken
 ) ELSE (
     echo.[ERROR] 2020/01/01 00:00:00 unknown command "%*" for "op" 1>&2


### PR DESCRIPTION
This is the long-promised draft of the 1Password account lookup table discussed in #1974.

Basic testing using `execute-template` with various values seems to work *very* well, but I have not yet modified the tests or test scripts to run this new functionality.