### PR TITLE
feat: Find config file with $CHEZMOI_CONFIG

### DIFF
--- a/assets/chezmoi.io/docs/reference/command-line-flags/global.md
+++ b/assets/chezmoi.io/docs/reference/command-line-flags/global.md
@@ -2,9 +2,13 @@
 
 ## `--cache` *directory*
 
+> Configuration: `cacheDir`
+
 Use *directory* as the cache directory.
 
 ## `--color` *value*
+
+> Configuration: `color`
 
 Colorize diffs, *value* can be `on`, `off`, `auto`, or any boolean-like value
 recognized by `promptBool`. The default is `auto` which will colorize diffs only
@@ -12,7 +16,7 @@ if the environment variable `$NO_COLOR` is not set and stdout is a terminal.
 
 ## `-c`, `--config` *filename*
 
-Read the configuration from *filename*.
+Read the [configuration](/reference/configuration-file) from *filename*.
 
 ## `--config-format` `json`|`jsonc`|`toml`|`yaml`
 
@@ -21,6 +25,8 @@ the config filename does not have an extension, for example when it is
 `/dev/stdin`.
 
 ## `-D`, `--destination` *directory*
+
+> Configuration: `destDir`
 
 Use *directory* as the destination directory.
 
@@ -56,6 +62,8 @@ Write the output to *filename* instead of stdout.
 
 ## `--persistent-state` *filename*
 
+> Configuration: `persistentState`
+
 Read and write the persistent state from *filename*. By default, chezmoi stores
 its persistent state in `chezmoistate.boltdb` in the same directory as its
 configuration file.
@@ -82,9 +90,13 @@ if no cached external is available.
 
 ## `-S`, `--source` *directory*
 
+> Configuration: `sourceDir`
+
 Use *directory* as the source directory.
 
 ## `--use-builtin-age` *value*
+
+> Configuration: `useBuiltinAge`
 
 Use chezmoi's builtin [age encryption](https://age-encryption.org) instead of an
 external `age` command. *value* can be `on`, `off`, `auto`, or any boolean-like
@@ -95,6 +107,8 @@ The builtin `age` command does not support passphrases, symmetric encryption,
 or the use of SSH keys.
 
 ## `--use-builtin-git` *value*
+
+> Configuration: `useBuiltinGit`
 
 Use chezmoi's builtin git instead of `git.command` for the `init` and `update`
 commands. *value* can be `on`, `off`, `auto`, or any boolean-like value

--- a/assets/chezmoi.io/docs/reference/configuration-file/index.md
+++ b/assets/chezmoi.io/docs/reference/configuration-file/index.md
@@ -1,20 +1,20 @@
 # Configuration file
 
