### PR TITLE
feat: Add external_ attribute for directories

### DIFF
--- a/assets/chezmoi.io/docs/reference/commands/chattr.md
+++ b/assets/chezmoi.io/docs/reference/commands/chattr.md
@@ -16,6 +16,7 @@ modifiers and their abbreviations are:
 | `encrypted`        | *none*       |
 | `exact`            | *none*       |
 | `executable`       | `x`          |
+| `external`         | *none*       |
 | `once`             | `o`          |
 | `private`          | `p`          |
 | `readonly`         | `r`          |

--- a/assets/chezmoi.io/docs/reference/source-state-attributes.md
+++ b/assets/chezmoi.io/docs/reference/source-state-attributes.md
@@ -19,6 +19,7 @@ to as "attributes":
 | `dot_`        | Rename to use a leading dot, e.g. `dot_foo` becomes `.foo`                          |
 | `empty_`      | Ensure the file exists, even if is empty. By default, empty files are removed       |
 | `encrypted_`  | Encrypt the file in the source state                                                |
+| `external_`   | Ignore attributes in child entries                                                  |
 | `exact_`      | Remove anything not managed by chezmoi                                              |
 | `executable_` | Add executable permissions to the target file                                       |
 | `literal_`    | Stop parsing prefix attributes                                                      |
@@ -41,7 +42,7 @@ prefixes is important.
 
 | Target type   | Source type | Allowed prefixes in order                                               | Allowed suffixes |
 | ------------- | ----------- | ----------------------------------------------------------------------- | ---------------- |
-| Directory     | Directory   | `remove_`, `exact_`, `private_`, `readonly_`, `dot_`                    | *none*           |
+| Directory     | Directory   | `external_` or `remove_`, `exact_`, `private_`, `readonly_`, `dot_`     | *none*           |
 | Regular file  | File        | `encrypted_`, `private_`, `executable_`, `dot_`                         | `.tmpl`          |
 | Create file   | File        | `create_`, `encrypted_`, `private_`, `readonly_`, `executable_`, `dot_` | `.tmpl`          |
 | Modify file   | File        | `modify_`, `encrypted_`, `private_`, `readonly_`, `executable_`, `dot_` | `.tmpl`          |

--- a/pkg/chezmoi/attr.go
+++ b/pkg/chezmoi/attr.go
@@ -122,6 +122,7 @@ func (da DirAttr) MarshalZerologObject(e *zerolog.Event) {
 	e.Bool("exact", da.Exact)
 	e.Bool("private", da.Private)
 	e.Bool("readOnly", da.ReadOnly)
+	e.Bool("remove", da.Remove)
 }
 
 // SourceName returns da's source name.

