### PR TITLE
fix: Support .zip files with empty internal directories

### DIFF
--- a/pkg/chezmoi/archive_test.go
+++ b/pkg/chezmoi/archive_test.go
@@ -71,6 +71,12 @@ func TestWalkArchive(t *testing.T) {
 			archiveFormat: ArchiveFormatZip,
 		},
 		{
+			name:          "zip-flat",
+			root:          flatRoot,
+			dataFunc:      archivetest.NewZip,
+			archiveFormat: ArchiveFormatZip,
+		},
+		{
 			name:          "tar-flat",
 			root:          flatRoot,
 			dataFunc:      archivetest.NewTar,


### PR DESCRIPTION
Fix for https://github.com/twpayne/chezmoi/issues/2700

Zip files can have multiple levels of directories that don't have files in them. This fix is similar to https://github.com/twpayne/chezmoi/commit/e74a926a464961f66cdb3476eb1f2ef79f56f5e9 but applies to .zip files.

Essentially a mkdir -p on the path to the file prior to writing the file.