-chezmoi searches for its configuration file according to the [XDG Base
-Directory
+chezmoi searches for its configuration file according to the [XDG Base Directory
 Specification](https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html)
 and supports [JSON](https://www.json.org/json-en.html), JSONC,
 [TOML](https://github.com/toml-lang/toml), and [YAML](https://yaml.org/). The
-basename of the config file is `chezmoi`, and the first config file found is
-used.
+basename of the config file is `chezmoi`. If multiple configuration file formats
+are present, chezmoi will report an error.
 
 In most installations, the config file will be read from
-`~/.config/chezmoi/chezmoi.$FORMAT`, where `$FORMAT` is one of `json`, `toml`,
-or `yaml`. The config file can be set explicitly with the `--config` command
-line option. By default, the format is detected based on the extension of the
-config file name, but can be overridden with the `--config-format` command line
-option.
-
+`$HOME/.config/chezmoi/chezmoi.$FORMAT`
+(`%USERPROFILE%/.config/chezmoi/chezmoi.$FORMAT`), where `$FORMAT` is one of
+`json`, `jsonc`, `toml`, or `yaml`. The config file can be set explicitly with
+the `--config` command line option or the environment variable
+`$CHEZMOI_CONFIG`. By default, the format is detected based on the extension of
+the config file name, but can be overridden with the `--config-format` command
+line option.
 
 ## Examples
 

--- a/assets/chezmoi.io/docs/reference/configuration-file/index.md
+++ b/assets/chezmoi.io/docs/reference/configuration-file/index.md
@@ -29,6 +29,18 @@ line option.
     }
     ```
 
+=== "JSONC"
+
+    ```jsonc title="~/.config/chezmoi/chezmoi.jsonc"
+    {
+        // The chezmoi source files are stored here
+        "sourceDir": "/home/user/.dotfiles",
+        "git": {
+            "autoPush": true
+        }
+    }
+    ```
+
 === "TOML"
 
     ```toml title="~/.config/chezmoi/chezmoi.toml"

--- a/assets/chezmoi.io/docs/reference/configuration-file/variables.md.yaml
+++ b/assets/chezmoi.io/docs/reference/configuration-file/variables.md.yaml
@@ -1,13 +1,21 @@
 sections:
   '':
+    cacheDir:
+      default: >-
+        `$XDG_CACHE_HOME/chezmoi` <br/>
+        `$HOME/.cache/chezmoi` <br/>
+        `%USERPROFILE%/.cache/chezmoi`
+      description: 'Cache directory'
     color:
       default: '`auto`'
       description: Colorize output
     data:
-      type: any
+      type: object
       description: Template data
     destDir:
-      default: '`~`'
+      default: >-
+        `$HOME` <br/>
+        `%USERPROFILE%`
       description: Destination directory
     encryption:
       description: Encryption type, either `age` or `gpg`
@@ -20,6 +28,12 @@ sections:
     pager:
       default: '`$PAGER`'
       description: Default pager CLI command
+    persistentState:
+      default: >-
+        `$XDG_CONFIG_HOME/chezmoi/chezmoi.boltdb` <br/>
+        `$HOME/.local/share/chezmoi/chezmoi.boltdb` <br/>
+        `%USERPROFILE%/.local/share/chezmoi/chezmoi.boltdb`
+      description: Location of the persistent state file
     progress:
       type: bool
       description: Display progress bars
@@ -29,7 +43,10 @@ sections:
     scriptTempDir:
       description: Temporary directory for scripts
     sourceDir:
-      default: '`~/.local/share/chezmoi`'
+      default: >-
+        `$XDG_SHARE_HOME/chezmoi` <br/>
+        `$HOME/.local/share/chezmoi` <br/>
+        `%USERPROFILE%/.local/share/chezmoi`
       description: Source directory
     umask:
       type: int
@@ -288,7 +305,7 @@ sections:
       description: Vault CLI command
   update:
     args:
-      type: "[]string"
+      type: '[]string'
       description: Extra args to update command
     command:
       description: Update command

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -1361,6 +1361,12 @@ func (c *Config) marshal(dataFormat writeDataFormat, data any) error {
 
 // newRootCmd returns a new root github.com/spf13/cobra.Command.
 func (c *Config) newRootCmd() (*cobra.Command, error) {
+	if configFileFromEnv := os.Getenv("CHEZMOI_CONFIG"); configFileFromEnv != "" {
+		if err := c.configFileAbsPath.Set(configFileFromEnv); err != nil {
+			return nil, err
+		}
+	}
+
 	rootCmd := &cobra.Command{
 		Use:                "chezmoi",
 		Short:              "Manage your dotfiles across multiple diverse machines, securely",

--- a/pkg/cmd/testdata/scripts/options.txtar
+++ b/pkg/cmd/testdata/scripts/options.txtar
@@ -15,6 +15,20 @@ chhome home3/user
 exec chezmoi apply --config=$HOME/.chezmoi.toml
 cmp $HOME/tmp/.file golden/.file
 
+chhome home4/user
+
+# test that $CHEZMOI_CONFIG is respected
+env CHEZMOI_CONFIG=$HOME/.chezmoi.toml
+exec chezmoi apply
+cmp $HOME/tmp/.file golden/.file
+
+chhome home5/user
+
+# test that --config flag overrides $CHEZMOI_CONFIG
+env CHEZMOI_CONFIG=$HOME/.chezmoi.toml
+exec chezmoi apply --config=$HOME/.chezmoi2.toml
+cmp $HOME/tmp2/.file golden/.file
+
 -- golden/.file --
 # contents of .file
 -- home/user/.dotfiles/dot_file --
@@ -27,3 +41,18 @@ destDir = "~/tmp"
 -- home3/user/.dotfiles/dot_file --
 # contents of .file
 -- home3/user/tmp/.keep --
+-- home4/user/.chezmoi.toml --
+sourceDir = "~/.dotfiles"
+destDir = "~/tmp"
+-- home4/user/.dotfiles/dot_file --
+# contents of .file
+-- home4/user/tmp/.keep --
+-- home5/user/.chezmoi.toml --
+sourceDir = "~/.dotfiles"
+destDir = "~/tmp"
+-- home5/user/.chezmoi2.toml --
+sourceDir = "~/.dotfiles"
+destDir = "~/tmp2"
+-- home5/user/.dotfiles/dot_file --
+# contents of .file
+-- home5/user/tmp2/.keep --


### PR DESCRIPTION
Closes #2771

This provides an alternative to pure command-line flag configuration when working with multiple source trees.