### PR TITLE
chore: Fix user guide link in support issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_support_request.md
+++ b/.github/ISSUE_TEMPLATE/01_support_request.md
@@ -16,7 +16,7 @@ Describe what you have tried so far.
 
 ## Where else have you checked for solutions?
 
-* [ ] I have read [chezmoi's user guide](https://chezmoi.io/user-guide/), and not found the answer.
+* [ ] I have read [chezmoi's user guide](https://chezmoi.io/user-guide/command-overview/), and not found the answer.
 * [ ] I have searched [chezmoi's reference guide](https://chezmoi.io/reference/), and not found the answer.
 * [ ] Other, please give details.
 


### PR DESCRIPTION
I first noticed this when reading https://github.com/twpayne/chezmoi/issues/2446.

An alternative solution would be to add an index page to the user guide section.