### PR TITLE
correct configuration file syntax for edit.args

### DIFF
--- a/assets/chezmoi.io/docs/reference/configuration-file/editor.md
+++ b/assets/chezmoi.io/docs/reference/configuration-file/editor.md
@@ -6,7 +6,7 @@ environment variable. If none are set then chezmoi falls back to `notepad.exe`
 on Windows systems and `vi` on non-Windows systems.
 
 When the `edit.command` configuration variable is used, extra arguments can be
-passed to the editor with the `editor.args` configuration variable.
+passed to the editor with the `edit.args` configuration variable.
 
 chezmoi will emit a warning if the editor returns in less than
 `edit.minDuration` (default `1s`). To disable this warning, set


### PR DESCRIPTION
Slight tweak to reference documentation to correct editor argument key.

Pretty sure this is right. It's at least what worked for me on
```bash
❯ chezmoi --version
chezmoi version v2.31.0, commit 4d2bc846212e27fae1e5bbd45d70e00908da603b, built at 2023-02-17T11:19:43Z, built by Homebrew
```
