### PR TITLE
fix: Revert cpina/github-action-push-to-another-repository version bump

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -456,7 +456,7 @@ jobs:
         cp assets/scripts/install.ps1 assets/get.chezmoi.io/ps1
         cp LICENSE assets/get.chezmoi.io/LICENSE
     - name: push-get.chezmoi.io
-      uses: cpina/github-action-push-to-another-repository@940a2857e598a6392bd336330b07416c1ae8ea1f
+      uses: cpina/github-action-push-to-another-repository@9e487f29582587eeb4837c0552c886bb0644b6b9
       env:
         SSH_DEPLOY_KEY: ${{ secrets.GET_CHEZMOI_IO_SSH_DEPLOY_KEY }}
       with:


### PR DESCRIPTION
Partial fix for https://github.com/twpayne/chezmoi/issues/2526

This reverts the version "bump" done in https://github.com/twpayne/chezmoi/commit/d6da479e158236e14c584f5a0e915c70bf3c8370.

We may have to deal with the bot attempting to bump it again, should be as simple as telling it to stop in a comment if it opens another PR.