### PR TITLE
chore: Make generation of versioninfo.json work without tags or git repo

### DIFF
--- a/assets/templates/versioninfo.json.tmpl
+++ b/assets/templates/versioninfo.json.tmpl
@@ -1,34 +1,35 @@
 {{- $name := "chezmoi" -}}
 {{- $filename := printf "%s.exe" $name -}}
 
-{{- /* Get the current year using the Magical Reference Date format */ -}}
-{{- $currentYear := now | date "2006" -}}
-
-{{- $commitHash := output "git" "rev-parse" "HEAD" | trim -}}
-{{- if ne "" (output "git" "diff" "--stat" | trim) -}}
-{{-   $commitHash = printf "%s-dirty" $commitHash -}}
+{{- $comments := "" -}}
+{{- if exists ".git" -}}
+{{-   $commitHash := output "git" "rev-parse" "HEAD" | trim -}}
+{{-   if ne "" (output "git" "diff" "--stat" | trim) -}}
+{{-     $commitHash = printf "%s-dirty" $commitHash -}}
+{{-   end -}}
+{{-   $comments = printf "commit: %s" $commitHash -}}
 {{- end -}}
 
-{{- $version := semver (output "git" "describe" "--abbrev=0" "--tags" | trim) -}}
-{{- $versionDict := (dict
-    "Major" $version.Major
-    "Minor" $version.Minor
-    "Patch" $version.Patch
-    "Build" 0)
--}}
+{{- $versionStr := "v0.0.0" -}}
+{{- if and (exists ".git") (output "git" "tag" "--list" | trim) -}}
+{{-   $versionStr = output "git" "describe" "--abbrev=0" "--tags" | trim -}}
+{{- end -}}
+{{- $versionDict := dict -}}
+{{- with semver $versionStr -}}
+{{-   $versionDict = (dict "Major" .Major "Minor" .Minor "Patch" .Patch "Build" 0) -}}
+{{- end -}}
 
 {{- dict
-    "FixedFileInfo" (dict
+      "FixedFileInfo" (dict
         "FileVersion" $versionDict
         "ProductVersion" $versionDict)
-    "StringFileInfo" (dict
-        "Comments" (printf "commit: %s" $commitHash)
+      "StringFileInfo" (dict
+        "Comments" $comments
         "FileDescription" "Manage your dotfiles across multiple diverse machines, securely."
-        "FileVersion" $version.Original
+        "FileVersion" $versionStr
         "InternalName" $filename
-        "LegalCopyright" (printf "Copyright (c) 2018-%s Tom Payne" $currentYear)
+        "LegalCopyright" (printf "Copyright (c) 2018-%s Tom Payne" (now | date "2006"))
         "OriginalFilename" $filename
         "ProductName" $name
-        "ProductVersion" $version.Original)
-    | toPrettyJson
-}}
+        "ProductVersion" $versionStr)
+      | toPrettyJson }}

--- a/internal/cmds/execute-template/main.go
+++ b/internal/cmds/execute-template/main.go
@@ -3,8 +3,10 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
 	"flag"
 	"fmt"
+	"io/fs"
 	"net/http"
 	"os"
 	"os/exec"
@@ -98,6 +100,16 @@ func run() error {
 	buffer := &bytes.Buffer{}
 	funcMap := sprig.TxtFuncMap()
 	gitHubClient := newGitHubClient(context.Background())
+	funcMap["exists"] = func(name string) bool {
+		switch _, err := os.Stat(name); {
+		case err == nil:
+			return true
+		case errors.Is(err, fs.ErrNotExist):
+			return false
+		default:
+			panic(err)
+		}
+	}
 	funcMap["gitHubLatestRelease"] = gitHubClient.gitHubLatestRelease
 	funcMap["gitHubListReleases"] = gitHubClient.gitHubListReleases
 	funcMap["gitHubTimestampFormat"] = func(layout string, timestamp github.Timestamp) string {


### PR DESCRIPTION
Previously, generating `versioninfo.json` required `git describe --abbrev=0 --tags` to succeed, which is not the case when chezmoi is forked (https://github.com/deivid-rodriguez/chezmoi/pull/2) or if chezmoi is built from a source archive (where there is no git repo). With this commit, `versioninfo.json` is generated in both cases, albeit without a correct version or commit hash. This allows the `test-release` job to succeed on forks.

cc @deivid-rodriguez