### PR TITLE
chore: Enable stylecheck exported comments issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -131,8 +131,12 @@ linters-settings:
     - stdlib
   misspell:
     locale: US
+  stylecheck:
+    checks: ["all", "-ST1000"]
 
 issues:
+  include:
+    - EXC0011 # include issues about comments from `stylecheck`
   exclude-rules:
   - linters:
     - goerr113


### PR DESCRIPTION
The PR modifies golangci-lint's config by enable `stylecheck` issues [`ST1*`](https://staticcheck.io/docs/checks/#ST1). This prevents wrong comments fixed in https://github.com/twpayne/chezmoi/pull/2481.