### PR TITLE
docs: note about actual auth types for GitHub private repos

### DIFF
--- a/assets/chezmoi.io/docs/install.md.tmpl
+++ b/assets/chezmoi.io/docs/install.md.tmpl
@@ -155,6 +155,13 @@ with a single command:
     sh -c "$(curl -fsLS get.chezmoi.io)" -- init --apply $GITHUB_USERNAME
     ```
 
+    Private GitHub repos requires other
+    [authentication methods](https://docs.github.com/en/get-started/getting-started-with-git/about-remote-repositories#cloning-with-https-urls):
+
+    ```sh
+    sh -c "$(curl -fsLS get.chezmoi.io)" -- init --apply git@github.com:$GITHUB_USERNAME/dotfiles.git
+    ```
+
 !!! hint
 
     To install the chezmoi binary in a different directory, use the `-b` option,

--- a/assets/chezmoi.io/docs/quick-start.md
+++ b/assets/chezmoi.io/docs/quick-start.md
@@ -122,6 +122,15 @@ On a second machine, initialize chezmoi with your dotfiles repo:
 $ chezmoi init https://github.com/$GITHUB_USERNAME/dotfiles.git
 ```
 
+!!! hint
+
+    Private GitHub repos requires other
+    [authentication methods](https://docs.github.com/en/get-started/getting-started-with-git/about-remote-repositories#cloning-with-https-urls):
+
+    ```console
+    $ chezmoi init git@github.com:$GITHUB_USERNAME/dotfiles.git
+    ```
+
 This will check out the repo and any submodules and optionally create a chezmoi
 config file for you.
 
@@ -187,6 +196,15 @@ shortened to:
 ```console
 $ chezmoi init --apply $GITHUB_USERNAME
 ```
+
+!!! hint
+
+    Private GitHub repos requires other
+    [authentication methods](https://docs.github.com/en/get-started/getting-started-with-git/about-remote-repositories#cloning-with-https-urls):
+
+    ```console
+    chezmoi init --apply git@github.com:$GITHUB_USERNAME/dotfiles.git
+    ```
 
 This command is summarized in this sequence diagram:
 


### PR DESCRIPTION
Issue on private GitHub repos: URL login is deprecared, SSH used instead.

When connecting to GitHub by URL, there was an error: "Support for password authentication was removed on August 13, 2021. Please see https://docs.github.com/en/get-started/getting-started-with-git/about-remote-repositories#cloning-with-https-urls for information on currently recommended modes of authentication."
