### PR TITLE
feat: Extend --include and --exclude flags to include templates

### DIFF
--- a/assets/chezmoi.io/docs/reference/command-line-flags/common.md
+++ b/assets/chezmoi.io/docs/reference/command-line-flags/common.md
@@ -10,8 +10,8 @@ Set the output format.
 
 Only operate on target state entries of type *types*. *types* is a
 comma-separated list of target states (`all`, `dirs`, `files`, `remove`,
-`scripts`, `symlinks`) and/or source attributes (`encrypted`, `externals`) and
-can be excluded by preceding them with a `no`.
+`scripts`, `symlinks`) and/or source attributes (`encrypted`, `externals`,
+`templates`) and can be excluded by preceding them with a `no`.
 
 !!! example
 
@@ -34,8 +34,8 @@ Recurse into subdirectories, `true` by default.
 ## `-x`, `--exclude` *types*
 
 Exclude target state entries of type *types*. *types* is a comma-separated list
-of target states (`all`, `dirs`, `files`, `remove`, `scripts`, `symlinks`,
-`encrypted`, and `externals`).
+of target states (`all`, `dirs`, `files`, `remove`, `scripts`, `symlinks`)
+and/or source attributes (`encrypted`, `externals`, `templates`).
 
 !!! example
 

--- a/assets/chezmoi.io/docs/reference/command-line-flags/common.md
+++ b/assets/chezmoi.io/docs/reference/command-line-flags/common.md
@@ -10,8 +10,8 @@ Set the output format.
 
 Only operate on target state entries of type *types*. *types* is a
 comma-separated list of target states (`all`, `dirs`, `files`, `remove`,
-`scripts`, `symlinks`, and `encrypted`) and can be excluded by preceding them
-with a `no`.
+`scripts`, `symlinks`) and/or source attributes (`encrypted`, `externals`) and
+can be excluded by preceding them with a `no`.
 
 !!! example
 

