### PR TITLE
feat: Improve handling of include and exclude for externals and encrypted files

### DIFF
--- a/pkg/chezmoi/entrytypeset.go
+++ b/pkg/chezmoi/entrytypeset.go
@@ -114,6 +114,14 @@ func (s *EntryTypeSet) IncludeFileInfo(fileInfo fs.FileInfo) bool {
 
 // IncludeTargetStateEntry returns true if type of targetStateEntry is a member.
 func (s *EntryTypeSet) IncludeTargetStateEntry(targetStateEntry TargetStateEntry) bool {
+	if s.IncludeEncrypted() && targetStateEntry.SourceAttr().Encrypted {
+		return true
+	}
+
+	if s.IncludeExternals() && targetStateEntry.SourceAttr().External {
+		return true
+	}
+
 	switch targetStateEntry.(type) {
 	case *TargetStateDir:
 		return s.bits&EntryTypeDirs != 0

--- a/pkg/chezmoi/sourcestate.go
+++ b/pkg/chezmoi/sourcestate.go
@@ -1014,6 +1014,9 @@ func (s *SourceState) Read(ctx context.Context, options *ReadOptions) error {
 				origin:        external,
 				forceRefresh:  options.RefreshExternals == RefreshExternalsAlways,
 				refreshPeriod: external.RefreshPeriod,
+				sourceAttr: SourceAttr{
+					External: true,
+				},
 			}
 			allSourceStateEntries[externalRelPath] = append(allSourceStateEntries[externalRelPath], sourceStateCommand)
 		case err != nil:
@@ -1032,6 +1035,9 @@ func (s *SourceState) Read(ctx context.Context, options *ReadOptions) error {
 				origin:        external,
 				forceRefresh:  options.RefreshExternals == RefreshExternalsAlways,
 				refreshPeriod: external.RefreshPeriod,
+				sourceAttr: SourceAttr{
+					External: true,
+				},
 			}
 			allSourceStateEntries[externalRelPath] = append(allSourceStateEntries[externalRelPath], sourceStateCommand)
 		}
@@ -1414,6 +1420,9 @@ func (s *SourceState) newCreateTargetStateEntryFunc(
 			lazyContents: lazyContents,
 			empty:        true,
 			perm:         fileAttr.perm() &^ s.umask,
+			sourceAttr: SourceAttr{
+				Encrypted: fileAttr.Encrypted,
+			},
 		}, nil
 	}
 }
@@ -1454,6 +1463,9 @@ func (s *SourceState) newFileTargetStateEntryFunc(
 			lazyContents: newLazyContentsFunc(contentsFunc),
 			empty:        fileAttr.Empty,
 			perm:         fileAttr.perm() &^ s.umask,
+			sourceAttr: SourceAttr{
+				Encrypted: fileAttr.Encrypted,
+			},
 		}, nil
 	}
 }
