### PR TITLE
feat: Add --script-contents flag to diff command

### DIFF
--- a/assets/chezmoi.io/docs/reference/configuration-file/variables.md.yaml
+++ b/assets/chezmoi.io/docs/reference/configuration-file/variables.md.yaml
@@ -116,6 +116,10 @@ sections:
     reverse:
       type: bool
       description: Reverse order of arguments to diff
+    scriptContents:
+      type: bool
+      default: '`true`'
+      description: Show script contents
   edit:
     apply:
       type: bool

--- a/pkg/chezmoi/externaldiffsystem.go
+++ b/pkg/chezmoi/externaldiffsystem.go
@@ -26,12 +26,14 @@ type ExternalDiffSystem struct {
 	tempDirAbsPath AbsPath
 	filter         *EntryTypeFilter
 	reverse        bool
+	scriptContents bool
 }
 
 // ExternalDiffSystemOptions are options for NewExternalDiffSystem.
 type ExternalDiffSystemOptions struct {
-	Filter  *EntryTypeFilter
-	Reverse bool
+	Filter         *EntryTypeFilter
+	Reverse        bool
+	ScriptContents bool
 }
 
 // NewExternalDiffSystem creates a new ExternalDiffSystem.
@@ -45,6 +47,7 @@ func NewExternalDiffSystem(
 		destDirAbsPath: destDirAbsPath,
 		filter:         options.Filter,
 		reverse:        options.Reverse,
+		scriptContents: options.ScriptContents,
 	}
 }
 
