### PR TITLE
docs: Fix typos in Sourcehut repo patterns

### DIFF
--- a/assets/chezmoi.io/docs/reference/commands/init.md
+++ b/assets/chezmoi.io/docs/reference/commands/init.md
@@ -12,8 +12,8 @@ following patterns:
 | `user`             | `https://github.com/user/dotfiles.git` | `git@github.com:user/dotfiles.git` |
 | `user/repo`        | `https://github.com/user/repo.git`     | `git@github.com:user/repo.git`     |
 | `site/user/repo`   | `https://site/user/repo.git`           | `git@site:user/repo.git`           |
-| `~sr.ht/user`      | `https://git.sr.ht/~user/dotfiles`     | `git@git.sr.ht:~user/dotfiles.git` |
-| `~sr.ht/user/repo` | `https://git.sr.ht/~user/repo`         | `git@git.sr.ht:~/user/repo.git`    |
+| `sr.ht/~user`      | `https://git.sr.ht/~user/dotfiles`     | `git@git.sr.ht:~user/dotfiles.git` |
+| `sr.ht/~user/repo` | `https://git.sr.ht/~user/repo`         | `git@git.sr.ht:~user/repo.git`    |
 
 To disable git repo URL guessing pass the `--guess-repo-url=false` option.
 


### PR DESCRIPTION
I was a bit confused with the location of the `~` in the pattern and, sure enough, it didn't work when entered as documented. I also removed an incorrect `/`.