### PR TITLE
Improve chezmoi cd command

### DIFF
--- a/pkg/cmd/cdcmd.go
+++ b/pkg/cmd/cdcmd.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"errors"
+	"os"
+
 	"github.com/spf13/cobra"
 
 	"github.com/twpayne/chezmoi/v2/pkg/chezmoi"
@@ -32,6 +35,10 @@ func (c *Config) newCDCmd() *cobra.Command {
 }
 
 func (c *Config) runCDCmd(cmd *cobra.Command, args []string) error {
+	if _, ok := os.LookupEnv("CHEZMOI"); ok {
+		return errors.New("already in a chezmoi subshell")
+	}
+
 	cdCommand, cdArgs, err := c.cdCommand()
 	if err != nil {
 		return err


### PR DESCRIPTION
This potentially fixes #2821 by setting the `$PS1` environment variable and stopping `chezmoi cd` subshells from nesting.

Review appreciated on this.