### PR TITLE
feat: Add option to exclude scripts that are always run

### DIFF
--- a/assets/chezmoi.io/docs/reference/command-line-flags/common.md
+++ b/assets/chezmoi.io/docs/reference/command-line-flags/common.md
@@ -8,15 +8,29 @@ Set the output format.
 
 ## `-i`, `--include` *types*
 
-Only operate on target state entries of type *types*. *types* is a
-comma-separated list of target states (`all`, `dirs`, `files`, `remove`,
-`scripts`, `symlinks`) and/or source attributes (`encrypted`, `externals`,
-`templates`) and can be excluded by preceding them with a `no`.
+Include target state entries of type *types*. *types* is a comma-separated list
+of types:
+
+| Type        | Description           |
+| ----------- | --------------------- |
+| `all`       | All entries (default) |
+| `none`      | No entries            |
+| `dirs`      | Directories           |
+| `files`     | Files                 |
+| `remove`    | Removes               |
+| `scripts`   | Scripts               |
+| `symlinks`  | Symbolic links        |
+| `encrypted` | Encrypted entries     |
+| `externals` | External entries      |
+| `templates` | Templates             |
+
+Types can be preceded with `no` to remove them.
+
+Types can be explicitly excluded with the `--exclude` flag.
 
 !!! example
 
-    `--include=dirs,files` will cause the command to apply to directories and
-    files only.
+    `--include=all,noencrypted` specifies all entries except encrypted files.
 
 ## `--init`
 
@@ -33,9 +47,8 @@ Recurse into subdirectories, `true` by default.
 
 ## `-x`, `--exclude` *types*
 
-Exclude target state entries of type *types*. *types* is a comma-separated list
-of target states (`all`, `dirs`, `files`, `remove`, `scripts`, `symlinks`)
-and/or source attributes (`encrypted`, `externals`, `templates`).
+Exclude target state entries of type *types*. *types* is defined as in the
+`--include` flag and defaults to `none`.
 
 !!! example
 

--- a/assets/chezmoi.io/docs/reference/command-line-flags/common.md
+++ b/assets/chezmoi.io/docs/reference/command-line-flags/common.md
@@ -11,18 +11,19 @@ Set the output format.
 Include target state entries of type *types*. *types* is a comma-separated list
 of types:
 
-| Type        | Description           |
-| ----------- | --------------------- |
-| `all`       | All entries (default) |
-| `none`      | No entries            |
-| `dirs`      | Directories           |
-| `files`     | Files                 |
-| `remove`    | Removes               |
-| `scripts`   | Scripts               |
-| `symlinks`  | Symbolic links        |
-| `encrypted` | Encrypted entries     |
-| `externals` | External entries      |
-| `templates` | Templates             |
+| Type        | Description                 |
+| ----------- | --------------------------- |
+| `all`       | All entries (default)       |
+| `none`      | No entries                  |
+| `dirs`      | Directories                 |
+| `files`     | Files                       |
+| `remove`    | Removes                     |
+| `scripts`   | Scripts                     |
+| `symlinks`  | Symbolic links              |
+| `always`    | Scripts that are always run |
+| `encrypted` | Encrypted entries           |
+| `externals` | External entries            |
+| `templates` | Templates                   |
 
 Types can be preceded with `no` to remove them.
 

--- a/pkg/chezmoi/attr.go
+++ b/pkg/chezmoi/attr.go
@@ -46,7 +46,8 @@ type ScriptCondition string
 
 // Script conditions.
 const (
-	ScriptConditionAlways   ScriptCondition = ""
+	ScriptConditionNone     ScriptCondition = ""
+	ScriptConditionAlways   ScriptCondition = "always"
 	ScriptConditionOnce     ScriptCondition = "once"
 	ScriptConditionOnChange ScriptCondition = "onchange"
 )
