### PR TITLE
chore: Remove +build comments from modules

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,5 +1,4 @@
 //go:build go1.18
-// +build go1.18
 
 //go:generate go run . completion bash -o completions/chezmoi-completion.bash
 //go:generate go run . completion fish -o completions/chezmoi.fish

--- a/pkg/chezmoi/chezmoi_unix.go
+++ b/pkg/chezmoi/chezmoi_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package chezmoi
 

--- a/pkg/chezmoi/chezmoi_unix_test.go
+++ b/pkg/chezmoi/chezmoi_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package chezmoi
 

--- a/pkg/chezmoi/path_unix.go
+++ b/pkg/chezmoi/path_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package chezmoi
 

--- a/pkg/chezmoi/realsystem_unix.go
+++ b/pkg/chezmoi/realsystem_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package chezmoi
 

--- a/pkg/chezmoitest/chezmoitest_unix.go
+++ b/pkg/chezmoitest/chezmoitest_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package chezmoitest
 

--- a/pkg/cmd/doctorcmd_unix.go
+++ b/pkg/cmd/doctorcmd_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package cmd
 

--- a/pkg/cmd/keyringtemplatefuncs.go
+++ b/pkg/cmd/keyringtemplatefuncs.go
@@ -1,5 +1,4 @@
 //go:build !freebsd || (freebsd && cgo)
-// +build !freebsd freebsd,cgo
 
 package cmd
 

--- a/pkg/cmd/keyringtemplatefuncs_freebsdnocgo.go
+++ b/pkg/cmd/keyringtemplatefuncs_freebsdnocgo.go
@@ -1,5 +1,4 @@
 //go:build freebsd && !cgo
-// +build freebsd,!cgo
 
 package cmd
 

--- a/pkg/cmd/noupgradecmd.go
+++ b/pkg/cmd/noupgradecmd.go
@@ -1,5 +1,4 @@
 //go:build noupgrade
-// +build noupgrade
 
 package cmd
 

--- a/pkg/cmd/secretkeyringcmd.go
+++ b/pkg/cmd/secretkeyringcmd.go
@@ -1,5 +1,4 @@
 //go:build !freebsd || (freebsd && cgo)
-// +build !freebsd freebsd,cgo
 
 package cmd
 

--- a/pkg/cmd/secretkeyringcmd_freebsdnocgo.go
+++ b/pkg/cmd/secretkeyringcmd_freebsdnocgo.go
@@ -1,5 +1,4 @@
 //go:build freebsd && !cgo
-// +build freebsd,!cgo
 
 package cmd
 

--- a/pkg/cmd/upgradecmd.go
+++ b/pkg/cmd/upgradecmd.go
@@ -1,5 +1,4 @@
 //go:build !noupgrade
-// +build !noupgrade
 
 package cmd
 

--- a/pkg/cmd/upgradecmd_test.go
+++ b/pkg/cmd/upgradecmd_test.go
@@ -1,5 +1,4 @@
 //go:build !noupgrade && !windows
-// +build !noupgrade,!windows
 
 package cmd
 

--- a/pkg/cmd/util_unix.go
+++ b/pkg/cmd/util_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package cmd
 

--- a/pkg/shell/shell_darwin.go
+++ b/pkg/shell/shell_darwin.go
@@ -1,5 +1,4 @@
 //go:build darwin
-// +build darwin
 
 package shell
 

--- a/pkg/shell/shell_plan9.go
+++ b/pkg/shell/shell_plan9.go
@@ -1,5 +1,4 @@
 //go:build plan9
-// +build plan9
 
 package shell
 

--- a/pkg/shell/shell_posix.go
+++ b/pkg/shell/shell_posix.go
@@ -1,5 +1,4 @@
 //go:build !darwin && !plan9 && !windows
-// +build !darwin,!plan9,!windows
 
 package shell
 

--- a/pkg/shell/shellcgo.go
+++ b/pkg/shell/shellcgo.go
@@ -1,5 +1,4 @@
 //go:build (cgo && aix) || (cgo && android) || (cgo && darwin) || (cgo && dragonfly) || (cgo && freebsd) || (cgo && illumos) || (cgo && linux) || (cgo && netbsd) || (cgo && openbsd) || (cgo && solaris)
-// +build cgo,aix cgo,android cgo,darwin cgo,dragonfly cgo,freebsd cgo,illumos cgo,linux cgo,netbsd cgo,openbsd cgo,solaris
 
 package shell
 

--- a/pkg/shell/shellnocgo.go
+++ b/pkg/shell/shellnocgo.go
@@ -1,5 +1,4 @@
 //go:build !cgo
-// +build !cgo
 
 package shell
 


### PR DESCRIPTION
This PR removes `// +build` comments because the minimum supported version is Go 1.18 by running the command:
```
go fix -fix buildtag ./...
```