### PR TITLE
chore: Reorder eqFold template function reference page

### DIFF
--- a/assets/chezmoi.io/mkdocs.yml
+++ b/assets/chezmoi.io/mkdocs.yml
@@ -174,6 +174,7 @@ nav:
               - comment: reference/templates/functions/comment.md
               - decrypt: reference/templates/functions/decrypt.md
               - encrypt: reference/templates/functions/encrypt.md
+              - eqFold: reference/templates/functions/eqFold.md
               - fromIni: reference/templates/functions/fromIni.md
               - fromToml: reference/templates/functions/fromToml.md
               - fromYaml: reference/templates/functions/fromYaml.md
@@ -188,7 +189,6 @@ nav:
               - quoteList: reference/templates/functions/quoteList.md
               - replaceAllRegex: reference/templates/functions/replaceAllRegex.md
               - stat: reference/templates/functions/stat.md
-              - eqFold: reference/templates/functions/eqFold.md
               - toIni: reference/templates/functions/toIni.md
               - toToml: reference/templates/functions/toToml.md
               - toYaml: reference/templates/functions/toYaml.md


### PR DESCRIPTION
It appears we missed this in both https://github.com/twpayne/chezmoi/commit/2c440aba38f10c04af548da3c7ae263a2c411c6f and https://github.com/twpayne/chezmoi/commit/520e4a6d0663aeb6eeafb4352906fdffecbd6702.