--- a/pkg/chezmoi/attr.go
+++ b/pkg/chezmoi/attr.go
@@ -56,6 +56,7 @@ const (
 type DirAttr struct {
 	TargetName string
 	Exact      bool
+	External   bool
 	Private    bool
 	ReadOnly   bool
 	Remove     bool
@@ -80,10 +81,15 @@ func parseDirAttr(sourceName string) DirAttr {
 	var (
 		name     = sourceName
 		exact    = false
+		external = false
 		private  = false
 		readOnly = false
 		remove   = false
 	)
+	if strings.HasPrefix(name, externalPrefix) {
+		name = mustTrimPrefix(name, externalPrefix)
+		external = true
+	}
 	if strings.HasPrefix(name, removePrefix) {
 		name = mustTrimPrefix(name, removePrefix)
 		remove = true
@@ -109,6 +115,7 @@ func parseDirAttr(sourceName string) DirAttr {
 	return DirAttr{
 		TargetName: name,
 		Exact:      exact,
+		External:   external,
 		Private:    private,
 		ReadOnly:   readOnly,
 		Remove:     remove,
@@ -120,6 +127,7 @@ func parseDirAttr(sourceName string) DirAttr {
 func (da DirAttr) MarshalZerologObject(e *zerolog.Event) {
 	e.Str("targetName", da.TargetName)
 	e.Bool("exact", da.Exact)
+	e.Bool("external", da.External)
 	e.Bool("private", da.Private)
 	e.Bool("readOnly", da.ReadOnly)
 	e.Bool("remove", da.Remove)
@@ -128,6 +136,9 @@ func (da DirAttr) MarshalZerologObject(e *zerolog.Event) {
 // SourceName returns da's source name.
 func (da DirAttr) SourceName() string {
 	sourceName := ""
+	if da.External {
+		sourceName += externalPrefix
+	}
 	if da.Remove {
 		sourceName += removePrefix
 	}

--- a/pkg/chezmoi/attr_test.go
+++ b/pkg/chezmoi/attr_test.go
@@ -13,6 +13,7 @@ func TestDirAttr(t *testing.T) {
 	testData := struct {
 		TargetName []string
 		Exact      []bool
+		External   []bool
 		Private    []bool
 		ReadOnly   []bool
 		Remove     []bool
@@ -31,6 +32,7 @@ func TestDirAttr(t *testing.T) {
 			"symlink_dir",
 		},
 		Exact:    []bool{false, true},
+		External: []bool{false, true},
 		Private:  []bool{false, true},
 		ReadOnly: []bool{false, true},
 		Remove:   []bool{false, true},

--- a/pkg/chezmoi/chezmoi.go
+++ b/pkg/chezmoi/chezmoi.go
@@ -51,6 +51,7 @@ const (
 	encryptedPrefix  = "encrypted_"
 	exactPrefix      = "exact_"
 	executablePrefix = "executable_"
+	externalPrefix   = "external_"
 	literalPrefix    = "literal_"
 	modifyPrefix     = "modify_"
 	oncePrefix       = "once_"

--- a/pkg/chezmoi/relpath.go
+++ b/pkg/chezmoi/relpath.go
@@ -100,6 +100,16 @@ func (p RelPath) Slice(begin, end int) RelPath {
 	return NewRelPath(p.relPath[begin:end])
 }
 
+// SourceRelPath returns p as a SourceRelPath.
+func (p RelPath) SourceRelPath() SourceRelPath {
+	return NewSourceRelPath(p.relPath)
+}
+
+// SourceRelDirPath returns p as a directory SourceRelPath.
+func (p RelPath) SourceRelDirPath() SourceRelPath {
+	return NewSourceRelDirPath(p.relPath)
+}
+
 // Split returns p's directory and path.
 func (p RelPath) Split() (RelPath, RelPath) {
 	dir, file := path.Split(p.relPath)

--- a/pkg/chezmoi/sourcestate.go
+++ b/pkg/chezmoi/sourcestate.go
@@ -800,8 +800,8 @@ func (s *SourceState) Read(ctx context.Context, options *ReadOptions) error {
 	allSourceStateEntries := make(map[RelPath][]SourceStateEntry)
 	addSourceStateEntries := func(relPath RelPath, sourceStateEntries ...SourceStateEntry) {
 		allSourceStateEntriesMu.Lock()
+		defer allSourceStateEntriesMu.Unlock()
 		allSourceStateEntries[relPath] = append(allSourceStateEntries[relPath], sourceStateEntries...)
-		allSourceStateEntriesMu.Unlock()
 	}
 	walkFunc := func(sourceAbsPath AbsPath, fileInfo fs.FileInfo, err error) error {
 		if err != nil {

--- a/pkg/chezmoi/sourcestate_test.go
+++ b/pkg/chezmoi/sourcestate_test.go
@@ -1309,6 +1309,88 @@ func TestSourceStateRead(t *testing.T) {
 			),
 		},
 		{
+			name: "external",
+			root: map[string]any{
+				"/home/user/.local/share/chezmoi": map[string]any{
+					"external_dir": map[string]any{
+						"dot_file": "# contents of dir/dot_file\n",
+						"subdir": map[string]any{
+							"empty_file": "",
+						},
+						"symlink": &vfst.Symlink{Target: "dot_file"},
+					},
+				},
+			},
+			expectedSourceState: NewSourceState(
+				withEntries(map[RelPath]SourceStateEntry{
+					NewRelPath("dir"): &SourceStateDir{
+						origin:        SourceStateOriginAbsPath(NewAbsPath("/home/user/.local/share/chezmoi/external_dir")),
+						sourceRelPath: NewSourceRelDirPath("external_dir"),
+						Attr: DirAttr{
+							TargetName: "dir",
+							External:   true,
+						},
+						targetStateEntry: &TargetStateDir{
+							perm: fs.ModePerm &^ chezmoitest.Umask,
+						},
+					},
+					NewRelPath("dir/dot_file"): &SourceStateFile{
+						origin:        SourceStateOriginAbsPath(NewAbsPath("/home/user/.local/share/chezmoi/external_dir/dot_file")),
+						sourceRelPath: NewSourceRelPath("external_dir/dot_file"),
+						Attr: FileAttr{
+							TargetName: "dot_file",
+							Type:       SourceFileTypeFile,
+							Empty:      true,
+						},
+						lazyContents: newLazyContents([]byte("# contents of dir/dot_file\n")),
+						targetStateEntry: &TargetStateFile{
+							empty:        true,
+							perm:         0o666 &^ chezmoitest.Umask,
+							lazyContents: newLazyContents([]byte("# contents of dir/dot_file\n")),
+						},
+					},
+					NewRelPath("dir/subdir"): &SourceStateDir{
+						origin:        SourceStateOriginAbsPath(NewAbsPath("/home/user/.local/share/chezmoi/external_dir/subdir")),
+						sourceRelPath: NewSourceRelDirPath("external_dir/subdir"),
+						Attr: DirAttr{
+							TargetName: "subdir",
+							Exact:      true,
+						},
+						targetStateEntry: &TargetStateDir{
+							perm: fs.ModePerm &^ chezmoitest.Umask,
+						},
+					},
+					NewRelPath("dir/subdir/empty_file"): &SourceStateFile{
+						origin:        SourceStateOriginAbsPath(NewAbsPath("/home/user/.local/share/chezmoi/external_dir/subdir/empty_file")),
+						sourceRelPath: NewSourceRelPath("external_dir/subdir/empty_file"),
+						Attr: FileAttr{
+							TargetName: "empty_file",
+							Type:       SourceFileTypeFile,
+							Empty:      true,
+						},
+						lazyContents: newLazyContents([]byte{}),
+						targetStateEntry: &TargetStateFile{
+							empty:        true,
+							perm:         0o666 &^ chezmoitest.Umask,
+							lazyContents: newLazyContents([]byte{}),
+						},
+					},
+					NewRelPath("dir/symlink"): &SourceStateFile{
+						origin:        SourceStateOriginAbsPath(NewAbsPath("/home/user/.local/share/chezmoi/external_dir/symlink")),
+						sourceRelPath: NewSourceRelPath("external_dir/symlink"),
+						Attr: FileAttr{
+							TargetName: "symlink",
+							Type:       SourceFileTypeFile,
+						},
+						lazyContents: newLazyContents([]byte("dot_file")),
+						targetStateEntry: &TargetStateSymlink{
+							lazyLinkname: newLazyLinkname("dot_file"),
+						},
+					},
+				}),
+			),
+		},
+		{
 			name: "chezmoitemplates",
 			root: map[string]any{
 				"/home/user/.local/share/chezmoi": map[string]any{

--- a/pkg/cmd/chattrcmd.go
+++ b/pkg/cmd/chattrcmd.go
@@ -63,6 +63,7 @@ type modifier struct {
 	encrypted      boolModifier
 	exact          boolModifier
 	executable     boolModifier
+	external       boolModifier
 	order          orderModifier
 	private        boolModifier
 	readOnly       boolModifier
@@ -106,6 +107,7 @@ func (c *Config) chattrCmdValidArgs(
 			"encrypted",
 			"exact",
 			"executable",
+			"external",
 			"modify",
 			"once",
 			"onchange",
@@ -382,6 +384,8 @@ func parseModifier(s string) (*modifier, error) {
 			m.exact = bm
 		case "executable", "x":
 			m.executable = bm
+		case "external":
+			m.external = bm
 		case "modify":
 			switch bm {
 			case boolModifierClear:
@@ -437,6 +441,7 @@ func (m *modifier) modifyDirAttr(dirAttr chezmoi.DirAttr) chezmoi.DirAttr {
 	return chezmoi.DirAttr{
 		TargetName: dirAttr.TargetName,
 		Exact:      m.exact.modify(dirAttr.Exact),
+		External:   m.external.modify(dirAttr.External),
 		Private:    m.private.modify(dirAttr.Private),
 		ReadOnly:   m.readOnly.modify(dirAttr.ReadOnly),
 		Remove:     m.remove.modify(dirAttr.Remove),

--- a/pkg/cmd/chattrcmd_test.go
+++ b/pkg/cmd/chattrcmd_test.go
@@ -23,7 +23,7 @@ func TestChattrCmdValidArgs(t *testing.T) {
 		},
 		{
 			toComplete:                 "e",
-			expectedCompletions:        []string{"empty", "encrypted", "exact", "executable"},
+			expectedCompletions:        []string{"empty", "encrypted", "exact", "executable", "external"},
 			expectedShellCompDirective: cobra.ShellCompDirectiveNoFileComp,
 		},
 		{

--- a/pkg/cmd/main_test.go
+++ b/pkg/cmd/main_test.go
@@ -57,6 +57,7 @@ func TestScript(t *testing.T) {
 			"edit":           cmdEdit,
 			"expandenv":      cmdExpandEnv,
 			"httpd":          cmdHTTPD,
+			"isdir":          cmdIsDir,
 			"issymlink":      cmdIsSymlink,
 			"lexists":        cmdLExists,
 			"mkfile":         cmdMkFile,
@@ -209,6 +210,23 @@ func cmdHTTPD(ts *testscript.TestScript, neg bool, args []string) {
 	dir := ts.MkAbs(args[0])
 	server := httptest.NewServer(http.FileServer(http.Dir(dir)))
 	ts.Setenv("HTTPD_URL", server.URL)
+}
+
+// cmdIsDir succeeds if all of its arguments are directories.
+func cmdIsDir(ts *testscript.TestScript, neg bool, args []string) {
+	for _, arg := range args {
+		filename := ts.MkAbs(arg)
+		fileInfo, err := os.Lstat(filename)
+		if err != nil {
+			ts.Fatalf("%s: %v", arg, err)
+		}
+		switch isDir := fileInfo.IsDir(); {
+		case isDir && neg:
+			ts.Fatalf("%s is a directory", arg)
+		case !isDir && !neg:
+			ts.Fatalf("%s is not a directory", arg)
+		}
+	}
 }
 
 // cmdIsSymlink succeeds if all of its arguments are symlinks.

--- a/pkg/cmd/testdata/scripts/externaldir.txtar
+++ b/pkg/cmd/testdata/scripts/externaldir.txtar
@@ -1,0 +1,35 @@
+symlink $CHEZMOISOURCEDIR/dot_vim/external_bundle/symlink -> executable_file
+
+# test that chezmoi ignores attributes in external_ dirs
+exec chezmoi apply
+
+# test that executable_ attributes are ignored and empty files are created
+cmp $HOME/.vim/bundle/executable_file $CHEZMOISOURCEDIR/dot_vim/external_bundle/executable_file
+
+# test that scripts are not run
+cmp $HOME/.vim/bundle/run_script.sh $CHEZMOISOURCEDIR/dot_vim/external_bundle/run_script.sh
+! stdout evil
+
+# test that private_ attributes are ignored and subdirectories are created
+isdir $HOME/.vim/bundle/private_subdir
+
+# test that files can be ignored
+! exists $HOME/.vim/bundle/private_subdir/.keep
+
+# test that symlinks are created
+issymlink $HOME/.vim/bundle/symlink
+
+# test that symlink_ attributes are ignored
+cmp $HOME/.vim/bundle/symlink_example $CHEZMOISOURCEDIR/dot_vim/external_bundle/symlink_example
+! issymlink $HOME/.vim/bundle/symlink_example
+
+-- home/user/.local/share/chezmoi/.chezmoiignore --
+**/.keep
+-- home/user/.local/share/chezmoi/dot_vim/external_bundle/executable_file --
+-- home/user/.local/share/chezmoi/dot_vim/external_bundle/private_subdir/.keep --
+-- home/user/.local/share/chezmoi/dot_vim/external_bundle/run_script.sh --
+#!/bin/sh
+
+echo evil
+-- home/user/.local/share/chezmoi/dot_vim/external_bundle/symlink_example --
+# contents of .vim/bundle/symlink_example


### PR DESCRIPTION
Fixes #2714.

@peterbraden would you be able to test this? For each of your git submodules, you should add the `external_` attribute in their directories. In your case, the following should work:

```console
$ chezmoi chattr +external ~/.vim/bundle/*
```

You'll probably also not want chezmoi to copy `.git` directories from the git submodules. To prevent this, add

```
.vim/bundle/**/.git
```

to your `.chezmoiignore`.