### PR TITLE
docs(bitwarden): Update outdated Bitwarden CLI link

### DIFF
--- a/assets/chezmoi.io/docs/user-guide/password-managers/bitwarden.md
+++ b/assets/chezmoi.io/docs/user-guide/password-managers/bitwarden.md
@@ -1,7 +1,7 @@
 # Bitwarden
 
 chezmoi includes support for [Bitwarden](https://bitwarden.com/) using the
-[Bitwarden CLI](https://github.com/bitwarden/cli) to expose data as a template
+[Bitwarden CLI](https://bitwarden.com/help/cli) to expose data as a template
 function.
 
 Log in to Bitwarden using:


### PR DESCRIPTION
[bitwarden/cli][1] is now archived and the code of Bitwarden CLI is now inside [bitwarden/clients][2]. However, since we are only using Bitwarden CLI here instead of trying to contribute to its code, linking to [documentation for Bitwarden CLI][3] may be more helpful.

[1]: https://github.com/bitwarden/cli
[2]: https://github.com/bitwarden/clients
[3]: https://bitwarden.com/help/cli

<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer/contributing-changes/

-->
