### PR TITLE
chore: Install Go in test-website and deploy-website jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -291,6 +291,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+    - uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f
+      with:
+        cache: true
+        go-version: ${{ env.GO_VERSION }}
     - name: install-website-dependencies
       run: pip3 install mkdocs-material mkdocs-mermaid2-plugin mkdocs-redirects mkdocs-simple-hooks
     - name: build-website
@@ -443,6 +447,10 @@ jobs:
     - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       with:
         fetch-depth: 0
+    - uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f
+      with:
+        cache: true
+        go-version: ${{ env.GO_VERSION }}
     - name: prepare-chezmoi.io
       run: |
         pip3 install mkdocs-material mkdocs-mermaid2-plugin mkdocs-redirects mkdocs-simple-hooks


### PR DESCRIPTION
Fixes #2525.
Builds on #2527.

Draft PR for testing, but should do the full website deploy.

The "Disable jobs for testing" commit needs to be removed before merging.