### PR TITLE
chore: Use run.go instead of deprecated lang-version

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,6 @@
+run:
+  go: '1.18'
+
 linters:
   enable:
   - asciicheck
@@ -110,7 +113,6 @@ linters-settings:
     - prefix(github.com/twpayne/chezmoi)
   gofumpt:
     extra-rules: true
-    lang-version: '1.18'
     module-path: github.com/twpayne/chezmoi
   goimports:
     local-prefixes: github.com/twpayne/chezmoi


### PR DESCRIPTION
The PR modifies `.golangci.yml` to use [`run.go`](https://github.com/golangci/golangci-lint/blob/28a94fde5cd3a075e012683a43ae96e69ca6e3e8/.golangci.reference.yml#L73) option instead of [deprecated `gofumpt.lang-version`](https://github.com/golangci/golangci-lint/blob/28a94fde5cd3a075e012683a43ae96e69ca6e3e8/.golangci.reference.yml#L629).