@@ -1825,6 +1837,9 @@ func (s *SourceState) readExternalArchive(
 		sourceRelPath: parentSourceRelPath.Join(NewSourceRelPath(dirAttr.SourceName())),
 		targetStateEntry: &TargetStateDir{
 			perm: 0o777 &^ s.umask,
+			sourceAttr: SourceAttr{
+				External: true,
+			},
 		},
 	}
 	sourceStateEntries := map[RelPath][]SourceStateEntry{
@@ -1887,6 +1902,9 @@ func (s *SourceState) readExternalArchive(
 		case fileInfo.IsDir():
 			targetStateEntry := &TargetStateDir{
 				perm: fileInfo.Mode().Perm() &^ s.umask,
+				sourceAttr: SourceAttr{
+					External: true,
+				},
 			}
 			dirAttr := DirAttr{
 				TargetName: fileInfo.Name(),
@@ -1919,6 +1937,9 @@ func (s *SourceState) readExternalArchive(
 				lazyContents: lazyContents,
 				empty:        fileAttr.Empty,
 				perm:         fileAttr.perm() &^ s.umask,
+				sourceAttr: SourceAttr{
+					External: true,
+				},
 			}
 			sourceStateEntry = &SourceStateFile{
 				lazyContents:     lazyContents,
@@ -1935,6 +1956,9 @@ func (s *SourceState) readExternalArchive(
 			sourceRelPath := NewSourceRelPath(fileAttr.SourceName(s.encryption.EncryptedSuffix()))
 			targetStateEntry := &TargetStateSymlink{
 				lazyLinkname: newLazyLinkname(linkname),
+				sourceAttr: SourceAttr{
+					External: true,
+				},
 			}
 			sourceStateEntry = &SourceStateFile{
 				Attr:             fileAttr,
@@ -1970,6 +1994,9 @@ func (s *SourceState) readExternalFile(
 		lazyContents: lazyContents,
 		empty:        fileAttr.Empty,
 		perm:         fileAttr.perm() &^ s.umask,
+		sourceAttr: SourceAttr{
+			External: true,
+		},
 	}
 	sourceStateEntry := &SourceStateFile{
 		origin:           external,

--- a/pkg/chezmoi/sourcestateentry.go
+++ b/pkg/chezmoi/sourcestateentry.go
@@ -9,6 +9,12 @@ import (
 	"github.com/twpayne/chezmoi/v2/pkg/chezmoilog"
 )
 
+// A SourceAttr contains attributes of the source.
+type SourceAttr struct {
+	Encrypted bool
+	External  bool
+}
+
 // A SourceStateOrigin represents the origin of a source state.
 type SourceStateOrigin interface {
 	Path() AbsPath
@@ -34,6 +40,7 @@ type SourceStateCommand struct {
 	origin        SourceStateOrigin
 	forceRefresh  bool
 	refreshPeriod Duration
+	sourceAttr    SourceAttr
 }
 
 // A SourceStateDir represents the state of a directory in the source state.
@@ -103,6 +110,7 @@ func (s *SourceStateCommand) TargetStateEntry(destSystem System, destDirAbsPath 
 		cmd:           s.cmd,
 		forceRefresh:  s.forceRefresh,
 		refreshPeriod: s.refreshPeriod,
+		sourceAttr:    s.sourceAttr,
 	}, nil
 }
 

--- a/pkg/cmd/testdata/scripts/external.txtar
+++ b/pkg/cmd/testdata/scripts/external.txtar
@@ -25,6 +25,10 @@ cmp $HOME/.file golden/.file
 
 chhome home3/user
 
+# test that chezmoi managed --include=externals lists external targets
+exec chezmoi managed --include=externals
+cmp stdout golden/managed
+
 # test that chezmoi diff includes external archives by default
 exec chezmoi diff
 stdout '^diff --git a/\.dir/dir/file b/\.dir/dir/file$'
@@ -86,6 +90,11 @@ exec chezmoi apply --force
 # contents of .file
 -- golden/dir/file --
 # contents of dir/file
+-- golden/managed --
+.dir
+.dir/dir
+.dir/dir/file
+.dir/dir/symlink
 -- home/user/.local/share/chezmoi/.chezmoiexternal.toml --
 [".file"]
     type = "file"

--- a/pkg/cmd/testdata/scripts/issue2427.txt
+++ b/pkg/cmd/testdata/scripts/issue2427.txt
@@ -1,0 +1,44 @@
+symlink archive/dir/symlink -> file
+exec tar czf www/archive.tar.gz archive
+
+httpd www
+
+# test that chezmoi managed lists all targets
+exec chezmoi managed
+cmp stdout golden/managed
+
+# test that chezmoi managed --include=encrypted lists encrypted files only
+exec chezmoi managed --include=encrypted
+cmp stdout golden/managed-encrypted
+
+# test that chezmoi managed --include=externals lists external targets only
+exec chezmoi managed --include=externals
+cmp stdout golden/managed-externals
+
+-- archive/dir/file --
+# contents of dir/file
+-- golden/managed --
+.dir
+.dir/dir
+.dir/dir/file
+.dir/dir/symlink
+.encrypted
+.file
+-- golden/managed-encrypted --
+.encrypted
+-- golden/managed-externals --
+.dir
+.dir/dir
+.dir/dir/file
+.dir/dir/symlink
+-- home/user/.config/chezmoi/chezmoi.toml --
+encryption = "gpg"
+-- home/user/.local/share/chezmoi/.chezmoiexternal.yaml --
+.dir:
+    type: archive
+    url: {{ env "HTTPD_URL" }}/archive.tar.gz
+    stripComponents: 1
+-- home/user/.local/share/chezmoi/dot_file --
+-- home/user/.local/share/chezmoi/encrypted_dot_encrypted.asc --
+-- www/.file --
+# contents of .file


### PR DESCRIPTION
Fixes #2427.

@sm1999 would you be able to test this, and, ideally find a way where `--include` and `--exclude` don't behave as expected with these changes? I'll leave an explanatory comment in #2427.


