### PR TITLE
fix: Allow underscores and dots in GitHub dotfile repo name guesses

### DIFF
--- a/pkg/cmd/initcmd.go
+++ b/pkg/cmd/initcmd.go
@@ -47,7 +47,7 @@ var repoGuesses = []struct {
 		sshRepoGuessRepl:  "git@github.com:$1/dotfiles.git",
 	},
 	{
-		rx:                regexp.MustCompile(`\A([-0-9A-Za-z]+)/([-0-9A-Za-z]+)(\.git)?\z`),
+		rx:                regexp.MustCompile(`\A([-0-9A-Za-z]+)/([-\.0-9A-Z_a-z]+?)(\.git)?\z`),
 		httpRepoGuessRepl: "https://github.com/$1/$2.git",
 		sshRepoGuessRepl:  "git@github.com:$1/$2.git",
 	},

--- a/pkg/cmd/initcmd_test.go
+++ b/pkg/cmd/initcmd_test.go
@@ -74,6 +74,16 @@ func TestGuessRepoURL(t *testing.T) {
 			expectedSSHRepoURL:  "git@github.com:user/dotfiles.git",
 		},
 		{
+			arg:                 "user/chezmoi_dotfiles",
+			expectedHTTPRepoURL: "https://github.com/user/chezmoi_dotfiles.git",
+			expectedSSHRepoURL:  "git@github.com:user/chezmoi_dotfiles.git",
+		},
+		{
+			arg:                 "user/.dotfiles",
+			expectedHTTPRepoURL: "https://github.com/user/.dotfiles.git",
+			expectedSSHRepoURL:  "git@github.com:user/.dotfiles.git",
+		},
+		{
 			arg:                 "user/dots",
 			expectedHTTPRepoURL: "https://github.com/user/dots.git",
 			expectedSSHRepoURL:  "git@github.com:user/dots.git",


### PR DESCRIPTION
Fixes #2816.