### PR TITLE
fix: Eliminate [DEFAULT] section for `fromIni` map

### DIFF
--- a/pkg/cmd/templatefuncs.go
+++ b/pkg/cmd/templatefuncs.go
@@ -473,7 +473,13 @@ func fileInfoToMap(fileInfo fs.FileInfo) map[string]any {
 func iniFileToMap(file *ini.File) map[string]any {
 	m := make(map[string]any)
 	for _, section := range file.Sections() {
-		m[section.Name()] = iniSectionToMap(section)
+		if section.Name() == ini.DefaultSection {
+			for _, k := range section.Keys() {
+				m[k.Name()] = k.Value()
+			}
+		} else {
+			m[section.Name()] = iniSectionToMap(section)
+		}
 	}
 	return m
 }

--- a/pkg/cmd/templatefuncs_test.go
+++ b/pkg/cmd/templatefuncs_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/ini.v1"
 
 	"github.com/twpayne/chezmoi/v2/pkg/chezmoitest"
 )
@@ -370,9 +369,7 @@ func TestFromIniTemplateFunc(t *testing.T) {
 				`key = value`,
 			),
 			expected: map[string]any{
-				ini.DefaultSection: map[string]any{
-					"key": "value",
-				},
+				"key": "value",
 			},
 		},
 		{
@@ -381,7 +378,19 @@ func TestFromIniTemplateFunc(t *testing.T) {
 				`sectionKey = sectionValue`,
 			),
 			expected: map[string]any{
-				ini.DefaultSection: map[string]any{},
+				"section": map[string]any{
+					"sectionKey": "sectionValue",
+				},
+			},
+		},
+		{
+			text: chezmoitest.JoinLines(
+				`key = value`,
+				`[section]`,
+				`sectionKey = sectionValue`,
+			),
+			expected: map[string]any{
+				"key": "value",
 				"section": map[string]any{
 					"sectionKey": "sectionValue",
 				},


### PR DESCRIPTION
Closes #2768

In `fromIni`, the `iniFileToMap` function converts top-level keys (the so-called "default" section) to being members of a `DEFAULT` map key, which results in different data than expected. Specifically, roundtripping fails such that `{{ . | fromIni | toIni }}` does not produce the same output as input.

This change results in code duplication, but prevents the unnecessary creation of a new `map[string]any` or a second loop for merging.