### PR TITLE
fix: Extend template directives functionality

### DIFF
--- a/pkg/chezmoi/sourcestate.go
+++ b/pkg/chezmoi/sourcestate.go
@@ -672,12 +672,8 @@ type ExecuteTemplateDataOptions struct {
 func (s *SourceState) ExecuteTemplateData(options ExecuteTemplateDataOptions) ([]byte, error) {
 	templateOptions := options.TemplateOptions
 	templateOptions.Options = append([]string(nil), s.templateOptions...)
-	data := templateOptions.parseDirectives(options.Data)
-	tmpl, err := template.New(options.Name).
-		Option(templateOptions.Options...).
-		Funcs(s.templateFuncs).
-		Delims(templateOptions.LeftDelimiter, templateOptions.RightDelimiter).
-		Parse(string(data))
+
+	tmpl, err := NewConfiguredTemplate(options.Name, options.Data, s.templateFuncs, templateOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -1265,7 +1261,13 @@ func (s *SourceState) addTemplatesDir(ctx context.Context, templatesDirAbsPath A
 			}
 			templateRelPath := templateAbsPath.MustTrimDirPrefix(templatesDirAbsPath)
 			name := templateRelPath.String()
-			tmpl, err := template.New(name).Option(s.templateOptions...).Funcs(s.templateFuncs).Parse(string(contents))
+
+			tmpl, err := NewConfiguredTemplate(
+				name,
+				contents,
+				s.templateFuncs,
+				TemplateOptions{Options: append([]string(nil), s.templateOptions...)},
+			)
 			if err != nil {
 				return err
 			}
@@ -2179,6 +2181,29 @@ func (e *External) OriginString() string {
 	return e.URL + " defined in " + e.sourceAbsPath.String()
 }
 
+func NewConfiguredTemplate(
+	name string,
+	data []byte,
+	funcs template.FuncMap,
+	options ...TemplateOptions,
+) (*template.Template, error) {
+	var o TemplateOptions
+
+	if len(options) > 0 {
+		o = options[0]
+	} else {
+		o = TemplateOptions{}
+	}
+
+	contents := o.parseDirectives(data)
+
+	return template.New(name).
+		Option(o.Options...).
+		Delims(o.LeftDelimiter, o.RightDelimiter).
+		Funcs(funcs).
+		Parse(string(contents))
+}
+
 // parseDirectives updates o by parsing all template directives in data and
 // returns data with the lines containing directives removed. The lines are
 // removed so that any delimiters do not break template parsing.
@@ -2212,6 +2237,7 @@ func (o *TemplateOptions) parseDirectives(data []byte) []byte {
 		slices = append(slices, data[directiveMatches[i][1]:directiveMatch[0]])
 	}
 	slices = append(slices, data[directiveMatches[len(directiveMatches)-1][1]:])
+
 	return bytes.Join(slices, nil)
 }
 

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -700,7 +700,7 @@ func (c *Config) createConfigFile(filename chezmoi.RelPath, data []byte) ([]byte
 	}
 	chezmoi.RecursiveMerge(funcMap, initTemplateFuncs)
 
-	t, err := template.New(filename.String()).Funcs(funcMap).Parse(string(data))
+	t, err := chezmoi.NewConfiguredTemplate(filename.String(), data, funcMap)
 	if err != nil {
 		return nil, err
 	}
@@ -1285,7 +1285,7 @@ func (c *Config) gitAutoCommit(status *git.Status) error {
 	funcMap["targetRelPath"] = func(source string) string {
 		return chezmoi.NewSourceRelPath(source).TargetRelPath(c.encryption.EncryptedSuffix()).String()
 	}
-	commitMessageTmpl, err := template.New("commit_message").Funcs(funcMap).Parse(string(commitMessageTemplate))
+	commitMessageTmpl, err := chezmoi.NewConfiguredTemplate("commit_message", commitMessageTemplate, funcMap)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/templatefuncs.go
+++ b/pkg/cmd/templatefuncs.go
@@ -12,7 +12,6 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-	"text/template"
 
 	"github.com/bradenhilton/mozillainstallhash"
 	"golang.org/x/exp/constraints"
@@ -158,7 +157,7 @@ func (c *Config) includeTemplateTemplateFunc(filename string, args ...any) strin
 		panic(err)
 	}
 
-	tmpl, err := template.New(filename).Funcs(c.templateFuncs).Parse(string(contents))
+	tmpl, err := chezmoi.NewConfiguredTemplate(filename, contents, c.templateFuncs)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/cmd/testdata/scripts/configstate.txtar
+++ b/pkg/cmd/testdata/scripts/configstate.txtar
@@ -52,12 +52,13 @@ exec chezmoi diff
 ! stderr .
 
 -- golden/.chezmoi.toml.tmpl --
-{{ $email := get . "email" -}}
-{{ if not $email -}}
-{{   $email = promptString "email" -}}
-{{ end -}}
+# chezmoi:template:left-delimiter="((" right-delimiter="))"
+(( $email := get . "email" -))
+(( if not $email -))
+((   $email = promptString "email" -))
+(( end -))
 [data]
-    email = {{ $email | quote }}
+    email = (( $email | quote ))
 -- golden/chezmoi.toml --
 [data]
     email = "me@home.org"

--- a/pkg/cmd/testdata/scripts/templatedirectives.txtar
+++ b/pkg/cmd/testdata/scripts/templatedirectives.txtar
@@ -7,8 +7,11 @@ exec chezmoi cat $HOME${/}template
 cmp stdout golden/template
 
 -- golden/template --
-<no value>
+<no value>(nested)
+-- home/user/.local/share/chezmoi/.chezmoitemplates/nested --
+# chezmoi:template:left-delimiter=(( right-delimiter=))
+((- . -))
 -- home/user/.local/share/chezmoi/template.tmpl --
 # chezmoi:template:left-delimiter=[[ right-delimiter=]]
 # chezmoi:template:missing-key=default
-[[ .MissingKey ]]
+[[ .MissingKey ]]([[ template "nested" "nested" ]])

--- a/pkg/cmd/testdata/scripts/templatefuncs.txtar
+++ b/pkg/cmd/testdata/scripts/templatefuncs.txtar
@@ -173,7 +173,8 @@ subkey = subvalue
 -- home/user/.local/share/chezmoi/.include --
 # contents of .local/share/chezmoi/.include
 -- home/user/.local/share/chezmoi/.template --
-{{ . }}
+chezmoi:template:left-delimiter=[[ right-delimiter=]]
+[[ . ]]
 -- home/user/.local/share/chezmoi/template --
 -- home/user/file1.txt --
 -- home/user/file2.txt --


### PR DESCRIPTION
Fixes #2468

Template directives have been added, but some places were missed in the initial implementation and review (oops).

- pkg/cmd/templatefuncs.go (`includeTemplateTemplateFunc`)
- pkg/chezmoi/sourcestate.go (`addTemplatesDir`)
- pkg/cmd/config.go (`createConfigFile`)
- pkg/cmd/config.go (`gitautoCommit`)

The last is not necessary (since the template is only included as an asset and cannot be replaced), so it can be reversed without issue.