### PR TITLE
docs: link to reference in script user guide

### DIFF
--- a/assets/chezmoi.io/docs/user-guide/use-scripts-to-perform-actions.md
+++ b/assets/chezmoi.io/docs/user-guide/use-scripts-to-perform-actions.md
@@ -38,6 +38,9 @@ file in a temporary directory with the executable bit set, and then executes
 the contents with `exec(3)`. Consequently, the script's contents must either
 include a `#!` line or be an executable binary.
 
+By default chezmoi will copy your scripts to a target directory. Place them inside
+(`.chezmoiscripts`)[special-files-and-directories/chezmoiscripts] to disable this behavior.
+
 ## Set environment variables
 
 You can set extra environment variables for your scripts in the `scriptEnv`


### PR DESCRIPTION
Thanks for this tool!

I'm converting my setup to chezmoi and I would have found it helpful to find out about `.chezmoiscripts` from the user guide.

<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer/contributing-changes/

-->
