### PR TITLE
feat: Refuse to add chezmoi files to chezmoi

### DIFF
--- a/pkg/cmd/addcmd.go
+++ b/pkg/cmd/addcmd.go
@@ -148,15 +148,27 @@ func (c *Config) runAddCmd(cmd *cobra.Command, args []string, sourceState *chezm
 		return err
 	}
 
+	persistentStateFileAbsPath, err := c.persistentStateFile()
+	if err != nil {
+		return err
+	}
+
 	return sourceState.Add(c.sourceSystem, c.persistentState, c.destSystem, destAbsPathInfos, &chezmoi.AddOptions{
-		AutoTemplate:     c.Add.autoTemplate,
-		Create:           c.Add.create,
-		Encrypt:          c.Add.encrypt,
-		EncryptedSuffix:  c.encryption.EncryptedSuffix(),
-		Exact:            c.Add.exact,
-		Filter:           c.Add.filter,
-		OnIgnoreFunc:     c.defaultOnIgnoreFunc,
-		PreAddFunc:       c.defaultPreAddFunc,
+		AutoTemplate:    c.Add.autoTemplate,
+		Create:          c.Add.create,
+		Encrypt:         c.Add.encrypt,
+		EncryptedSuffix: c.encryption.EncryptedSuffix(),
+		Exact:           c.Add.exact,
+		Filter:          c.Add.filter,
+		OnIgnoreFunc:    c.defaultOnIgnoreFunc,
+		PreAddFunc:      c.defaultPreAddFunc,
+		ProtectedAbsPaths: []chezmoi.AbsPath{
+			c.CacheDirAbsPath,
+			c.WorkingTreeAbsPath,
+			c.configFileAbsPath,
+			persistentStateFileAbsPath,
+			c.sourceDirAbsPath,
+		},
 		ReplaceFunc:      c.defaultReplaceFunc,
 		Template:         c.Add.template,
 		TemplateSymlinks: c.Add.TemplateSymlinks,

--- a/pkg/cmd/testdata/scripts/issue1832.txtar
+++ b/pkg/cmd/testdata/scripts/issue1832.txtar
@@ -3,7 +3,7 @@
 # test that chezmoi add succeeds when changing the permissions of an intermediate directory
 exec chezmoi add $HOME/.config/fish/config
 chmod 700 $HOME/.config
-exec chezmoi add --force $HOME/.config
+exec chezmoi add --force --recursive=false $HOME/.config
 
 -- home/user/.config/fish/config --
 # contents of .config/fish/config

--- a/pkg/cmd/testdata/scripts/issue2820.txtar
+++ b/pkg/cmd/testdata/scripts/issue2820.txtar
@@ -1,0 +1,17 @@
+# test that chezmoi add refuses to add files in chezmoi's source directory
+! exec chezmoi add $CHEZMOISOURCEDIR
+stderr 'cannot add chezmoi file to chezmoi'
+
+# test that chezmoi add refuses to add files in chezmoi's config directory
+! exec chezmoi add $CHEZMOICONFIGDIR
+stderr 'cannot add chezmoi file to chezmoi'
+
+# test that chezmoi add refuses to add files in chezmoi's source directory when already in that directory
+cd $CHEZMOISOURCEDIR
+exists dot_file
+! exec chezmoi add dot_file
+stderr 'cannot add chezmoi file to chezmoi'
+
+-- home/user/.config/chezmoi/chezmoi.toml --
+-- home/user/.local/share/chezmoi/dot_file --
+# contents of .file


### PR DESCRIPTION
Refs #2820.

@bradenhilton I'd appreciate your thoughts on this. Right now, this stops `chezmoi add` from adding any path where `chezmoi` is one of the components, but it's a pretty simple check and there are probably improvements/fixes.