### PR TITLE
fix: walk flattened external archives

### DIFF
--- a/pkg/chezmoi/archive_test.go
+++ b/pkg/chezmoi/archive_test.go
@@ -12,50 +12,73 @@ import (
 )
 
 func TestWalkArchive(t *testing.T) {
+	nestedRoot := map[string]any{
+		"dir1": map[string]any{
+			"subdir1": map[string]any{
+				"file1": "",
+				"file2": "",
+			},
+			"subdir2": map[string]any{
+				"file1": "",
+				"file2": "",
+			},
+		},
+		"dir2": map[string]any{
+			"subdir1": map[string]any{
+				"file1": "",
+				"file2": "",
+			},
+			"subdir2": map[string]any{
+				"file1": "",
+				"file2": "",
+			},
+		},
+		"file1":    "",
+		"file2":    "",
+		"symlink1": &archivetest.Symlink{Target: "file1"},
+		"symlink2": &archivetest.Symlink{Target: "file2"},
+	}
+	flatRoot := map[string]any{
+		"dir1/subdir1/file1": "",
+		"dir1/subdir1/file2": "",
+		"dir1/subdir2/file1": "",
+		"dir1/subdir2/file2": "",
+		"dir2/subdir1/file1": "",
+		"dir2/subdir1/file2": "",
+		"dir2/subdir2/file1": "",
+		"dir2/subdir2/file2": "",
+		"file1":              "",
+		"file2":              "",
+		"symlink1":           &archivetest.Symlink{Target: "file1"},
+		"symlink2":           &archivetest.Symlink{Target: "file2"},
+	}
 	for _, tc := range []struct {
 		name          string
+		root          map[string]any
 		dataFunc      func(map[string]any) ([]byte, error)
 		archiveFormat ArchiveFormat
 	}{
 		{
 			name:          "tar",
+			root:          nestedRoot,
 			dataFunc:      archivetest.NewTar,
 			archiveFormat: ArchiveFormatTar,
 		},
 		{
 			name:          "zip",
+			root:          nestedRoot,
 			dataFunc:      archivetest.NewZip,
 			archiveFormat: ArchiveFormatZip,
 		},
+		{
+			name:          "tar-flat",
+			root:          flatRoot,
+			dataFunc:      archivetest.NewTar,
+			archiveFormat: ArchiveFormatTar,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			root := map[string]any{
-				"dir1": map[string]any{
-					"subdir1": map[string]any{
-						"file1": "",
-						"file2": "",
-					},
-					"subdir2": map[string]any{
-						"file1": "",
-						"file2": "",
-					},
-				},
-				"dir2": map[string]any{
-					"subdir1": map[string]any{
-						"file1": "",
-						"file2": "",
-					},
-					"subdir2": map[string]any{
-						"file1": "",
-						"file2": "",
-					},
-				},
-				"file1":    "",
-				"file2":    "",
-				"symlink1": &archivetest.Symlink{Target: "file1"},
-				"symlink2": &archivetest.Symlink{Target: "file2"},
-			}
-			data, err := tc.dataFunc(root)
+			data, err := tc.dataFunc(tc.root)
 			require.NoError(t, err)
 
 			expectedNames := []string{


### PR DESCRIPTION
Tarballs from `registry.npmjs.org` only include a flattened list of files, and thus don't contain any tar headers where `header.Typeflag == tar.TypeDir`.

This causes `chezmoi apply` to fail the first time it tries to create a file whose parent directory does not exist.

Here's an example of an `npm` tarball vs one from `GitHub`:

```sh
> curl -sL https://github.com/npm/node-semver/tarball/v7.3.8 --output gh.tgz

> curl -sL https://registry.npmjs.org/semver/-/semver-7.3.8.tgz --output npm.tgz

> tar ztvf npm.tgz | grep "^d" # no output

> tar ztvf gh.tgz | grep "^d"
drwxrwxr-x  0 root   root        0 Oct  4 12:37 npm-node-semver-dc0fe20/
drwxrwxr-x  0 root   root        0 Oct  4 12:37 npm-node-semver-dc0fe20/.github/
drwxrwxr-x  0 root   root        0 Oct  4 12:37 npm-node-semver-dc0fe20/.github/ISSUE_TEMPLATE/
drwxrwxr-x  0 root   root        0 Oct  4 12:37 npm-node-semver-dc0fe20/.github/matchers/
drwxrwxr-x  0 root   root        0 Oct  4 12:37 npm-node-semver-dc0fe20/.github/workflows/
drwxrwxr-x  0 root   root        0 Oct  4 12:37 npm-node-semver-dc0fe20/bin/
drwxrwxr-x  0 root   root        0 Oct  4 12:37 npm-node-semver-dc0fe20/classes/
drwxrwxr-x  0 root   root        0 Oct  4 12:37 npm-node-semver-dc0fe20/functions/
drwxrwxr-x  0 root   root        0 Oct  4 12:37 npm-node-semver-dc0fe20/internal/
drwxrwxr-x  0 root   root        0 Oct  4 12:37 npm-node-semver-dc0fe20/ranges/
drwxrwxr-x  0 root   root        0 Oct  4 12:37 npm-node-semver-dc0fe20/scripts/
drwxrwxr-x  0 root   root        0 Oct  4 12:37 npm-node-semver-dc0fe20/tap-snapshots/
drwxrwxr-x  0 root   root        0 Oct  4 12:37 npm-node-semver-dc0fe20/tap-snapshots/test/
drwxrwxr-x  0 root   root        0 Oct  4 12:37 npm-node-semver-dc0fe20/tap-snapshots/test/bin/
drwxrwxr-x  0 root   root        0 Oct  4 12:37 npm-node-semver-dc0fe20/test/
drwxrwxr-x  0 root   root        0 Oct  4 12:37 npm-node-semver-dc0fe20/test/bin/
drwxrwxr-x  0 root   root        0 Oct  4 12:37 npm-node-semver-dc0fe20/test/classes/
drwxrwxr-x  0 root   root        0 Oct  4 12:37 npm-node-semver-dc0fe20/test/fixtures/
drwxrwxr-x  0 root   root        0 Oct  4 12:37 npm-node-semver-dc0fe20/test/functions/
drwxrwxr-x  0 root   root        0 Oct  4 12:37 npm-node-semver-dc0fe20/test/internal/
drwxrwxr-x  0 root   root        0 Oct  4 12:37 npm-node-semver-dc0fe20/test/ranges/
```

And here's a `.chezmoiexternal` example that fails with the following error:

```sh
> cat .chezmoiexternal.toml
["npm"]
    type = "archive"
    url = "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz"
    exact = true
    stripComponents = 1

["github"]
    type = "archive"
    url = "https://github.com/npm/node-semver/tarball/v7.3.8"
    exact = true
    stripComponents = 1

> chezmoi apply --init
chezmoi: stat /Users/lukekarrys/Desktop/chezmoi-test/dest/npm/bin: no such file or directory
```

## Solution

This PR keeps track of all seen directories inside `walkArchiveTar` and if a file is seen before its directory, the walk function will first process a directory.


## Caveats

I was not sure what to do about the `Mode` of the implicit directories, so they are currently always set to `0o755`.

Also this is my first time writing `Go` so I have no idea how idiomatic any of the code is, except all the `make` commands pass.

