### PR TITLE
docs: Remove duplicate words

### DIFF
--- a/assets/chezmoi.io/docs/developer/install-script.md
+++ b/assets/chezmoi.io/docs/developer/install-script.md
@@ -8,7 +8,7 @@ from a single source of truth. You must run
 $ go generate
 ```
 
-if you change includes any of the following:
+if your change includes any of the following:
 
 * Modifications to the install script template.
 

--- a/assets/chezmoi.io/docs/reference/command-line-flags/global.md
+++ b/assets/chezmoi.io/docs/reference/command-line-flags/global.md
@@ -8,7 +8,7 @@ Use *directory* as the cache directory.
 
 Colorize diffs, *value* can be `on`, `off`, `auto`, or any boolean-like value
 recognized by `promptBool`. The default is `auto` which will colorize diffs only
-if the the environment variable `$NO_COLOR` is not set and stdout is a terminal.
+if the environment variable `$NO_COLOR` is not set and stdout is a terminal.
 
 ## `-c`, `--config` *filename*
 

--- a/assets/chezmoi.io/docs/reference/commands/cat.md
+++ b/assets/chezmoi.io/docs/reference/commands/cat.md
@@ -2,7 +2,7 @@
 
 Write the target contents of *target*s to stdout. *target*s must be files,
 scripts, or symlinks. For files, the target file contents are written. For
-scripts, the script's contents are written. For symlinks, the target target is
+scripts, the script's contents are written. For symlinks, the target is
 written.
 
 !!! example

--- a/assets/chezmoi.io/docs/reference/special-files-and-directories/chezmoi-format-tmpl.md
+++ b/assets/chezmoi.io/docs/reference/special-files-and-directories/chezmoi-format-tmpl.md
@@ -1,7 +1,7 @@
 # `.chezmoi.$FORMAT.tmpl`
 
 If a file called `.chezmoi.$FORMAT.tmpl` exists then `chezmoi init` will use it
-to create an initial config file. `$FORMAT` must be one of the the supported
+to create an initial config file. `$FORMAT` must be one of the supported
 config file formats, e.g. `json`, `toml`, or `yaml`.
 
 !!! example

--- a/assets/chezmoi.io/docs/reference/special-files-and-directories/chezmoiexternal-format.md
+++ b/assets/chezmoi.io/docs/reference/special-files-and-directories/chezmoiexternal-format.md
@@ -40,7 +40,7 @@ The optional boolean `encrypted` field specifies whether the file or archive is
 encrypted.
 
 If optional string `filter.command` and array of strings `filter.args` are
-specified, the the file or archive is filtered by piping it into the command's
+specified, the file or archive is filtered by piping it into the command's
 standard input and reading the command's standard output.
 
 If `type` is `file` then the target is a file with the contents of `url`. The

--- a/assets/chezmoi.io/docs/reference/target-types.md
+++ b/assets/chezmoi.io/docs/reference/target-types.md
@@ -13,7 +13,7 @@ performs actions in ASCII order of their target name.
 
 Files are represented by regular files in the source state. The `encrypted_`
 attribute determines whether the file in the source state is encrypted. The
-`executable_` attribute will set the executable bits in the the target state,
+`executable_` attribute will set the executable bits in the target state,
 and the `private_` attribute will clear all group and world permissions. The
 `readonly_` attribute will clear all write permission bits in the target state.
 Files with the `.tmpl` suffix will be interpreted as templates. If the target

--- a/assets/chezmoi.io/docs/user-guide/encryption/gpg.md
+++ b/assets/chezmoi.io/docs/user-guide/encryption/gpg.md
@@ -82,7 +82,7 @@ a new machine, and then remember the passphrase in your configuration file.
 ## Muting gpg output
 
 Since gpg sends some info messages to stderr instead of stdout, you will see
-some output even if you redirect stdout to to `/dev/null`.
+some output even if you redirect stdout to `/dev/null`.
 
 You can mute this by adding `--quiet` to the `gpg.args` key in your
 configuration:

--- a/assets/chezmoi.io/docs/user-guide/frequently-asked-questions/design.md
+++ b/assets/chezmoi.io/docs/user-guide/frequently-asked-questions/design.md
@@ -79,7 +79,7 @@ better than just having the correct dotfile contents.
 ## What are the limitations of chezmoi's symlink mode?
 
 In symlink mode chezmoi replaces targets with symlinks to the source directory
-if the the target is a regular file and is not encrypted, executable, private,
+if the target is a regular file and is not encrypted, executable, private,
 or a template.
 
 Symlinks cannot be used for encrypted files because the source state contains

--- a/assets/chezmoi.io/docs/user-guide/password-managers/1password.md
+++ b/assets/chezmoi.io/docs/user-guide/password-managers/1password.md
@@ -177,8 +177,8 @@ current environment. If it is missing or expired, you will be interactively
 prompted to sign-in again.
 
 In the past chezmoi used to simply exit with an error when no valid session was
-available. If you'd like to restore this behavior, set the the
-`onepassword.prompt` configuration variable to `false`, for example:
+available. If you'd like to restore this behavior, set the `onepassword.prompt`
+configuration variable to `false`, for example:
 
 ```toml title="~/.config/chezmoi/chezmoi.toml"
 [onepassword]


### PR DESCRIPTION
(+ a typo fix)

I found these by RegEx searching `\b(\w+)\s+\1\b`.