### PR TITLE
chore: Add COMMIT file to source archives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.vagrant
+/COMMIT
 /bin/chezmoi
 /bin/gofumpt
 /bin/golangci-lint

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -2,6 +2,7 @@ project_name: chezmoi
 
 before:
   hooks:
+  - assets/scripts/generate-commit.sh -o COMMIT
   - go mod download all
 
 builds:
@@ -229,3 +230,5 @@ snapcrafts:
 source:
   enabled: true
   prefix_template: '{{ .ProjectName }}-{{ .Version }}/'
+  files:
+  - COMMIT

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ PREFIX?=/usr/local
 default: build
 
 .PHONY: smoketest
-smoketest: run build-all test lint format
+smoketest: run build-all test lint shellcheck format
 
 .PHONY: build
 build:
@@ -137,6 +137,10 @@ release:
 	goreleaser release \
 		--rm-dist \
 		${GORELEASER_FLAGS}
+
+.PHONY: shellcheck
+shellcheck:
+	find . -type f -name \*.sh | xargs shellcheck
 
 .PHONY: test-release
 test-release:

--- a/assets/chezmoi.io/docs/developer/packaging.md
+++ b/assets/chezmoi.io/docs/developer/packaging.md
@@ -31,8 +31,13 @@ optional and will be stripped, so you can pass the git tag in directly.
 
 !!! hint
 
-    The command `git rev-parse HEAD` will return a suitable value for
-    `$COMMIT`.
+    The `assets/scripts/generate-commit.sh` script will return a suitable value
+    for `$COMMIT`.
+
+!!! hint
+
+    The source archive contains a file called `COMMIT` containing the commit
+    hash.
 
 `$DATE` should be the date of the build as a UNIX timestamp or in RFC3339
 format.

--- a/assets/scripts/generate-commit.sh
+++ b/assets/scripts/generate-commit.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+output=""
+while getopts "o:" arg; do
+	case "${arg}" in
+	o) output="${OPTARG}" ;;
+	*) exit 1 ;;
+	esac
+done
+
+commit="$(git rev-parse HEAD)"
+if ! git diff-index --quiet HEAD; then
+	commit="${commit}-dirty"
+fi
+
+if [ -z "${output}" ]; then
+	echo "${commit}"
+else
+	echo "${commit}" > "${output}"
+fi

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -284,7 +284,7 @@ func runMain(versionInfo VersionInfo, args []string) (err error) {
 			if versionInfo.Commit == "" && vcs == "git" {
 				versionInfo.Commit = vcsRevision
 				if modified, err := strconv.ParseBool(vcsModified); err == nil && modified {
-					versionInfo.Commit += " (modified)"
+					versionInfo.Commit += "-dirty"
 				}
 			}
 			if versionInfo.Date == "" {


### PR DESCRIPTION
As [discussed](https://github.com/twpayne/chezmoi/pull/2442#issuecomment-1275066645) om #2442.

@FilippoBonazziSUSE this means that chezmoi versions 2.25.0 and later will have a `COMMIT` file in the source archive containing the git commit hash.