### PR TITLE
Make `onepasswordRead` respect the passed account

### DIFF
--- a/pkg/cmd/onepasswordtemplatefuncs.go
+++ b/pkg/cmd/onepasswordtemplatefuncs.go
@@ -374,7 +374,8 @@ func (c *Config) onepasswordReadTemplateFunc(url string, args ...string) string 
 	case 0:
 		// Do nothing.
 	case 1:
-		onepasswordArgs.args = append(onepasswordArgs.args, "--account", c.onepasswordAccount(args[0]))
+		onepasswordArgs.account = c.onepasswordAccount(args[0])
+		onepasswordArgs.args = append(onepasswordArgs.args, "--account", onepasswordArgs.account)
 	default:
 		panic(fmt.Errorf("expected 1 or 2 arguments, got %d", len(args)))
 	}


### PR DESCRIPTION
Indirectly, the lack of setting `onepasswordArgs.account` in `onepasswordReadTemplateFunc` was causing 1Password to prompt me for an account, even though it's provided.

The selection is prompted by the `withSessionToken` handling, which depends on `onepasswordAccount.account`.

Discovered while investigating #2498.