@@ -170,7 +173,11 @@ func (s *ExternalDiffSystem) RunScript(scriptname RelPath, dir AbsPath, data []b
 		if err := os.MkdirAll(targetAbsPath.Dir().String(), 0o700); err != nil {
 			return err
 		}
-		if err := os.WriteFile(targetAbsPath.String(), data, 0o700); err != nil { //nolint:gosec
+		toData := data
+		if !s.scriptContents {
+			toData = nil
+		}
+		if err := os.WriteFile(targetAbsPath.String(), toData, 0o700); err != nil { //nolint:gosec
 			return err
 		}
 		if err := s.runDiffCommand(devNullAbsPath, targetAbsPath); err != nil {

--- a/pkg/chezmoi/gitdiffsystem.go
+++ b/pkg/chezmoi/gitdiffsystem.go
@@ -200,12 +200,12 @@ func (s *GitDiffSystem) RunCmd(cmd *exec.Cmd) error {
 // RunScript implements System.RunScript.
 func (s *GitDiffSystem) RunScript(scriptname RelPath, dir AbsPath, data []byte, interpreter *Interpreter) error {
 	if s.filter.IncludeEntryTypeBits(EntryTypeScripts) {
-		mode := fs.FileMode(filemode.Executable)
+		fromMode, toMode := fs.FileMode(0), fs.FileMode(filemode.Executable)
 		fromData, toData := []byte(nil), data
 		if s.reverse {
 			fromData, toData = toData, fromData
 		}
-		diffPatch, err := DiffPatch(scriptname, fromData, mode, toData, mode)
+		diffPatch, err := DiffPatch(scriptname, fromData, fromMode, toData, toMode)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -1445,16 +1445,18 @@ func (c *Config) newRootCmd() (*cobra.Command, error) {
 func (c *Config) newDiffSystem(s chezmoi.System, w io.Writer, dirAbsPath chezmoi.AbsPath) chezmoi.System {
 	if c.Diff.useBuiltinDiff || c.Diff.Command == "" {
 		options := &chezmoi.GitDiffSystemOptions{
-			Color:        c.Color.Value(c.colorAutoFunc),
-			Filter:       chezmoi.NewEntryTypeFilter(c.Diff.include.Bits(), c.Diff.Exclude.Bits()),
-			Reverse:      c.Diff.Reverse,
-			TextConvFunc: c.TextConv.convert,
+			Color:          c.Color.Value(c.colorAutoFunc),
+			Filter:         chezmoi.NewEntryTypeFilter(c.Diff.include.Bits(), c.Diff.Exclude.Bits()),
+			Reverse:        c.Diff.Reverse,
+			ScriptContents: c.Diff.ScriptContents,
+			TextConvFunc:   c.TextConv.convert,
 		}
 		return chezmoi.NewGitDiffSystem(s, w, dirAbsPath, options)
 	}
 	options := &chezmoi.ExternalDiffSystemOptions{
-		Filter:  chezmoi.NewEntryTypeFilter(c.Diff.include.Bits(), c.Diff.Exclude.Bits()),
-		Reverse: c.Diff.Reverse,
+		Filter:         chezmoi.NewEntryTypeFilter(c.Diff.include.Bits(), c.Diff.Exclude.Bits()),
+		Reverse:        c.Diff.Reverse,
+		ScriptContents: c.Diff.ScriptContents,
 	}
 	return chezmoi.NewExternalDiffSystem(s, c.Diff.Command, c.Diff.Args, c.DestDirAbsPath, options)
 }
@@ -2381,8 +2383,9 @@ func newConfigFile(bds *xdg.BaseDirectorySpecification) ConfigFile {
 			recursive: true,
 		},
 		Diff: diffCmdConfig{
-			Exclude: chezmoi.NewEntryTypeSet(chezmoi.EntryTypesNone),
-			include: chezmoi.NewEntryTypeSet(chezmoi.EntryTypesAll),
+			Exclude:        chezmoi.NewEntryTypeSet(chezmoi.EntryTypesNone),
+			ScriptContents: true,
+			include:        chezmoi.NewEntryTypeSet(chezmoi.EntryTypesAll),
 		},
 		Edit: editCmdConfig{
 			Hardlink:    true,

--- a/pkg/cmd/diffcmd.go
+++ b/pkg/cmd/diffcmd.go
@@ -14,6 +14,7 @@ type diffCmdConfig struct {
 	Exclude        *chezmoi.EntryTypeSet `mapstructure:"exclude"`
 	Pager          string                `mapstructure:"pager"`
 	Reverse        bool                  `mapstructure:"reverse"`
+	ScriptContents bool                  `mapstructure:"scriptContents"`
 	include        *chezmoi.EntryTypeSet
 	init           bool
 	recursive      bool
@@ -38,9 +39,10 @@ func (c *Config) newDiffCmd() *cobra.Command {
 	flags.VarP(c.Diff.Exclude, "exclude", "x", "Exclude entry types")
 	flags.VarP(c.Diff.include, "include", "i", "Include entry types")
 	flags.BoolVar(&c.Diff.init, "init", c.Diff.init, "Recreate config file from template")
+	flags.StringVar(&c.Diff.Pager, "pager", c.Diff.Pager, "Set pager")
 	flags.BoolVarP(&c.Diff.recursive, "recursive", "r", c.Diff.recursive, "Recurse into subdirectories")
 	flags.BoolVar(&c.Diff.Reverse, "reverse", c.Diff.Reverse, "Reverse the direction of the diff")
-	flags.StringVar(&c.Diff.Pager, "pager", c.Diff.Pager, "Set pager")
+	flags.BoolVar(&c.Diff.ScriptContents, "script-contents", c.Diff.ScriptContents, "Show script contents")
 	flags.BoolVarP(&c.Diff.useBuiltinDiff, "use-builtin-diff", "", c.Diff.useBuiltinDiff, "Use the builtin diff")
 
 	registerExcludeIncludeFlagCompletionFuncs(diffCmd)

--- a/pkg/cmd/testdata/scripts/exclude.txtar
+++ b/pkg/cmd/testdata/scripts/exclude.txtar
@@ -26,8 +26,9 @@ cmp stdout golden/diff-exclude-always.diff
     exclude = ["scripts"]
 -- golden/diff-exclude-always.diff --
 diff --git a/script-once.sh b/script-once.sh
-index e69de29bb2d1d6434b8b29ae775ad8c2e48c5391..d7dff6100cefc930f4161600c12b6f7ea37b7d3a 100755
---- a/script-once.sh
+new file mode 100755
+index 0000000000000000000000000000000000000000..d7dff6100cefc930f4161600c12b6f7ea37b7d3a
+--- /dev/null
 +++ b/script-once.sh
 @@ -0,0 +1,3 @@
 +#!/bin/sh
@@ -58,8 +59,9 @@ index 0000000000000000000000000000000000000000..8a52cb9ce9551221716a53786ad74104
 @@ -0,0 +1 @@
 +# contents of .file
 diff --git a/script.sh b/script.sh
-index e69de29bb2d1d6434b8b29ae775ad8c2e48c5391..3747a7ba08ee591c41b7c518e430d2802137eac4 100755
---- a/script.sh
+new file mode 100755
+index 0000000000000000000000000000000000000000..3747a7ba08ee591c41b7c518e430d2802137eac4
+--- /dev/null
 +++ b/script.sh
 @@ -0,0 +1,3 @@
 +#!/bin/sh
@@ -74,8 +76,9 @@ index 0000000000000000000000000000000000000000..8a52cb9ce9551221716a53786ad74104
 @@ -0,0 +1 @@
 +# contents of .file
 diff --git a/script.sh b/script.sh
-index e69de29bb2d1d6434b8b29ae775ad8c2e48c5391..3747a7ba08ee591c41b7c518e430d2802137eac4 100755
---- a/script.sh
+new file mode 100755
+index 0000000000000000000000000000000000000000..3747a7ba08ee591c41b7c518e430d2802137eac4
+--- /dev/null
 +++ b/script.sh
 @@ -0,0 +1,3 @@
 +#!/bin/sh

--- a/pkg/cmd/testdata/scripts/issue-2510.txtar
+++ b/pkg/cmd/testdata/scripts/issue-2510.txtar
@@ -10,8 +10,9 @@ cmp stdout golden/diff2
 
 -- golden/diff --
 diff --git a/script-one.sh b/script-one.sh
-index e69de29bb2d1d6434b8b29ae775ad8c2e48c5391..a5498fa48acd6f616d60604b94352958c5e967fc 100755
---- a/script-one.sh
+new file mode 100755
+index 0000000000000000000000000000000000000000..a5498fa48acd6f616d60604b94352958c5e967fc
+--- /dev/null
 +++ b/script-one.sh
 @@ -0,0 +1,3 @@
 +#!/bin/sh
@@ -19,8 +20,9 @@ index e69de29bb2d1d6434b8b29ae775ad8c2e48c5391..a5498fa48acd6f616d60604b94352958
 +echo "script one"
 -- golden/diff2 --
 diff --git a/.chezmoiscripts/script-one.sh b/.chezmoiscripts/script-one.sh
-index e69de29bb2d1d6434b8b29ae775ad8c2e48c5391..a5498fa48acd6f616d60604b94352958c5e967fc 100755
---- a/.chezmoiscripts/script-one.sh
+new file mode 100755
+index 0000000000000000000000000000000000000000..a5498fa48acd6f616d60604b94352958c5e967fc
+--- /dev/null
 +++ b/.chezmoiscripts/script-one.sh
 @@ -0,0 +1,3 @@
 +#!/bin/sh

--- a/pkg/cmd/testdata/scripts/script_unix.txtar
+++ b/pkg/cmd/testdata/scripts/script_unix.txtar
@@ -41,8 +41,9 @@ cmp stdout golden/archive
 script.sh
 -- golden/diff.diff --
 diff --git a/script.sh b/script.sh
-index e69de29bb2d1d6434b8b29ae775ad8c2e48c5391..f9103e018df1bbc178e66b46d8f133f49c85225d 100755
---- a/script.sh
+new file mode 100755
+index 0000000000000000000000000000000000000000..f9103e018df1bbc178e66b46d8f133f49c85225d
+--- /dev/null
 +++ b/script.sh
 @@ -0,0 +1,3 @@
 +#!/bin/sh

--- a/pkg/cmd/testdata/scripts/script_unix.txtar
+++ b/pkg/cmd/testdata/scripts/script_unix.txtar
@@ -4,9 +4,13 @@
 exec chezmoi status
 cmp stdout golden/status
 
-# test the chezmoi diff prints the script
+# test that chezmoi diff prints the script
 exec chezmoi diff
 cmp stdout golden/diff.diff
+
+# test that chezmoi diff --script-contents=false prints the script name but not its contents
+exec chezmoi diff --script-contents=false
+cmp stdout golden/diff-no-script-contents.diff
 
 # test that chezmoi apply runs the script
 exec chezmoi apply --force
@@ -39,6 +43,12 @@ cmp stdout golden/archive
 
 -- golden/archive --
 script.sh
+-- golden/diff-no-script-contents.diff --
+diff --git a/script.sh b/script.sh
+new file mode 100755
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+--- /dev/null
++++ b/script.sh
 -- golden/diff.diff --
 diff --git a/script.sh b/script.sh
 new file mode 100755

--- a/pkg/cmd/testdata/scripts/scriptonce_unix.txtar
+++ b/pkg/cmd/testdata/scripts/scriptonce_unix.txtar
@@ -40,8 +40,9 @@ stdout ${HOME@R}
 
 -- golden/diff.diff --
 diff --git a/script.sh b/script.sh
-index e69de29bb2d1d6434b8b29ae775ad8c2e48c5391..f9103e018df1bbc178e66b46d8f133f49c85225d 100755
---- a/script.sh
+new file mode 100755
+index 0000000000000000000000000000000000000000..f9103e018df1bbc178e66b46d8f133f49c85225d
+--- /dev/null
 +++ b/script.sh
 @@ -0,0 +1,3 @@
 +#!/bin/sh


### PR DESCRIPTION
As requested by @halostatue in https://github.com/twpayne/chezmoi/issues/2536#issuecomment-1299402155.

You can set `diff.scriptContents` to `false` in your configuration file.