### PR TITLE
docs: Fix typo in merge user guide

### DIFF
--- a/assets/chezmoi.io/docs/user-guide/tools/merge.md
+++ b/assets/chezmoi.io/docs/user-guide/tools/merge.md
@@ -2,9 +2,9 @@
 
 ## Use a custom merge command
 
-By default, chezmoi uses `vimdiff.` You can use a custom command by setting the
+By default, chezmoi uses `vimdiff`. You can use a custom command by setting the
 `merge.command` and `merge.args` configuration variables. The elements of
-`merge.args` are interprested as templates with the variables `.Destination`,
+`merge.args` are interpreted as templates with the variables `.Destination`,
 `.Source`, and `.Target` containing filenames of the file in the destination
 state, source state, and target state respectively. For example, to use
 [neovim's diff mode](https://neovim.io/doc/user/diff.html), specify:


### PR DESCRIPTION
Noticed a small typo on the merge page of the user guide.