--- a/pkg/chezmoi/entrytypeset.go
+++ b/pkg/chezmoi/entrytypeset.go
@@ -29,6 +29,7 @@ const (
 	EntryTypeSymlinks
 	EntryTypeEncrypted
 	EntryTypeExternals
+	EntryTypeTemplates
 
 	// EntryTypesAll is all entry types.
 	EntryTypesAll EntryTypeBits = EntryTypeDirs |
@@ -37,7 +38,8 @@ const (
 		EntryTypeScripts |
 		EntryTypeSymlinks |
 		EntryTypeEncrypted |
-		EntryTypeExternals
+		EntryTypeExternals |
+		EntryTypeTemplates
 
 	// EntryTypesNone is no entry types.
 	EntryTypesNone EntryTypeBits = 0
@@ -54,6 +56,7 @@ var (
 		"symlinks":  EntryTypeSymlinks,
 		"encrypted": EntryTypeEncrypted,
 		"externals": EntryTypeExternals,
+		"templates": EntryTypeTemplates,
 	}
 
 	entryTypeCompletions = []string{
@@ -70,9 +73,11 @@ var (
 		"noremove",
 		"noscripts",
 		"nosymlinks",
+		"notemplates",
 		"remove",
 		"scripts",
 		"symlinks",
+		"templates",
 	}
 )
 
@@ -98,6 +103,11 @@ func (s *EntryTypeSet) IncludeExternals() bool {
 	return s.bits&EntryTypeExternals != 0
 }
 
+// IncludeTemplates returns true if s includes templates.
+func (s *EntryTypeSet) IncludeTemplates() bool {
+	return s.bits&EntryTypeTemplates != 0
+}
+
 // IncludeFileInfo returns true if the type of fileInfo is a member.
 func (s *EntryTypeSet) IncludeFileInfo(fileInfo fs.FileInfo) bool {
 	switch {
@@ -118,6 +128,8 @@ func (s *EntryTypeSet) IncludeTargetStateEntry(targetStateEntry TargetStateEntry
 	case s.IncludeEncrypted() && sourceAttr.Encrypted:
 		return true
 	case s.IncludeExternals() && sourceAttr.External:
+		return true
+	case s.IncludeTemplates() && sourceAttr.Template:
 		return true
 	}
 
@@ -197,6 +209,7 @@ func (s *EntryTypeSet) String() string {
 		"symlinks",
 		"encrypted",
 		"externals",
+		"templates",
 	} {
 		if s.bits&(1<<i) != 0 {
 			elements = append(elements, element)

--- a/pkg/chezmoi/entrytypeset.go
+++ b/pkg/chezmoi/entrytypeset.go
@@ -114,11 +114,10 @@ func (s *EntryTypeSet) IncludeFileInfo(fileInfo fs.FileInfo) bool {
 
 // IncludeTargetStateEntry returns true if type of targetStateEntry is a member.
 func (s *EntryTypeSet) IncludeTargetStateEntry(targetStateEntry TargetStateEntry) bool {
-	if s.IncludeEncrypted() && targetStateEntry.SourceAttr().Encrypted {
+	switch sourceAttr := targetStateEntry.SourceAttr(); {
+	case s.IncludeEncrypted() && sourceAttr.Encrypted:
 		return true
-	}
-
-	if s.IncludeExternals() && targetStateEntry.SourceAttr().External {
+	case s.IncludeExternals() && sourceAttr.External:
 		return true
 	}
 

--- a/pkg/chezmoi/entrytypeset_test.go
+++ b/pkg/chezmoi/entrytypeset_test.go
@@ -32,7 +32,7 @@ func TestIncludeMaskSet(t *testing.T) {
 		},
 		{
 			s:        "all,noscripts",
-			expected: NewEntryTypeSet(EntryTypeDirs | EntryTypeFiles | EntryTypeRemove | EntryTypeSymlinks | EntryTypeEncrypted | EntryTypeExternals),
+			expected: NewEntryTypeSet(EntryTypeDirs | EntryTypeFiles | EntryTypeRemove | EntryTypeSymlinks | EntryTypeEncrypted | EntryTypeExternals | EntryTypeTemplates),
 		},
 		{
 			s:        "noscripts",

--- a/pkg/chezmoi/sourcestate.go
+++ b/pkg/chezmoi/sourcestate.go
@@ -1422,6 +1422,7 @@ func (s *SourceState) newCreateTargetStateEntryFunc(
 			perm:         fileAttr.perm() &^ s.umask,
 			sourceAttr: SourceAttr{
 				Encrypted: fileAttr.Encrypted,
+				Template:  fileAttr.Template,
 			},
 		}, nil
 	}
@@ -1443,6 +1444,9 @@ func (s *SourceState) newFileTargetStateEntryFunc(
 				linkname := normalizeLinkname(s.sourceDirAbsPath.Join(sourceRelPath.RelPath()).String())
 				return &TargetStateSymlink{
 					lazyLinkname: newLazyLinkname(linkname),
+					sourceAttr: SourceAttr{
+						Template: fileAttr.Template,
+					},
 				}, nil
 			}
 		}
@@ -1465,6 +1469,7 @@ func (s *SourceState) newFileTargetStateEntryFunc(
 			perm:         fileAttr.perm() &^ s.umask,
 			sourceAttr: SourceAttr{
 				Encrypted: fileAttr.Encrypted,
+				Template:  fileAttr.Template,
 			},
 		}, nil
 	}

--- a/pkg/chezmoi/sourcestateentry.go
+++ b/pkg/chezmoi/sourcestateentry.go
@@ -13,6 +13,7 @@ import (
 type SourceAttr struct {
 	Encrypted bool
 	External  bool
+	Template  bool
 }
 
 // A SourceStateOrigin represents the origin of a source state.

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -311,9 +311,7 @@ func newConfig(options ...configOption) (*Config, error) {
 		},
 		managed: managedCmdConfig{
 			exclude: chezmoi.NewEntryTypeSet(chezmoi.EntryTypesNone),
-			include: chezmoi.NewEntryTypeSet(
-				chezmoi.EntryTypeDirs | chezmoi.EntryTypeFiles | chezmoi.EntryTypeSymlinks | chezmoi.EntryTypeEncrypted,
-			),
+			include: chezmoi.NewEntryTypeSet(chezmoi.EntryTypesAll &^ (chezmoi.EntryTypeRemove | chezmoi.EntryTypeScripts)),
 		},
 		mergeAll: mergeAllCmdConfig{
 			recursive: true,

--- a/pkg/cmd/testdata/scripts/managed.txtar
+++ b/pkg/cmd/testdata/scripts/managed.txtar
@@ -20,9 +20,17 @@ cmp stdout golden/managed-files
 exec chezmoi managed --include=symlinks
 cmp stdout golden/managed-symlinks
 
+# test chezmoi managed --include=templates
+exec chezmoi managed --include=templates
+cmp stdout golden/managed-templates
+
 # test chezmoi managed --exclude=files
 exec chezmoi managed --exclude=files
 cmp stdout golden/managed-except-files
+
+# test chezmoi managed --exclude=files,templates
+exec chezmoi managed --exclude=files,templates
+cmp stdout golden/managed-except-files-and-templates
 
 # test chezmoi managed with arguments
 exec chezmoi managed $HOME${/}.dir $HOME${/}.create
@@ -81,6 +89,24 @@ cmp stdout golden/managed2
 .dir
 .dir/subdir
 .symlink
+.template
+-- golden/managed-except-files-and-templates --
+.dir
+.dir/subdir
+.symlink
+-- golden/managed-except-templates --
+.create
+.dir
+.dir/file
+.dir/subdir
+.dir/subdir/file
+.empty
+.executable
+.file
+.private
+.readonly
+.remove
+.symlink
 -- golden/managed-files --
 .create
 .dir/file
@@ -97,6 +123,8 @@ cmp stdout golden/managed2
 .dir/subdir/file
 -- golden/managed-symlinks --
 .symlink
+-- golden/managed-templates --
+.template
 -- golden/managed-with-absent-args --
 .dir
 .dir/file


### PR DESCRIPTION
Refs @sm1999 in https://github.com/twpayne/chezmoi/issues/2427#issuecomment-1278819861.

This allows you to run commands like:

```console
$ chezmoi managed --include=templates
```

to list all your templates.

chezmoi still needs some work here. The `--include` and `--exclude` flags mix two separate concepts: target state (e.g. `files`, `dirs`,`symlinks`, etc.) and source state (e.g. `encrypted`, `externals`, `templates`). This leads to conflicts when both are specified, for example should `--include=files --exclude=templates` include templated files or not?

Fixing this properly is probably a task for chezmoi v3. 