### PR TITLE
docs(bitwarden): Correct bitwardenFields example

### DIFF
--- a/assets/chezmoi.io/docs/reference/templates/bitwarden-functions/bitwardenFields.md
+++ b/assets/chezmoi.io/docs/reference/templates/bitwarden-functions/bitwardenFields.md
@@ -31,14 +31,14 @@ the same arguments will only invoke `bw get` once.
         "favorite": false,
         "fields": [
             {
-                "name": "text",
-                "value": "text-value",
-                "type": 0
-            },
-            {
                 "name": "hidden",
                 "value": "hidden-value",
                 "type": 1
+            },
+            {
+                "name": "token",
+                "value": "token-value",
+                "type": 0
             }
         ],
         "login": {


### PR DESCRIPTION
The example is about `token.value`, so `token` should be part of the `fields` of `bw get` output.
