### PR TITLE
docs: Fix config path in scripts doc

### DIFF
--- a/assets/chezmoi.io/docs/reference/target-types.md
+++ b/assets/chezmoi.io/docs/reference/target-types.md
@@ -161,7 +161,7 @@ section of the configuration file.
     If you intend to use PowerShell Core (`pwsh.exe`) as the `.ps1`
     interpreter, include the following in your config file:
 
-    ```toml title="~/.confg/chezmoi/chezmoi.toml"
+    ```toml title="~/.config/chezmoi/chezmoi.toml"
     [interpreters.ps1]
         command = "pwsh"
         args = ["-NoLogo"]


### PR DESCRIPTION
Noticed this small issue in the docs:

![config-path-discrepancy](https://user-images.githubusercontent.com/4542383/205973485-4167a75a-3a8e-491e-9179-e3834b143dde.png)
