### PR TITLE
chore: Fix comments that start from an incorrect name

### DIFF
--- a/pkg/chezmoi/actualstateentry.go
+++ b/pkg/chezmoi/actualstateentry.go
@@ -102,7 +102,7 @@ func (s *ActualStateAbsent) Remove(system System) error {
 	return nil
 }
 
-// Origin returns s's origin.
+// OriginString returns s's origin.
 func (s *ActualStateAbsent) OriginString() string {
 	return s.absPath.String()
 }
@@ -125,7 +125,7 @@ func (s *ActualStateDir) Remove(system System) error {
 	return system.RemoveAll(s.absPath)
 }
 
-// Origin returns s's origin.
+// OriginString returns s's origin.
 func (s *ActualStateDir) OriginString() string {
 	return s.absPath.String()
 }
@@ -163,7 +163,7 @@ func (s *ActualStateFile) Remove(system System) error {
 	return system.RemoveAll(s.absPath)
 }
 
-// Origin returns s's origin.
+// OriginString returns s's origin.
 func (s *ActualStateFile) OriginString() string {
 	return s.absPath.String()
 }
@@ -195,7 +195,7 @@ func (s *ActualStateSymlink) Remove(system System) error {
 	return system.RemoveAll(s.absPath)
 }
 
-// Origin returns s's origin.
+// OriginString returns s's origin.
 func (s *ActualStateSymlink) OriginString() string {
 	return s.absPath.String()
 }

--- a/pkg/chezmoi/entrytypefilter.go
+++ b/pkg/chezmoi/entrytypefilter.go
@@ -19,7 +19,7 @@ func NewEntryTypeFilter(includeEntryTypeBits, excludeEntryTypeBits EntryTypeBits
 	}
 }
 
-// IncludeEntryTypes returns if entryTypeBits is included.
+// IncludeEntryTypeBits returns if entryTypeBits is included.
 func (f *EntryTypeFilter) IncludeEntryTypeBits(entryTypeBits EntryTypeBits) bool {
 	return f.Include.ContainsEntryTypeBits(entryTypeBits) && !f.Exclude.ContainsEntryTypeBits(entryTypeBits)
 }

--- a/pkg/chezmoi/format.go
+++ b/pkg/chezmoi/format.go
@@ -40,7 +40,7 @@ var (
 		"yaml": FormatYAML,
 	}
 
-	// Formats is a map of all Formats by extension.
+	// FormatsByExtension is a map of all Formats by extension.
 	FormatsByExtension = map[string]Format{
 		"json": FormatJSON,
 		"toml": FormatTOML,

--- a/pkg/chezmoi/gitdiffsystem.go
+++ b/pkg/chezmoi/gitdiffsystem.go
@@ -28,7 +28,7 @@ type GitDiffSystem struct {
 	unifiedEncoder *diff.UnifiedEncoder
 }
 
-// GetDiffSystemOptions are options for NewGitDiffSystem.
+// GitDiffSystemOptions are options for NewGitDiffSystem.
 type GitDiffSystemOptions struct {
 	Color        bool
 	Filter       *EntryTypeFilter

--- a/pkg/chezmoi/sourcestateentry.go
+++ b/pkg/chezmoi/sourcestateentry.go
@@ -231,7 +231,7 @@ func (s SourceStateOriginAbsPath) Path() AbsPath {
 	return AbsPath(s)
 }
 
-// Origin returns s's origin.
+// OriginString returns s's origin.
 func (s SourceStateOriginAbsPath) OriginString() string {
 	return AbsPath(s).String()
 }
@@ -241,7 +241,7 @@ func (s SourceStateOriginRemove) Path() AbsPath {
 	return EmptyAbsPath
 }
 
-// Origin returns s's origin.
+// OriginString returns s's origin.
 func (s SourceStateOriginRemove) OriginString() string {
 	return "remove"
 }


### PR DESCRIPTION
This PR changes comments for some functions and structs that are started with the incorrect name.