### PR TITLE
chore: Add package descriptions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -134,7 +134,6 @@ linters-settings:
   stylecheck:
     checks:
     - all
-    - -ST1000
 
 issues:
   include:

--- a/assets/chezmoi.io/docs/docs.go
+++ b/assets/chezmoi.io/docs/docs.go
@@ -1,3 +1,4 @@
+// Package docs contains chezmoi's documentation.
 package docs
 
 import _ "embed"

--- a/pkg/archivetest/archivetest.go
+++ b/pkg/archivetest/archivetest.go
@@ -1,3 +1,4 @@
+// Package archivetest provides useful functions for testing archives.
 package archivetest
 
 import (

--- a/pkg/chezmoibubbles/chezmoibubbles.go
+++ b/pkg/chezmoibubbles/chezmoibubbles.go
@@ -1,0 +1,3 @@
+// Package chezmoibubbles provides text user interface components for chezmoi
+// using github.com/charmbracelet/bubbletea.
+package chezmoibubbles


### PR DESCRIPTION
This enables the `stylecheck` linter's `ST1000` warning to be enabled, thanks to @alexandear in https://github.com/twpayne/chezmoi/pull/2484#issue-1420962977.