@@ -166,7 +167,7 @@ func parseFileAttr(sourceName, encryptedSuffix string) FileAttr {
 	var (
 		sourceFileType = SourceFileTypeFile
 		name           = sourceName
-		condition      = ScriptConditionAlways
+		condition      = ScriptConditionNone
 		empty          = false
 		encrypted      = false
 		executable     = false
@@ -208,6 +209,8 @@ func parseFileAttr(sourceName, encryptedSuffix string) FileAttr {
 		case strings.HasPrefix(name, onChangePrefix):
 			name = mustTrimPrefix(name, onChangePrefix)
 			condition = ScriptConditionOnChange
+		default:
+			condition = ScriptConditionAlways
 		}
 		switch {
 		case strings.HasPrefix(name, beforePrefix):

--- a/pkg/chezmoi/attr_test.go
+++ b/pkg/chezmoi/attr_test.go
@@ -242,6 +242,7 @@ func TestFileAttrLiteral(t *testing.T) {
 			sourceName: "run_literal_once_script",
 			fileAttr: FileAttr{
 				TargetName: "once_script",
+				Condition:  ScriptConditionAlways,
 				Type:       SourceFileTypeScript,
 			},
 		},

--- a/pkg/chezmoi/dumpsystem_test.go
+++ b/pkg/chezmoi/dumpsystem_test.go
@@ -49,7 +49,7 @@ func TestDumpSystem(t *testing.T) {
 		dumpSystem := NewDumpSystem()
 		persistentState := NewMockPersistentState()
 		require.NoError(t, s.applyAll(dumpSystem, system, persistentState, EmptyAbsPath, ApplyOptions{
-			Include: NewEntryTypeSet(EntryTypesAll),
+			Filter: NewEntryTypeFilter(EntryTypesAll, EntryTypesNone),
 		}))
 		expectedData := map[string]any{
 			".dir": &dirData{

--- a/pkg/chezmoi/entrytypefilter.go
+++ b/pkg/chezmoi/entrytypefilter.go
@@ -1,0 +1,40 @@
+package chezmoi
+
+import "io/fs"
+
+// An EntryTypeFilter filters entries by type and source attributes. Any entry
+// in the include set is included, otherwise if the entry is in the exclude set
+// then it is excluded, otherwise it is included.
+type EntryTypeFilter struct {
+	Include *EntryTypeSet
+	Exclude *EntryTypeSet
+}
+
+// NewEntryTypeFilter returns a new EntryTypeFilter with the given entry type
+// bits.
+func NewEntryTypeFilter(includeEntryTypeBits, excludeEntryTypeBits EntryTypeBits) *EntryTypeFilter {
+	return &EntryTypeFilter{
+		Include: NewEntryTypeSet(includeEntryTypeBits),
+		Exclude: NewEntryTypeSet(excludeEntryTypeBits),
+	}
+}
+
+// IncludeEntryTypes returns if entryTypeBits is included.
+func (f *EntryTypeFilter) IncludeEntryTypeBits(entryTypeBits EntryTypeBits) bool {
+	return f.Include.ContainsEntryTypeBits(entryTypeBits) && !f.Exclude.ContainsEntryTypeBits(entryTypeBits)
+}
+
+// IncludeFileInfo returns if fileInfo is included.
+func (f *EntryTypeFilter) IncludeFileInfo(fileInfo fs.FileInfo) bool {
+	return f.Include.ContainsFileInfo(fileInfo) && !f.Exclude.ContainsFileInfo(fileInfo)
+}
+
+// IncludeSourceStateEntry returns if sourceStateEntry is included.
+func (f *EntryTypeFilter) IncludeSourceStateEntry(sourceStateEntry SourceStateEntry) bool {
+	return f.Include.ContainsSourceStateEntry(sourceStateEntry) && !f.Exclude.ContainsSourceStateEntry(sourceStateEntry)
+}
+
+// IncludeTargetStateEntry returns if targetStateEntry is included.
+func (f *EntryTypeFilter) IncludeTargetStateEntry(targetStateEntry TargetStateEntry) bool {
+	return f.Include.ContainsTargetStateEntry(targetStateEntry) && !f.Exclude.ContainsTargetStateEntry(targetStateEntry)
+}

--- a/pkg/chezmoi/entrytypeset.go
+++ b/pkg/chezmoi/entrytypeset.go
@@ -30,6 +30,7 @@ const (
 	EntryTypeEncrypted
 	EntryTypeExternals
 	EntryTypeTemplates
+	EntryTypeAlways
 
 	// EntryTypesAll is all entry types.
 	EntryTypesAll EntryTypeBits = EntryTypeDirs |
@@ -39,7 +40,8 @@ const (
 		EntryTypeSymlinks |
 		EntryTypeEncrypted |
 		EntryTypeExternals |
-		EntryTypeTemplates
+		EntryTypeTemplates |
+		EntryTypeAlways
 
 	// EntryTypesNone is no entry types.
 	EntryTypesNone EntryTypeBits = 0
@@ -49,6 +51,7 @@ var (
 	// entryTypeBits is a map from human-readable strings to EntryTypeBits.
 	entryTypeBits = map[string]EntryTypeBits{
 		"all":       EntryTypesAll,
+		"always":    EntryTypeAlways,
 		"dirs":      EntryTypeDirs,
 		"files":     EntryTypeFiles,
 		"remove":    EntryTypeRemove,
@@ -63,10 +66,12 @@ var (
 
 	entryTypeCompletions = []string{
 		"all",
+		"always",
 		"dirs",
 		"encrypted",
 		"externals",
 		"files",
+		"noalways",
 		"nodirs",
 		"noencrypted",
 		"noexternals",
@@ -149,6 +154,8 @@ func (s *EntryTypeSet) ContainsSourceStateEntry(sourceStateEntry SourceStateEntr
 			return true
 		case s.bits&EntryTypeSymlinks != 0 && sourceAttr.Type == SourceFileTypeSymlink:
 			return true
+		case s.bits&EntryTypeAlways != 0 && sourceAttr.Condition == ScriptConditionAlways:
+			return true
 		case s.bits&EntryTypeEncrypted != 0 && sourceAttr.Encrypted:
 			return true
 		case s.bits&EntryTypeExternals != 0 && !sourceStateEntry.origin.Path().Empty():
@@ -218,6 +225,8 @@ func (s *EntryTypeSet) ContainsTargetStateEntry(targetStateEntry TargetStateEntr
 		case s.bits&EntryTypeEncrypted != 0 && sourceAttr.Encrypted:
 			return true
 		case s.bits&EntryTypeTemplates != 0 && sourceAttr.Template:
+			return true
+		case s.bits&EntryTypeAlways != 0 && sourceAttr.Condition == ScriptConditionAlways:
 			return true
 		default:
 			return false

--- a/pkg/chezmoi/entrytypeset_test.go
+++ b/pkg/chezmoi/entrytypeset_test.go
@@ -32,7 +32,7 @@ func TestIncludeMaskSet(t *testing.T) {
 		},
 		{
 			s:        "all,noscripts",
-			expected: NewEntryTypeSet(EntryTypeDirs | EntryTypeFiles | EntryTypeRemove | EntryTypeSymlinks | EntryTypeEncrypted | EntryTypeExternals | EntryTypeTemplates),
+			expected: NewEntryTypeSet(EntryTypesAll &^ EntryTypeScripts),
 		},
 		{
 			s:        "noscripts",
@@ -132,6 +132,12 @@ func TestEntryTypeSetFlagCompletionFunc(t *testing.T) {
 			expectedCompletions: []string{
 				"encrypted",
 				"externals",
+			},
+		},
+		{
+			toComplete: "t",
+			expectedCompletions: []string{
+				"templates",
 			},
 		},
 		{

--- a/pkg/chezmoi/entrytypeset_test.go
+++ b/pkg/chezmoi/entrytypeset_test.go
@@ -125,6 +125,7 @@ func TestEntryTypeSetFlagCompletionFunc(t *testing.T) {
 			toComplete: "a",
 			expectedCompletions: []string{
 				"all",
+				"always",
 			},
 		},
 		{

--- a/pkg/chezmoi/sourcestate.go
+++ b/pkg/chezmoi/sourcestate.go
@@ -1607,6 +1607,9 @@ func (s *SourceState) newScriptTargetStateEntryFunc(
 			name:         targetRelPath,
 			condition:    fileAttr.Condition,
 			interpreter:  interpreter,
+			sourceAttr: SourceAttr{
+				Condition: fileAttr.Condition,
+			},
 		}, nil
 	}
 }

--- a/pkg/chezmoi/sourcestate_test.go
+++ b/pkg/chezmoi/sourcestate_test.go
@@ -37,7 +37,7 @@ func TestSourceStateAdd(t *testing.T) {
 				NewAbsPath("/home/user/.dir"),
 			},
 			addOptions: AddOptions{
-				Include: NewEntryTypeSet(EntryTypesAll),
+				Filter: NewEntryTypeFilter(EntryTypesAll, EntryTypesNone),
 			},
 			tests: []any{
 				vfst.TestPath("/home/user/.local/share/chezmoi/dot_dir",
@@ -58,7 +58,7 @@ func TestSourceStateAdd(t *testing.T) {
 				NewAbsPath("/home/user/.dir"),
 			},
 			addOptions: AddOptions{
-				Include: NewEntryTypeSet(EntryTypesAll),
+				Filter: NewEntryTypeFilter(EntryTypesAll, EntryTypesNone),
 			},
 			extraRoot: map[string]any{
 				"/home/user": map[string]any{
@@ -86,7 +86,7 @@ func TestSourceStateAdd(t *testing.T) {
 				NewAbsPath("/home/user/.dir/file"),
 			},
 			addOptions: AddOptions{
-				Include: NewEntryTypeSet(EntryTypesAll),
+				Filter: NewEntryTypeFilter(EntryTypesAll, EntryTypesNone),
 			},
 			tests: []any{
 				vfst.TestPath("/home/user/.local/share/chezmoi/dot_dir",
@@ -106,7 +106,7 @@ func TestSourceStateAdd(t *testing.T) {
 				NewAbsPath("/home/user/.dir/file"),
 			},
 			addOptions: AddOptions{
-				Include: NewEntryTypeSet(EntryTypesAll),
+				Filter: NewEntryTypeFilter(EntryTypesAll, EntryTypesNone),
 			},
 			extraRoot: map[string]any{
 				"/home/user/.local/share/chezmoi/dot_dir": &vfst.Dir{Perm: 0o777},
@@ -124,7 +124,7 @@ func TestSourceStateAdd(t *testing.T) {
 				NewAbsPath("/home/user/.dir/subdir"),
 			},
 			addOptions: AddOptions{
-				Include: NewEntryTypeSet(EntryTypesAll),
+				Filter: NewEntryTypeFilter(EntryTypesAll, EntryTypesNone),
 			},
 			tests: []any{
 				vfst.TestPath("/home/user/.local/share/chezmoi/dot_dir",
@@ -146,7 +146,7 @@ func TestSourceStateAdd(t *testing.T) {
 				NewAbsPath("/home/user/.dir/subdir/file"),
 			},
 			addOptions: AddOptions{
-				Include: NewEntryTypeSet(EntryTypesAll),
+				Filter: NewEntryTypeFilter(EntryTypesAll, EntryTypesNone),
 			},
 			tests: []any{
 				vfst.TestPath("/home/user/.local/share/chezmoi/dot_dir",
@@ -173,7 +173,7 @@ func TestSourceStateAdd(t *testing.T) {
 				NewAbsPath("/home/user/.dir/subdir/file"),
 			},
 			addOptions: AddOptions{
-				Include: NewEntryTypeSet(EntryTypesAll),
+				Filter: NewEntryTypeFilter(EntryTypesAll, EntryTypesNone),
 			},
 			extraRoot: map[string]any{
 				"/home/user/.local/share/chezmoi/dot_dir/subdir": &vfst.Dir{Perm: 0o777},
@@ -191,7 +191,7 @@ func TestSourceStateAdd(t *testing.T) {
 				NewAbsPath("/home/user/.readonly_dir"),
 			},
 			addOptions: AddOptions{
-				Include: NewEntryTypeSet(EntryTypesAll),
+				Filter: NewEntryTypeFilter(EntryTypesAll, EntryTypesNone),
 			},
 			extraRoot: map[string]any{
 				"/home/user/.readonly_dir": &vfst.Dir{Perm: 0o555},
@@ -209,7 +209,7 @@ func TestSourceStateAdd(t *testing.T) {
 				NewAbsPath("/home/user/.empty"),
 			},
 			addOptions: AddOptions{
-				Include: NewEntryTypeSet(EntryTypesAll),
+				Filter: NewEntryTypeFilter(EntryTypesAll, EntryTypesNone),
 			},
 			tests: []any{
 				vfst.TestPath("/home/user/.local/share/chezmoi/dot_empty",
@@ -223,7 +223,7 @@ func TestSourceStateAdd(t *testing.T) {
 				NewAbsPath("/home/user/.empty"),
 			},
 			addOptions: AddOptions{
-				Include: NewEntryTypeSet(EntryTypesAll),
+				Filter: NewEntryTypeFilter(EntryTypesAll, EntryTypesNone),
 			},
 			tests: []any{
 				vfst.TestPath("/home/user/.local/share/chezmoi/empty_dot_empty",
@@ -239,7 +239,7 @@ func TestSourceStateAdd(t *testing.T) {
 				NewAbsPath("/home/user/.executable"),
 			},
 			addOptions: AddOptions{
-				Include: NewEntryTypeSet(EntryTypesAll),
+				Filter: NewEntryTypeFilter(EntryTypesAll, EntryTypesNone),
 			},
 			tests: []any{
 				vfst.TestPath("/home/user/.local/share/chezmoi/executable_dot_executable",
@@ -255,7 +255,7 @@ func TestSourceStateAdd(t *testing.T) {
 				NewAbsPath("/home/user/.executable"),
 			},
 			addOptions: AddOptions{
-				Include: NewEntryTypeSet(EntryTypesAll),
+				Filter: NewEntryTypeFilter(EntryTypesAll, EntryTypesNone),
 			},
 			tests: []any{
 				vfst.TestPath("/home/user/.local/share/chezmoi/dot_executable",
@@ -271,8 +271,8 @@ func TestSourceStateAdd(t *testing.T) {
 				NewAbsPath("/home/user/.create"),
 			},
 			addOptions: AddOptions{
-				Create:  true,
-				Include: NewEntryTypeSet(EntryTypesAll),
+				Create: true,
+				Filter: NewEntryTypeFilter(EntryTypesAll, EntryTypesNone),
 			},
 			tests: []any{
 				vfst.TestPath("/home/user/.local/share/chezmoi/create_dot_create",
@@ -288,7 +288,7 @@ func TestSourceStateAdd(t *testing.T) {
 				NewAbsPath("/home/user/.file"),
 			},
 			addOptions: AddOptions{
-				Include: NewEntryTypeSet(EntryTypesAll),
+				Filter: NewEntryTypeFilter(EntryTypesAll, EntryTypesNone),
 			},
 			tests: []any{
 				vfst.TestPath("/home/user/.local/share/chezmoi/dot_file",
@@ -304,7 +304,7 @@ func TestSourceStateAdd(t *testing.T) {
 				NewAbsPath("/home/user/.file"),
 			},
 			addOptions: AddOptions{
-				Include: NewEntryTypeSet(EntryTypesAll),
+				Filter: NewEntryTypeFilter(EntryTypesAll, EntryTypesNone),
 			},
 			extraRoot: map[string]any{
 				"/home/user/.local/share/chezmoi/executable_dot_file": "# contents of .file\n",
@@ -326,7 +326,7 @@ func TestSourceStateAdd(t *testing.T) {
 				NewAbsPath("/home/user/.file"),
 			},
 			addOptions: AddOptions{
-				Include: NewEntryTypeSet(EntryTypesAll),
+				Filter: NewEntryTypeFilter(EntryTypesAll, EntryTypesNone),
 			},
 			extraRoot: map[string]any{
 				"/home/user/.local/share/chezmoi/dot_file": "# old contents of .file\n",
@@ -345,7 +345,7 @@ func TestSourceStateAdd(t *testing.T) {
 				NewAbsPath("/home/user/.private"),
 			},
 			addOptions: AddOptions{
-				Include: NewEntryTypeSet(EntryTypesAll),
+				Filter: NewEntryTypeFilter(EntryTypesAll, EntryTypesNone),
 			},
 			tests: []any{
 				vfst.TestPath("/home/user/.local/share/chezmoi/private_dot_private",
@@ -361,7 +361,7 @@ func TestSourceStateAdd(t *testing.T) {
 				NewAbsPath("/home/user/.private"),
 			},
 			addOptions: AddOptions{
-				Include: NewEntryTypeSet(EntryTypesAll),
+				Filter: NewEntryTypeFilter(EntryTypesAll, EntryTypesNone),
 			},
 			tests: []any{
 				vfst.TestPath("/home/user/.local/share/chezmoi/dot_private",
@@ -377,7 +377,7 @@ func TestSourceStateAdd(t *testing.T) {
 				NewAbsPath("/home/user/.readonly"),
 			},
 			addOptions: AddOptions{
-				Include: NewEntryTypeSet(EntryTypesAll),
+				Filter: NewEntryTypeFilter(EntryTypesAll, EntryTypesNone),
 			},
 			extraRoot: map[string]any{
 				"/home/user/.readonly": &vfst.File{
@@ -399,7 +399,7 @@ func TestSourceStateAdd(t *testing.T) {
 				NewAbsPath("/home/user/.symlink"),
 			},
 			addOptions: AddOptions{
-				Include: NewEntryTypeSet(EntryTypesAll),
+				Filter: NewEntryTypeFilter(EntryTypesAll, EntryTypesNone),
 			},
 			tests: []any{
 				vfst.TestPath("/home/user/.local/share/chezmoi/symlink_dot_symlink",
@@ -414,7 +414,7 @@ func TestSourceStateAdd(t *testing.T) {
 				NewAbsPath("/home/user/.symlink_windows"),
 			},
 			addOptions: AddOptions{
-				Include: NewEntryTypeSet(EntryTypesAll),
+				Filter: NewEntryTypeFilter(EntryTypesAll, EntryTypesNone),
 			},
 			extraRoot: map[string]any{
 				"/home/user": map[string]any{
@@ -435,7 +435,7 @@ func TestSourceStateAdd(t *testing.T) {
 			},
 			addOptions: AddOptions{
 				AutoTemplate: true,
-				Include:      NewEntryTypeSet(EntryTypesAll),
+				Filter:       NewEntryTypeFilter(EntryTypesAll, EntryTypesNone),
 			},
 			tests: []any{
 				vfst.TestPath("/home/user/.local/share/chezmoi/dot_template.tmpl",
@@ -452,7 +452,7 @@ func TestSourceStateAdd(t *testing.T) {
 				NewAbsPath("/home/user/.dir/file"),
 			},
 			addOptions: AddOptions{
-				Include: NewEntryTypeSet(EntryTypesAll),
+				Filter: NewEntryTypeFilter(EntryTypesAll, EntryTypesNone),
 			},
 			tests: []any{
 				vfst.TestPath("/home/user/.local/share/chezmoi/dot_dir",
@@ -472,7 +472,7 @@ func TestSourceStateAdd(t *testing.T) {
 				NewAbsPath("/home/user/.dir/subdir/file"),
 			},
 			addOptions: AddOptions{
-				Include: NewEntryTypeSet(EntryTypesAll),
+				Filter: NewEntryTypeFilter(EntryTypesAll, EntryTypesNone),
 			},
 			extraRoot: map[string]any{
 				"/home/user/.local/share/chezmoi/dot_dir/exact_subdir": &vfst.Dir{Perm: 0o777},
@@ -596,7 +596,7 @@ func TestSourceStateAddInExternal(t *testing.T) {
 			destAbsPath: fileInfo,
 		}
 		require.NoError(t, s.Add(system, persistentState, system, destAbsPathInfos, &AddOptions{
-			Include: NewEntryTypeSet(EntryTypesAll),
+			Filter: NewEntryTypeFilter(EntryTypesAll, EntryTypesNone),
 		}))
 
 		vfst.RunTests(t, fileSystem, "",
@@ -822,8 +822,8 @@ func TestSourceStateApplyAll(t *testing.T) {
 				require.NoError(t, s.Read(ctx, nil))
 				requireEvaluateAll(t, s, system)
 				require.NoError(t, s.applyAll(system, system, persistentState, NewAbsPath("/home/user"), ApplyOptions{
-					Include: NewEntryTypeSet(EntryTypesAll),
-					Umask:   chezmoitest.Umask,
+					Filter: NewEntryTypeFilter(EntryTypesAll, EntryTypesNone),
+					Umask:  chezmoitest.Umask,
 				}))
 
 				vfst.RunTests(t, fileSystem, "", tc.tests...)

--- a/pkg/chezmoi/sourcestate_test.go
+++ b/pkg/chezmoi/sourcestate_test.go
@@ -972,11 +972,16 @@ func TestSourceStateRead(t *testing.T) {
 						Attr: FileAttr{
 							TargetName: "script",
 							Type:       SourceFileTypeScript,
+							Condition:  ScriptConditionAlways,
 						},
 						lazyContents: newLazyContents([]byte("# contents of .script\n")),
 						targetStateEntry: &TargetStateScript{
 							name:         NewRelPath("script"),
 							lazyContents: newLazyContents([]byte("# contents of .script\n")),
+							condition:    ScriptConditionAlways,
+							sourceAttr: SourceAttr{
+								Condition: ScriptConditionAlways,
+							},
 						},
 					},
 				}),
@@ -997,11 +1002,16 @@ func TestSourceStateRead(t *testing.T) {
 						Attr: FileAttr{
 							TargetName: "script",
 							Type:       SourceFileTypeScript,
+							Condition:  ScriptConditionAlways,
 						},
 						lazyContents: newLazyContents([]byte("# contents of script\n")),
 						targetStateEntry: &TargetStateScript{
 							name:         NewRelPath("script"),
 							lazyContents: newLazyContents([]byte("# contents of script\n")),
+							condition:    ScriptConditionAlways,
+							sourceAttr: SourceAttr{
+								Condition: ScriptConditionAlways,
+							},
 						},
 					},
 				}),

--- a/pkg/chezmoi/sourcestateentry.go
+++ b/pkg/chezmoi/sourcestateentry.go
@@ -11,6 +11,7 @@ import (
 
 // A SourceAttr contains attributes of the source.
 type SourceAttr struct {
+	Condition ScriptCondition
 	Encrypted bool
 	External  bool
 	Template  bool

--- a/pkg/chezmoi/tarwritersystem_test.go
+++ b/pkg/chezmoi/tarwritersystem_test.go
@@ -53,7 +53,7 @@ func TestTarWriterSystem(t *testing.T) {
 		tarWriterSystem := NewTarWriterSystem(b, tar.Header{})
 		persistentState := NewMockPersistentState()
 		require.NoError(t, s.applyAll(tarWriterSystem, system, persistentState, EmptyAbsPath, ApplyOptions{
-			Include: NewEntryTypeSet(EntryTypesAll),
+			Filter: NewEntryTypeFilter(EntryTypesAll, EntryTypesNone),
 		}))
 		require.NoError(t, tarWriterSystem.Close())
 

--- a/pkg/chezmoi/zipwritersystem_test.go
+++ b/pkg/chezmoi/zipwritersystem_test.go
@@ -55,7 +55,7 @@ func TestZIPWriterSystem(t *testing.T) {
 		zipWriterSystem := NewZIPWriterSystem(b, time.Now().UTC())
 		persistentState := NewMockPersistentState()
 		require.NoError(t, s.applyAll(zipWriterSystem, system, persistentState, EmptyAbsPath, ApplyOptions{
-			Include: NewEntryTypeSet(EntryTypesAll),
+			Filter: NewEntryTypeFilter(EntryTypesAll, EntryTypesNone),
 		}))
 		require.NoError(t, zipWriterSystem.Close())
 

--- a/pkg/cmd/addcmd.go
+++ b/pkg/cmd/addcmd.go
@@ -14,9 +14,8 @@ type addCmdConfig struct {
 	create           bool
 	encrypt          bool
 	exact            bool
-	exclude          *chezmoi.EntryTypeSet
+	filter           *chezmoi.EntryTypeFilter
 	follow           bool
-	include          *chezmoi.EntryTypeSet
 	prompt           bool
 	recursive        bool
 	template         bool
@@ -44,9 +43,9 @@ func (c *Config) newAddCmd() *cobra.Command {
 	flags.BoolVar(&c.Add.create, "create", c.Add.create, "Add files that should exist, irrespective of their contents")
 	flags.BoolVar(&c.Add.encrypt, "encrypt", c.Add.encrypt, "Encrypt files")
 	flags.BoolVar(&c.Add.exact, "exact", c.Add.exact, "Add directories exactly")
-	flags.VarP(c.Add.exclude, "exclude", "x", "Exclude entry types")
+	flags.VarP(c.Add.filter.Exclude, "exclude", "x", "Exclude entry types")
 	flags.BoolVarP(&c.Add.follow, "follow", "f", c.Add.follow, "Add symlink targets instead of symlinks")
-	flags.VarP(c.Add.include, "include", "i", "Include entry types")
+	flags.VarP(c.Add.filter.Include, "include", "i", "Include entry types")
 	flags.BoolVarP(&c.Add.prompt, "prompt", "p", c.Add.prompt, "Prompt before adding each entry")
 	flags.BoolVarP(&c.Add.recursive, "recursive", "r", c.Add.recursive, "Recurse into subdirectories")
 	flags.BoolVarP(&c.Add.template, "template", "T", c.Add.template, "Add files as templates")
@@ -147,7 +146,7 @@ func (c *Config) runAddCmd(cmd *cobra.Command, args []string, sourceState *chezm
 		Encrypt:          c.Add.encrypt,
 		EncryptedSuffix:  c.encryption.EncryptedSuffix(),
 		Exact:            c.Add.exact,
-		Include:          c.Add.include.Sub(c.Add.exclude),
+		Filter:           c.Add.filter,
 		PreAddFunc:       c.defaultPreAddFunc,
 		ReplaceFunc:      c.defaultReplaceFunc,
 		Template:         c.Add.template,

--- a/pkg/cmd/applycmd.go
+++ b/pkg/cmd/applycmd.go
@@ -7,9 +7,8 @@ import (
 )
 
 type applyCmdConfig struct {
-	exclude   *chezmoi.EntryTypeSet
+	filter    *chezmoi.EntryTypeFilter
 	init      bool
-	include   *chezmoi.EntryTypeSet
 	recursive bool
 }
 
@@ -29,8 +28,8 @@ func (c *Config) newApplyCmd() *cobra.Command {
 	}
 
 	flags := applyCmd.Flags()
-	flags.VarP(c.apply.exclude, "exclude", "x", "Exclude entry types")
-	flags.VarP(c.apply.include, "include", "i", "Include entry types")
+	flags.VarP(c.apply.filter.Exclude, "exclude", "x", "Exclude entry types")
+	flags.VarP(c.apply.filter.Include, "include", "i", "Include entry types")
 	flags.BoolVar(&c.apply.init, "init", c.update.init, "Recreate config file from template")
 	flags.BoolVarP(&c.apply.recursive, "recursive", "r", c.apply.recursive, "Recurse into subdirectories")
 
@@ -41,7 +40,7 @@ func (c *Config) newApplyCmd() *cobra.Command {
 
 func (c *Config) runApplyCmd(cmd *cobra.Command, args []string) error {
 	return c.applyArgs(cmd.Context(), c.destSystem, c.DestDirAbsPath, args, applyArgsOptions{
-		include:      c.apply.include.Sub(c.apply.exclude),
+		filter:       c.apply.filter,
 		init:         c.apply.init,
 		recursive:    c.apply.recursive,
 		umask:        c.Umask,

--- a/pkg/cmd/archivecmd.go
+++ b/pkg/cmd/archivecmd.go
@@ -14,10 +14,9 @@ import (
 )
 
 type archiveCmdConfig struct {
-	exclude   *chezmoi.EntryTypeSet
+	filter    *chezmoi.EntryTypeFilter
 	format    chezmoi.ArchiveFormat
 	gzip      bool
-	include   *chezmoi.EntryTypeSet
 	init      bool
 	recursive bool
 }
@@ -37,10 +36,10 @@ func (c *Config) newArchiveCmd() *cobra.Command {
 	}
 
 	flags := archiveCmd.Flags()
-	flags.VarP(c.archive.exclude, "exclude", "x", "Exclude entry types")
+	flags.VarP(c.archive.filter.Exclude, "exclude", "x", "Exclude entry types")
 	flags.VarP(&c.archive.format, "format", "f", "Set archive format")
 	flags.BoolVarP(&c.archive.gzip, "gzip", "z", c.archive.gzip, "Compress output with gzip")
-	flags.VarP(c.archive.include, "include", "i", "Include entry types")
+	flags.VarP(c.archive.filter.Exclude, "include", "i", "Include entry types")
 	flags.BoolVar(&c.archive.init, "init", c.update.init, "Recreate config file from template")
 	flags.BoolVarP(&c.archive.recursive, "recursive", "r", c.archive.recursive, "Recurse into subdirectories")
 
@@ -77,7 +76,7 @@ func (c *Config) runArchiveCmd(cmd *cobra.Command, args []string) error {
 		return chezmoi.UnknownArchiveFormatError(format)
 	}
 	if err := c.applyArgs(cmd.Context(), archiveSystem, chezmoi.EmptyAbsPath, args, applyArgsOptions{
-		include:   c.archive.include.Sub(c.archive.exclude),
+		filter:    c.archive.filter,
 		init:      c.archive.init,
 		recursive: c.archive.recursive,
 	}); err != nil {

--- a/pkg/cmd/diffcmd.go
+++ b/pkg/cmd/diffcmd.go
@@ -53,7 +53,7 @@ func (c *Config) runDiffCmd(cmd *cobra.Command, args []string) (err error) {
 	dryRunSystem := chezmoi.NewDryRunSystem(c.destSystem)
 	diffSystem := c.newDiffSystem(dryRunSystem, builder, c.DestDirAbsPath)
 	if err = c.applyArgs(cmd.Context(), diffSystem, c.DestDirAbsPath, args, applyArgsOptions{
-		include:   c.Diff.include.Sub(c.Diff.Exclude),
+		filter:    chezmoi.NewEntryTypeFilter(c.Diff.include.Bits(), c.Diff.Exclude.Bits()),
 		init:      c.Diff.init,
 		recursive: c.Diff.recursive,
 		umask:     c.Umask,

--- a/pkg/cmd/dumpcmd.go
+++ b/pkg/cmd/dumpcmd.go
@@ -7,8 +7,7 @@ import (
 )
 
 type dumpCmdConfig struct {
-	exclude   *chezmoi.EntryTypeSet
-	include   *chezmoi.EntryTypeSet
+	filter    *chezmoi.EntryTypeFilter
 	init      bool
 	recursive bool
 }
@@ -28,9 +27,9 @@ func (c *Config) newDumpCmd() *cobra.Command {
 	}
 
 	flags := dumpCmd.Flags()
-	flags.VarP(c.dump.exclude, "exclude", "x", "Exclude entry types")
+	flags.VarP(c.dump.filter.Exclude, "exclude", "x", "Exclude entry types")
 	flags.VarP(&c.Format, "format", "f", "Output format")
-	flags.VarP(c.dump.include, "include", "i", "Include entry types")
+	flags.VarP(c.dump.filter.Include, "include", "i", "Include entry types")
 	flags.BoolVar(&c.dump.init, "init", c.update.init, "Recreate config file from template")
 	flags.BoolVarP(&c.dump.recursive, "recursive", "r", c.dump.recursive, "Recurse into subdirectories")
 	if err := dumpCmd.RegisterFlagCompletionFunc("format", writeDataFormatFlagCompletionFunc); err != nil {
@@ -45,7 +44,7 @@ func (c *Config) newDumpCmd() *cobra.Command {
 func (c *Config) runDumpCmd(cmd *cobra.Command, args []string) error {
 	dumpSystem := chezmoi.NewDumpSystem()
 	if err := c.applyArgs(cmd.Context(), dumpSystem, chezmoi.EmptyAbsPath, args, applyArgsOptions{
-		include:   c.dump.include.Sub(c.dump.exclude),
+		filter:    c.dump.filter,
 		init:      c.dump.init,
 		recursive: c.dump.recursive,
 		umask:     c.Umask,

--- a/pkg/cmd/editcmd.go
+++ b/pkg/cmd/editcmd.go
@@ -18,8 +18,7 @@ type editCmdConfig struct {
 	MinDuration time.Duration `mapstructure:"minDuration"`
 	Watch       bool          `mapstructure:"watch"`
 	Apply       bool          `mapstructure:"apply"`
-	exclude     *chezmoi.EntryTypeSet
-	include     *chezmoi.EntryTypeSet
+	filter      *chezmoi.EntryTypeFilter
 	init        bool
 }
 
@@ -42,9 +41,9 @@ func (c *Config) newEditCmd() *cobra.Command {
 
 	flags := editCmd.Flags()
 	flags.BoolVarP(&c.Edit.Apply, "apply", "a", c.Edit.Apply, "Apply after editing")
-	flags.VarP(c.Edit.exclude, "exclude", "x", "Exclude entry types")
+	flags.VarP(c.Edit.filter.Exclude, "exclude", "x", "Exclude entry types")
 	flags.BoolVar(&c.Edit.Hardlink, "hardlink", c.Edit.Hardlink, "Invoke editor with a hardlink to the source file")
-	flags.VarP(c.Edit.include, "include", "i", "Include entry types")
+	flags.VarP(c.Edit.filter.Include, "include", "i", "Include entry types")
 	flags.BoolVar(&c.Edit.init, "init", c.Edit.init, "Recreate config file from template")
 	flags.BoolVar(&c.Edit.Watch, "watch", c.Edit.Watch, "Apply on save")
 
@@ -60,7 +59,7 @@ func (c *Config) runEditCmd(cmd *cobra.Command, args []string) error {
 		}
 		if c.Edit.Apply {
 			if err := c.applyArgs(cmd.Context(), c.destSystem, c.DestDirAbsPath, noArgs, applyArgsOptions{
-				include:      c.Edit.include.Sub(c.Edit.exclude),
+				filter:       c.Edit.filter,
 				init:         c.Edit.init,
 				recursive:    true,
 				umask:        c.Umask,
@@ -179,7 +178,7 @@ TARGETRELPATH:
 
 		if c.Edit.Apply || c.Edit.Watch {
 			if err := c.applyArgs(cmd.Context(), c.destSystem, c.DestDirAbsPath, args, applyArgsOptions{
-				include:      c.Edit.include,
+				filter:       c.Edit.filter,
 				init:         c.Edit.init,
 				recursive:    true,
 				umask:        c.Umask,

--- a/pkg/cmd/importcmd.go
+++ b/pkg/cmd/importcmd.go
@@ -9,10 +9,9 @@ import (
 )
 
 type importCmdConfig struct {
-	exclude           *chezmoi.EntryTypeSet
 	destination       chezmoi.AbsPath
 	exact             bool
-	include           *chezmoi.EntryTypeSet
+	filter            *chezmoi.EntryTypeFilter
 	removeDestination bool
 	stripComponents   int
 }
@@ -35,8 +34,8 @@ func (c *Config) newImportCmd() *cobra.Command {
 	flags := importCmd.Flags()
 	flags.VarP(&c._import.destination, "destination", "d", "Set destination prefix")
 	flags.BoolVar(&c._import.exact, "exact", c._import.exact, "Set exact_ attribute on imported directories")
-	flags.VarP(c._import.exclude, "exclude", "x", "Exclude entry types")
-	flags.VarP(c._import.include, "include", "i", "Include entry types")
+	flags.VarP(c._import.filter.Exclude, "exclude", "x", "Exclude entry types")
+	flags.VarP(c._import.filter.Include, "include", "i", "Include entry types")
 	flags.BoolVarP(&c._import.removeDestination, "remove-destination", "r", c._import.removeDestination, "Remove destination before import") //nolint:lll
 	flags.IntVar(&c._import.stripComponents, "strip-components", c._import.stripComponents, "Strip leading path components")                 //nolint:lll
 
@@ -87,7 +86,7 @@ func (c *Config) runImportCmd(cmd *cobra.Command, args []string, sourceState *ch
 	return sourceState.Add(
 		c.sourceSystem, c.persistentState, archiveReaderSystem, archiveReaderSystem.FileInfos(), &chezmoi.AddOptions{
 			Exact:     c._import.exact,
-			Include:   c._import.include.Sub(c._import.exclude),
+			Filter:    c._import.filter,
 			RemoveDir: removeDir,
 		},
 	)

--- a/pkg/cmd/initcmd.go
+++ b/pkg/cmd/initcmd.go
@@ -24,7 +24,7 @@ type initCmdConfig struct {
 	configPath      chezmoi.AbsPath
 	data            bool
 	depth           int
-	exclude         *chezmoi.EntryTypeSet
+	filter          *chezmoi.EntryTypeFilter
 	guessRepoURL    bool
 	oneShot         bool
 	forcePromptOnce bool
@@ -119,9 +119,10 @@ func (c *Config) newInitCmd() *cobra.Command {
 	flags.VarP(&c.init.configPath, "config-path", "C", "Path to write generated config file")
 	flags.BoolVar(&c.init.data, "data", c.init.data, "Include existing template data")
 	flags.IntVarP(&c.init.depth, "depth", "d", c.init.depth, "Create a shallow clone")
-	flags.VarP(c.init.exclude, "exclude", "x", "Exclude entry types")
+	flags.VarP(c.init.filter.Exclude, "exclude", "x", "Exclude entry types")
 	flags.BoolVar(&c.init.forcePromptOnce, "prompt", c.init.forcePromptOnce, "Force prompt*Once template functions to prompt") //nolint:lll
 	flags.BoolVarP(&c.init.guessRepoURL, "guess-repo-url", "g", c.init.guessRepoURL, "Guess the repo URL")
+	flags.VarP(c.init.filter.Include, "include", "i", "Include entry types")
 	flags.BoolVar(&c.init.oneShot, "one-shot", c.init.oneShot, "Run in one-shot mode")
 	flags.StringToStringVar(&c.init.promptBool, "promptBool", c.init.promptBool, "Populate promptBool")
 	flags.StringToIntVar(&c.init.promptInt, "promptInt", c.init.promptInt, "Populate promptInt")
@@ -222,7 +223,7 @@ func (c *Config) runInitCmd(cmd *cobra.Command, args []string) error {
 	// Apply.
 	if c.init.apply {
 		if err := c.applyArgs(cmd.Context(), c.destSystem, c.DestDirAbsPath, noArgs, applyArgsOptions{
-			include:      chezmoi.NewEntryTypeSet(chezmoi.EntryTypesAll).Sub(c.init.exclude),
+			filter:       c.init.filter,
 			recursive:    false,
 			umask:        c.Umask,
 			preApplyFunc: c.defaultPreApplyFunc,

--- a/pkg/cmd/managedcmd_test.go
+++ b/pkg/cmd/managedcmd_test.go
@@ -60,7 +60,7 @@ func TestManagedCmd(t *testing.T) {
 				"/home/user/.local/share/chezmoi/run_script.tmpl": "{{ fail \"Template should not be executed\" }}\n",
 			},
 			args: []string{
-				"--include", "scripts",
+				"--include", "always,scripts",
 			},
 			expectedOutput: chezmoitest.JoinLines(
 				"script",

--- a/pkg/cmd/managedcmd_test.go
+++ b/pkg/cmd/managedcmd_test.go
@@ -75,6 +75,19 @@ func TestManagedCmd(t *testing.T) {
 				".symlink",
 			),
 		},
+		{
+			name: "external_git_repo",
+			root: map[string]any{
+				"/home/user/.local/share/chezmoi/.chezmoiexternal.toml": chezmoitest.JoinLines(
+					`[".dir"]`,
+					`    type = "git-repo"`,
+					`    url = "https://github.com/example/example.git"`,
+				),
+			},
+			expectedOutput: chezmoitest.JoinLines(
+				".dir",
+			),
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			chezmoitest.WithTestFS(t, tc.root, func(fileSystem vfs.FS) {

--- a/pkg/cmd/mergeallcmd.go
+++ b/pkg/cmd/mergeallcmd.go
@@ -43,7 +43,7 @@ func (c *Config) runMergeAllCmd(cmd *cobra.Command, args []string) error {
 		return chezmoi.Skip
 	}
 	if err := c.applyArgs(cmd.Context(), dryRunSystem, c.DestDirAbsPath, args, applyArgsOptions{
-		include:      chezmoi.NewEntryTypeSet(chezmoi.EntryTypeFiles),
+		filter:       chezmoi.NewEntryTypeFilter(chezmoi.EntryTypesAll, chezmoi.EntryTypesNone),
 		init:         c.mergeAll.init,
 		recursive:    c.mergeAll.recursive,
 		umask:        c.Umask,

--- a/pkg/cmd/readdcmd.go
+++ b/pkg/cmd/readdcmd.go
@@ -11,8 +11,7 @@ import (
 )
 
 type reAddCmdConfig struct {
-	exclude *chezmoi.EntryTypeSet
-	include *chezmoi.EntryTypeSet
+	filter *chezmoi.EntryTypeFilter
 }
 
 func (c *Config) newReAddCmd() *cobra.Command {
@@ -32,8 +31,8 @@ func (c *Config) newReAddCmd() *cobra.Command {
 	}
 
 	flags := reAddCmd.Flags()
-	flags.VarP(c.reAdd.exclude, "exclude", "x", "Exclude entry types")
-	flags.VarP(c.reAdd.include, "include", "i", "Include entry types")
+	flags.VarP(c.reAdd.filter.Exclude, "exclude", "x", "Exclude entry types")
+	flags.VarP(c.reAdd.filter.Include, "include", "i", "Include entry types")
 
 	registerExcludeIncludeFlagCompletionFuncs(reAddCmd)
 
@@ -100,7 +99,7 @@ func (c *Config) runReAddCmd(cmd *cobra.Command, args []string, sourceState *che
 		if err := sourceState.Add(c.sourceSystem, c.persistentState, c.destSystem, destAbsPathInfos, &chezmoi.AddOptions{
 			Encrypt:         sourceStateFile.Attr.Encrypted,
 			EncryptedSuffix: c.encryption.EncryptedSuffix(),
-			Include:         c.reAdd.include.Sub(c.reAdd.exclude),
+			Filter:          c.reAdd.filter,
 		}); err != nil {
 			return err
 		}

--- a/pkg/cmd/statuscmd.go
+++ b/pkg/cmd/statuscmd.go
@@ -72,7 +72,7 @@ func (c *Config) runStatusCmd(cmd *cobra.Command, args []string) error {
 		return chezmoi.Skip
 	}
 	if err := c.applyArgs(cmd.Context(), dryRunSystem, c.DestDirAbsPath, args, applyArgsOptions{
-		include:      c.Status.include.Sub(c.Status.Exclude),
+		filter:       chezmoi.NewEntryTypeFilter(c.Status.include.Bits(), c.Status.Exclude.Bits()),
 		init:         c.Status.init,
 		recursive:    c.Status.recursive,
 		umask:        c.Umask,

--- a/pkg/cmd/testdata/scripts/exclude.txtar
+++ b/pkg/cmd/testdata/scripts/exclude.txtar
@@ -15,9 +15,24 @@ exec chezmoi diff
 [!windows] cmp stdout golden/diff-no-scripts.diff
 [windows] cmp stdout golden/diff-no-scripts-windows.diff
 
+chhome home2/user
+
+# test that chezmoi diff --exclude=always excludes scripts that are always run
+exec chezmoi diff --exclude=always
+cmp stdout golden/diff-exclude-always.diff
+
 -- golden/chezmoi.toml --
 [diff]
     exclude = ["scripts"]
+-- golden/diff-exclude-always.diff --
+diff --git a/script-once.sh b/script-once.sh
+index e69de29bb2d1d6434b8b29ae775ad8c2e48c5391..d7dff6100cefc930f4161600c12b6f7ea37b7d3a 100755
+--- a/script-once.sh
++++ b/script-once.sh
+@@ -0,0 +1,3 @@
++#!/bin/sh
++
++echo once
 -- golden/diff-no-scripts-windows.diff --
 diff --git a/.file b/.file
 new file mode 100666
@@ -72,3 +87,11 @@ index e69de29bb2d1d6434b8b29ae775ad8c2e48c5391..3747a7ba08ee591c41b7c518e430d280
 #!/bin/sh
 
 echo $*
+-- home2/user/.local/share/chezmoi/run_once_script-once.sh --
+#!/bin/sh
+
+echo once
+-- home2/user/.local/share/chezmoi/run_script-always.sh --
+#!/bin/sh
+
+echo always

--- a/pkg/cmd/testdata/scripts/managed.txtar
+++ b/pkg/cmd/testdata/scripts/managed.txtar
@@ -89,7 +89,6 @@ cmp stdout golden/managed2
 .dir
 .dir/subdir
 .symlink
-.template
 -- golden/managed-except-files-and-templates --
 .dir
 .dir/subdir

--- a/pkg/cmd/updatecmd.go
+++ b/pkg/cmd/updatecmd.go
@@ -11,8 +11,7 @@ import (
 
 type updateCmdConfig struct {
 	apply     bool
-	exclude   *chezmoi.EntryTypeSet
-	include   *chezmoi.EntryTypeSet
+	filter    *chezmoi.EntryTypeFilter
 	init      bool
 	recursive bool
 }
@@ -36,8 +35,8 @@ func (c *Config) newUpdateCmd() *cobra.Command {
 
 	flags := updateCmd.Flags()
 	flags.BoolVarP(&c.update.apply, "apply", "a", c.update.apply, "Apply after pulling")
-	flags.VarP(c.update.exclude, "exclude", "x", "Exclude entry types")
-	flags.VarP(c.update.include, "include", "i", "Include entry types")
+	flags.VarP(c.update.filter.Exclude, "exclude", "x", "Exclude entry types")
+	flags.VarP(c.update.filter.Include, "include", "i", "Include entry types")
 	flags.BoolVar(&c.update.init, "init", c.update.init, "Recreate config file from template")
 	flags.BoolVarP(&c.update.recursive, "recursive", "r", c.update.recursive, "Recurse into subdirectories")
 
@@ -78,7 +77,7 @@ func (c *Config) runUpdateCmd(cmd *cobra.Command, args []string) error {
 
 	if c.update.apply {
 		if err := c.applyArgs(cmd.Context(), c.destSystem, c.DestDirAbsPath, args, applyArgsOptions{
-			include:      c.update.include.Sub(c.update.exclude),
+			filter:       c.update.filter,
 			init:         c.update.init,
 			recursive:    c.update.recursive,
 			umask:        c.Umask,

--- a/pkg/cmd/verifycmd.go
+++ b/pkg/cmd/verifycmd.go
@@ -41,7 +41,7 @@ func (c *Config) newVerifyCmd() *cobra.Command {
 func (c *Config) runVerifyCmd(cmd *cobra.Command, args []string) error {
 	errorOnWriteSystem := chezmoi.NewErrorOnWriteSystem(c.destSystem, chezmoi.ExitCodeError(1))
 	return c.applyArgs(cmd.Context(), errorOnWriteSystem, c.DestDirAbsPath, args, applyArgsOptions{
-		include:   c.Verify.include.Sub(c.Verify.Exclude),
+		filter:    chezmoi.NewEntryTypeFilter(c.Verify.include.Bits(), c.Verify.Exclude.Bits()),
 		init:      c.Verify.init,
 		recursive: c.Verify.recursive,
 		umask:     c.Umask,


### PR DESCRIPTION
As requested by @felipecrs and @Lockszmith-GH in #1666.

With this, you can put

```toml
[diff]
    exclude = ["always"]
```

to exclude scripts that are always run from the output of `chezmoi diff`.

This PR also includes a re-work of the `--include` and `--exclude` options thanks to the discussion with @sm1999 in #2455.
