### PR TITLE
docs: Use get.chezmoi.io for install links

### DIFF
--- a/assets/chezmoi.io/docs/index.md
+++ b/assets/chezmoi.io/docs/index.md
@@ -7,7 +7,7 @@ dotfiles from your GitHub dotfiles repo on a new, empty machine with a single
 command:
 
 ```console
-$ sh -c "$(curl -fsLS https://chezmoi.io/get)" -- init --apply $GITHUB_USERNAME
+$ sh -c "$(curl -fsLS get.chezmoi.io)" -- init --apply $GITHUB_USERNAME
 ```
 
 As well as `curl | sh` installation, you can [install chezmoi with your favorite

--- a/assets/chezmoi.io/docs/install.md.tmpl
+++ b/assets/chezmoi.io/docs/install.md.tmpl
@@ -120,13 +120,13 @@ with a single command:
 === "curl"
 
     ```sh
-    sh -c "$(curl -fsLS https://chezmoi.io/get)"
+    sh -c "$(curl -fsLS get.chezmoi.io)"
     ```
 
 === "wget"
 
     ```sh
-    sh -c "$(wget -qO- https://chezmoi.io/get)"
+    sh -c "$(wget -qO- get.chezmoi.io)"
     ```
 
 === "PowerShell"
@@ -142,7 +142,7 @@ with a single command:
     chezmoi and your dotfiles with the single command:
 
     ```sh
-    sh -c "$(curl -fsLS https://chezmoi.io/get)" -- init --apply $GITHUB_USERNAME
+    sh -c "$(curl -fsLS get.chezmoi.io)" -- init --apply $GITHUB_USERNAME
     ```
 
 !!! hint
@@ -151,7 +151,7 @@ with a single command:
     for example:
 
     ```sh
-    sh -c "$(curl -fsLS https://chezmoi.io/get)" -- -b $HOME/.local/bin
+    sh -c "$(curl -fsLS get.chezmoi.io)" -- -b $HOME/.local/bin
     ```
 
 ## Download a pre-built Linux package

--- a/assets/chezmoi.io/docs/user-guide/daily-operations.md
+++ b/assets/chezmoi.io/docs/user-guide/daily-operations.md
@@ -92,7 +92,7 @@ arguments to the newly installed chezmoi binary. If your dotfiles repo is
 shell:
 
 ```console
-$ sh -c "$(curl -fsLS https://chezmoi.io/get)" -- init --apply $GITHUB_USERNAME
+$ sh -c "$(curl -fsLS get.chezmoi.io)" -- init --apply $GITHUB_USERNAME
 ```
 
 If your dotfiles repo has a different name to `dotfiles`, or if you host your
@@ -105,5 +105,5 @@ chezmoi, including the source directory and chezmoi's configuration directory,
 with a single command:
 
 ```console
-$ sh -c "$(curl -fsLS https://chezmoi.io/get)" -- init --one-shot $GITHUB_USERNAME
+$ sh -c "$(curl -fsLS get.chezmoi.io)" -- init --one-shot $GITHUB_USERNAME
 ```

--- a/assets/templates/install.sh
+++ b/assets/templates/install.sh
@@ -9,9 +9,9 @@ if ! chezmoi="$(command -v chezmoi)"; then
   chezmoi="${bin_dir}/chezmoi"
   echo "Installing chezmoi to '${chezmoi}'" >&2
   if command -v curl >/dev/null; then
-    chezmoi_install_script="$(curl -fsSL https://chezmoi.io/get)"
+    chezmoi_install_script="$(curl -fsSL get.chezmoi.io)"
   elif command -v wget >/dev/null; then
-    chezmoi_install_script="$(wget -qO- https://chezmoi.io/get)"
+    chezmoi_install_script="$(wget -qO- get.chezmoi.io)"
   else
     echo "To install chezmoi, you must have curl or wget installed." >&2
     exit 1


### PR DESCRIPTION
Refs #2430. cc @felipecrs 

I think this is correct. We should probably add an equivalent to `get.chezmoi.io` for PowerShell users.
