### PR TITLE
Add YAML example for interpreters

### DIFF
--- a/assets/chezmoi.io/docs/reference/target-types.md
+++ b/assets/chezmoi.io/docs/reference/target-types.md
@@ -133,6 +133,17 @@ Script interpreters can be added or overridden with the
         command = "tclsh"
     ```
 
+    If using YAML for the config file, each extension should be a child node of
+    `interpreters`, like this:
+
+    ```yaml title="~/.config/chezmoi/chezmoi.yaml"
+    interpreters:
+      py:
+        command: 'C:\Python39\python3.exe'
+      tcl:
+        command: "tclsh"
+    ```
+
 !!! note
 
     If you intend to use PowerShell Core (`pwsh.exe`) as the `.ps1`

--- a/assets/chezmoi.io/docs/reference/target-types.md
+++ b/assets/chezmoi.io/docs/reference/target-types.md
@@ -113,13 +113,9 @@ The default script interpreters are:
 | `.ps1`    | `powershell` | `-NoLogo` |
 | `.rb`     | `ruby`       | *none*    |
 
-Script interpreters can be added or overridden with the
-`interpreters.`*extension* section in the configuration file.
-
-!!! note
-
-    The leading `.` is dropped from *extension*, for example to specify the
-    interpreter for `.pl` files you configure `interpreters.pl`.
+Script interpreters can be added or overridden by adding the corresponding
+extension (without the leading dot) as a key under the `interpreters`
+section of the configuration file.
 
 !!! example
 
@@ -127,14 +123,21 @@ Script interpreters can be added or overridden with the
     Tcl/Tk interpreter, include the following in your config file:
 
     ```toml title="~/.config/chezmoi/chezmoi.toml"
+    [interpreters]
+    py = { command = 'C:\Python39\python3.exe' }
+    tcl = { command = "tclsh" }
+    ```
+
+    If using TOML, it's also possible to write it like this:
+    
+    ```toml title="~/.config/chezmoi/chezmoi.toml"
     [interpreters.py]
         command = 'C:\Python39\python3.exe'
     [interpreters.tcl]
         command = "tclsh"
     ```
 
-    If using YAML for the config file, each extension should be a child node of
-    `interpreters`, like this:
+    Or if using YAML:
 
     ```yaml title="~/.config/chezmoi/chezmoi.yaml"
     interpreters:

--- a/assets/chezmoi.io/docs/reference/target-types.md
+++ b/assets/chezmoi.io/docs/reference/target-types.md
@@ -117,26 +117,25 @@ Script interpreters can be added or overridden by adding the corresponding
 extension (without the leading dot) as a key under the `interpreters`
 section of the configuration file.
 
+!!! note
+
+    The leading `.` is dropped from *extension*, for example to specify the
+    interpreter for `.pl` files you configure `interpreters.pl` (where `.`
+    in this case just means "a child of" in the configuration file, however
+    that is specified in your preferred format).
+
 !!! example
 
     To change the Python interpreter to `C:\Python39\python3.exe` and add a
     Tcl/Tk interpreter, include the following in your config file:
 
     ```toml title="~/.config/chezmoi/chezmoi.toml"
-    [interpreters]
-    py = { command = 'C:\Python39\python3.exe' }
-    tcl = { command = "tclsh" }
-    ```
-
-    If using TOML, it's also possible to write it like this:
-    
-    ```toml title="~/.config/chezmoi/chezmoi.toml"
     [interpreters.py]
         command = 'C:\Python39\python3.exe'
     [interpreters.tcl]
         command = "tclsh"
     ```
-
+    
     Or if using YAML:
 
     ```yaml title="~/.config/chezmoi/chezmoi.yaml"
@@ -145,6 +144,16 @@ section of the configuration file.
         command: "C:\Python39\python3.exe"
       tcl:
         command: "tclsh"
+    ```
+
+    Note that the TOML version can also be written like this, which
+    resembles the YAML version more and makes it clear that the key
+    for each file extension should not have a leading `.`:
+
+    ```toml title="~/.config/chezmoi/chezmoi.toml"
+    [interpreters]
+    py = { command = 'C:\Python39\python3.exe' }
+    tcl = { command = "tclsh" }
     ```
 
 !!! note

--- a/assets/chezmoi.io/docs/reference/target-types.md
+++ b/assets/chezmoi.io/docs/reference/target-types.md
@@ -139,7 +139,7 @@ Script interpreters can be added or overridden with the
     ```yaml title="~/.config/chezmoi/chezmoi.yaml"
     interpreters:
       py:
-        command: 'C:\Python39\python3.exe'
+        command: "C:\Python39\python3.exe"
       tcl:
         command: "tclsh"
     ```


### PR DESCRIPTION
Adds an example of how interpreters are configured if using a YAML config file