### PR TITLE
fix: Detect absolute paths in externals on Windows

### DIFF
--- a/pkg/chezmoi/sourcestate.go
+++ b/pkg/chezmoi/sourcestate.go
@@ -1180,7 +1180,7 @@ func (s *SourceState) addExternal(sourceAbsPath AbsPath) error {
 	s.Lock()
 	defer s.Unlock()
 	for path, external := range externals {
-		if filepath.IsAbs(path) {
+		if strings.HasPrefix(path, "/") || filepath.IsAbs(path) {
 			return fmt.Errorf("%s: %s: path is not relative", sourceAbsPath, path)
 		}
 		targetRelPath := parentTargetSourceRelPath.JoinString(path)

--- a/pkg/cmd/testdata/scripts/issue2302.txtar
+++ b/pkg/cmd/testdata/scripts/issue2302.txtar
@@ -1,5 +1,3 @@
-[windows] skip 'UNIX only'
-
 # test that chezmoi does not panic if an external uses an absolute path
 ! exec chezmoi diff
 stderr 'path is not relative'


### PR DESCRIPTION
Fixes #2777.