### PR TITLE
feat: Add support for ejson

### DIFF
--- a/assets/chezmoi.io/docs/reference/configuration-file/variables.md.yaml
+++ b/assets/chezmoi.io/docs/reference/configuration-file/variables.md.yaml
@@ -165,6 +165,13 @@ sections:
     watch:
       type: bool
       description: Automatically apply changes when files are saved
+  ejson:
+    keyDir:
+      type: 'string'
+      description: Path to directory containing private keys. Defaults to /opt/ejson/keys. Setting the EJSON_KEYDIR environment will also set this value, with lower precedence.
+    key:
+      type: 'string'
+      description: The private key to use for decryption, will supersede using the keyDir if set.
   git:
     autoAdd:
       type: bool

--- a/assets/chezmoi.io/docs/reference/templates/ejson-functions/ejsonDecrypt.md
+++ b/assets/chezmoi.io/docs/reference/templates/ejson-functions/ejsonDecrypt.md
@@ -1,0 +1,16 @@
+# `ejsonDecrypt` *filePath*
+
+`ejsonDecrypt` returns the decrypted content of an
+[ejson](https://github.com/Shopify/ejson)-encrypted file.
+
+*filePath* indicates where the encrypted file is located.
+
+The decrypted file is cached so calling `ejsonDecrypt` multiple
+times with the same *filePath* will only run through the decryption
+process once. The cache is shared with `ejsonDecryptWithKey`.
+
+!!! example
+
+    ```
+    {{ (ejsonDecrypt "my-secrets.ejson").password }}
+    ```

--- a/assets/chezmoi.io/docs/reference/templates/ejson-functions/ejsonDecryptWithKey.md
+++ b/assets/chezmoi.io/docs/reference/templates/ejson-functions/ejsonDecryptWithKey.md
@@ -1,0 +1,17 @@
+# `ejsonDecryptWithKey` *filePath* *key*
+
+`ejsonDecryptWithKey` returns the decrypted content of an
+[ejson](https://github.com/Shopify/ejson)-encrypted file.
+
+*filePath* indicates where the encrypted file is located,
+and *key* is used to decrypt the file.
+
+The decrypted file is cached so calling `ejsonDecryptWithKey` multiple
+times with the same *filePath* will only run through the decryption
+process once. The cache is shared with `ejsonDecrypt`.
+
+!!! example
+
+    ```
+    {{ (ejsonDecryptWithKey "my-secrets.ejson" "top-secret-key").password }}
+    ```

--- a/assets/chezmoi.io/docs/reference/templates/ejson-functions/index.md
+++ b/assets/chezmoi.io/docs/reference/templates/ejson-functions/index.md
@@ -1,0 +1,4 @@
+# ejson functions
+
+The `ejson*` functions return data from
+[ejson](https://github.com/Shopify/ejson)-encrypted files.

--- a/assets/chezmoi.io/docs/user-guide/password-managers/ejson.md
+++ b/assets/chezmoi.io/docs/user-guide/password-managers/ejson.md
@@ -1,0 +1,18 @@
+# ejson
+
+chezmoi includes support for [ejson](https://github.com/Shopify/ejson).
+
+Structured data can be retrieved with the `ejsonDecrypt` template function,
+for example:
+
+```
+examplePassword = {{ (ejsonDecrypt "my-secrets.ejson").password }}
+```
+
+If you want to specify the private key to use for the decryption,
+structured data can be retrieved with the `ejsonDecryptWithKey` template
+function, for example:
+
+```
+examplePassword = {{ (ejsonDecryptWithKey "my-secrets.ejson" "top-secret-key").password }}
+```

--- a/assets/chezmoi.io/mkdocs.yml
+++ b/assets/chezmoi.io/mkdocs.yml
@@ -63,6 +63,7 @@ nav:
     - AWS Secrets Manager: user-guide/password-managers/aws-secrets-manager.md
     - Bitwarden: user-guide/password-managers/bitwarden.md
     - Dashlane: user-guide/password-managers/dashlane.md
+    - ejson: user-guide/password-managers/ejson.md
     - gopass: user-guide/password-managers/gopass.md
     - KeePassXC: user-guide/password-managers/keepassxc.md
     - Keychain and Windows Credentials Manager: user-guide/password-managers/keychain-and-windows-credentials-manager.md
@@ -240,14 +241,18 @@ nav:
       - bitwardenFields: reference/templates/bitwarden-functions/bitwardenFields.md
       - rbw: reference/templates/bitwarden-functions/rbw.md
       - rbwFields: reference/templates/bitwarden-functions/rbwFields.md
-    - gopass functions:
-      - reference/templates/gopass-functions/index.md
-      - gopass: reference/templates/gopass-functions/gopass.md
-      - gopassRaw: reference/templates/gopass-functions/gopassRaw.md
     - Dashlane functions:
       - reference/templates/dashlane-functions/index.md
       - dashlaneNote: reference/templates/dashlane-functions/dashlaneNote.md
       - dashlanePassword: reference/templates/dashlane-functions/dashlanePassword.md
+    - ejson functions:
+      - reference/templates/ejson-functions/index.md
+      - ejsonDecrypt: reference/templates/ejson-functions/ejsonDecrypt.md
+      - ejsonDecryptWithKey: reference/templates/ejson-functions/ejsonDecryptWithKey.md
+    - gopass functions:
+      - reference/templates/gopass-functions/index.md
+      - gopass: reference/templates/gopass-functions/gopass.md
+      - gopassRaw: reference/templates/gopass-functions/gopassRaw.md
     - KeePassXC functions:
       - reference/templates/keepassxc-functions/index.md
       - keepassxc: reference/templates/keepassxc-functions/keepassxc.md

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	filippo.io/age v1.1.1
 	github.com/Masterminds/sprig/v3 v3.2.3
+	github.com/Shopify/ejson v1.3.3
 	github.com/aws/aws-sdk-go-v2 v1.17.6
 	github.com/aws/aws-sdk-go-v2/config v1.18.16
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.19.0
@@ -80,6 +81,7 @@ require (
 	github.com/danieljoos/wincred v1.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dlclark/regexp2 v1.8.1 // indirect
+	github.com/dustin/gojson v0.0.0-20160307161227-2e71ec9dd5ad // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/go-git/gcfg v1.5.0 // indirect
 	github.com/go-git/go-billy/v5 v5.4.1 // indirect
@@ -115,6 +117,7 @@ require (
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/skeema/knownhosts v1.1.0 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
+	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	github.com/yuin/goldmark v1.5.4 // indirect
 	github.com/yuin/goldmark-emoji v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/Microsoft/go-winio v0.6.0/go.mod h1:cTAf44im0RAYeL23bpB+fzCyDH2MJiz2B
 github.com/ProtonMail/go-crypto v0.0.0-20221026131551-cf6655e29de4/go.mod h1:UBYPn8k0D56RtnR8RFQMjmh4KrZzWJ5o7Z9SYjossQ8=
 github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8 h1:wPbRQzjjwFc0ih8puEVAOFGELsn1zoIIYdxvML7mDxA=
 github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8/go.mod h1:I0gYDMZ6Z5GRU7l58bNFSkPTFN6Yl12dsUlAZ8xy98g=
+github.com/Shopify/ejson v1.3.3 h1:dPzgmvFhUPTJIzwdF5DaqbwW1dWaoR8ADKRdSTy6Mss=
+github.com/Shopify/ejson v1.3.3/go.mod h1:VZMUtDzvBW/PAXRUF5fzp1ffb1ucT8MztrZXXLYZurw=
 github.com/acomagu/bufpipe v1.0.3/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
 github.com/acomagu/bufpipe v1.0.4 h1:e3H4WUzM3npvo5uv95QuJM3cQspFNtFBzvJ2oNjKIDQ=
 github.com/acomagu/bufpipe v1.0.4/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
@@ -94,6 +96,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/dlclark/regexp2 v1.4.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
 github.com/dlclark/regexp2 v1.8.1 h1:6Lcdwya6GjPUNsBct8Lg/yRPwMhABj269AAzdGSiR+0=
 github.com/dlclark/regexp2 v1.8.1/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/dustin/gojson v0.0.0-20160307161227-2e71ec9dd5ad h1:Qk76DOWdOp+GlyDKBAG3Klr9cn7N+LcYc82AZ2S7+cA=
+github.com/dustin/gojson v0.0.0-20160307161227-2e71ec9dd5ad/go.mod h1:mPKfmRa823oBIgl2r20LeMSpTAteW5j7FLkc0vjmzyQ=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/frankban/quicktest v1.14.4 h1:g2rn0vABPOOXmZUj+vbmUp0lPoXEMuhTpIluN0XL9UY=
@@ -135,6 +139,7 @@ github.com/google/renameio/v2 v2.0.0/go.mod h1:BtmJXm5YlszgC+TD4HOEEUFgkJP3nLxeh
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gopherjs/gopherjs v0.0.0-20200217142428-fce0ec30dd00 h1:l5lAOZEym3oK3SQ2HBHWsJUfbNBiTXJDeW2QDxw9AQ0=
 github.com/gorilla/css v1.0.0 h1:BQqNyPTi50JCFMTw/b67hByjMVXZRwGha6wxVGkeihY=
 github.com/gorilla/css v1.0.0/go.mod h1:Dn721qIggHpt4+EFCcTLTU/vk5ySda2ReITrtgBl60c=
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 h1:+ngKgrYPPJrOjhax5N+uePQ0Fh1Z7PheYoUI/0nzkPA=
@@ -154,6 +159,7 @@ github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJS
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
+github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
 github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/klauspost/compress v1.16.0 h1:iULayQNOReoYUe+1qtKOqw9CwJv3aNQu8ivo7lw1HU4=
@@ -246,6 +252,8 @@ github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFR
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/skeema/knownhosts v1.1.0 h1:Wvr9V0MxhjRbl3f9nMnKnFfiWTJmtECJ9Njkea3ysW0=
 github.com/skeema/knownhosts v1.1.0/go.mod h1:sKFq3RD6/TKZkSWn8boUbDC7Qkgcv+8XXijpFO6roag=
+github.com/smartystreets/assertions v1.0.1 h1:voD4ITNjPL5jjBfgR/r8fPIIBrliWrWHeiJApdr3r4w=
+github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cast v1.5.0 h1:rj3WzYc11XZaIZMPKmwP96zkFEnnAmV8s6XbB2aY32w=
 github.com/spf13/cast v1.5.0/go.mod h1:SpXXQ5YoyJw6s3/6cMTQuxvgRl3PCJiyaX9p6b155UU=

--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -120,6 +120,7 @@ type ConfigFile struct {
 	AWSSecretsManager awsSecretsManagerConfig `json:"awsSecretsManager" mapstructure:"awsSecretsManager" yaml:"awsSecretsManager"` //nolint:lll
 	Bitwarden         bitwardenConfig         `json:"bitwarden" mapstructure:"bitwarden" yaml:"bitwarden"`
 	Dashlane          dashlaneConfig          `json:"dashlane" mapstructure:"dashlane" yaml:"dashlane"`
+	Ejson             ejsonConfig             `json:"ejson" mapstructure:"ejson" yaml:"ejson"`
 	Gopass            gopassConfig            `json:"gopass" mapstructure:"gopass" yaml:"gopass"`
 	Keepassxc         keepassxcConfig         `json:"keepassxc" mapstructure:"keepassxc" yaml:"keepassxc"`
 	Keeper            keeperConfig            `json:"keeper" mapstructure:"keeper" yaml:"keeper"`
@@ -379,6 +380,8 @@ func newConfig(options ...configOption) (*Config, error) {
 		"dashlanePassword":         c.dashlanePasswordTemplateFunc,
 		"decrypt":                  c.decryptTemplateFunc,
 		"deleteValueAtPath":        c.deleteValueAtPathTemplateFunc,
+		"ejsonDecrypt":             c.ejsonDecryptTemplateFunc,
+		"ejsonDecryptWithKey":      c.ejsonDecryptWithKeyTemplateFunc,
 		"encrypt":                  c.encryptTemplateFunc,
 		"eqFold":                   c.eqFoldTemplateFunc,
 		"fromIni":                  c.fromIniTemplateFunc,
@@ -2450,6 +2453,7 @@ func newConfigFile(bds *xdg.BaseDirectorySpecification) ConfigFile {
 		Dashlane: dashlaneConfig{
 			Command: "dcli",
 		},
+		Ejson: ejsonConfig{},
 		Gopass: gopassConfig{
 			Command: "gopass",
 		},

--- a/pkg/cmd/ejsontemplatefuncs.go
+++ b/pkg/cmd/ejsontemplatefuncs.go
@@ -1,0 +1,60 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/Shopify/ejson"
+)
+
+const (
+	ejsonDefaultKeyDir = "/opt/ejson/keys"
+	ejsonEnvKeyDir     = "EJSON_KEYDIR"
+)
+
+type ejsonConfig struct {
+	KeyDir string `json:"keyDir" mapstructure:"keyDir" yaml:"keyDir"`
+	Key    string `json:"key" mapstructure:"key" yaml:"key"`
+	cache  map[string]any
+}
+
+func (c *Config) ejsonDecryptWithKeyTemplateFunc(filePath, key string) any {
+	if data, ok := c.Ejson.cache[filePath]; ok {
+		return data
+	}
+
+	if c.Ejson.cache == nil {
+		c.Ejson.cache = make(map[string]any)
+	}
+
+	/* We accept here that an empty string is considered as if
+	   the value was not provided; in reality, someone could
+	   provide an empty value, but ejson would then look into
+	   the root of the filesystem; this means that this is not
+	   a real limitation, since people could simply set '/'
+	   if wanting to use the filesystem root (or equivalent) */
+	keyDir := c.Ejson.KeyDir
+	if keyDir == "" {
+		keyDir = os.Getenv(ejsonEnvKeyDir)
+	}
+	if keyDir == "" {
+		keyDir = ejsonDefaultKeyDir
+	}
+
+	decrypted, err := ejson.DecryptFile(filePath, keyDir, key)
+	if err != nil {
+		panic(err)
+	}
+
+	var data any
+	if err := json.Unmarshal(decrypted, &data); err != nil {
+		panic(err)
+	}
+
+	c.Ejson.cache[filePath] = data
+	return data
+}
+
+func (c *Config) ejsonDecryptTemplateFunc(filePath string) any {
+	return c.ejsonDecryptWithKeyTemplateFunc(filePath, c.Ejson.Key)
+}

--- a/pkg/cmd/testdata/scripts/ejson.txtar
+++ b/pkg/cmd/testdata/scripts/ejson.txtar
@@ -1,0 +1,51 @@
+# test ejsonDecrypt uses default parameters
+! exec chezmoi execute-template '{{ (ejsonDecrypt "golden/my-file.ejson") }}'
+stderr 'couldn''t read key file'
+stderr '/opt/ejson/keys/df82a403a3b58ebedd09758d3b131ff3113b39bdbfb92110940eb57832774345'
+
+# test ejsonDecrypt uses EJSON_KEYDIR when set
+env EJSON_KEYDIR=golden/keys
+exec chezmoi execute-template '{{ (ejsonDecrypt "golden/my-file.ejson").key1 }}'
+stdout ^value1$
+
+# test ejsonDecrypt uses configuration's keyDir when set
+chhome home_set_valid_keydir/user
+env EJSON_KEYDIR=invalid/keys
+exec chezmoi execute-template '{{ (ejsonDecrypt "golden/my-file.ejson").key2 }}'
+stdout ^value2$
+
+# test ejsonDecrypt uses configuration's key when set, and succeeds if valid
+chhome home_set_valid_key/user
+exec chezmoi execute-template '{{ (ejsonDecrypt "golden/my-file.ejson").key1 }}'
+stdout ^value1$
+
+# test ejsonDecrypt uses configuration's key when set, and fails if invalid
+chhome home_set_invalid_key/user
+! exec chezmoi execute-template '{{ (ejsonDecrypt "golden/my-file.ejson") }}'
+
+# test ejsonDecryptWithKey uses the key passed as parameter, and succeeds if valid
+chhome home_set_invalid_key/user
+exec chezmoi execute-template '{{ (ejsonDecryptWithKey "golden/my-file.ejson" "4fed3b88a33a4621b30230f1ad17e175e10f8587e37e84da740711c9fecfe16d").key2 }}'
+stdout ^value2$
+
+# test ejsonDecryptWithKey uses the key passed as parameter, and fails if invalid
+chhome home_set_valid_key/user
+! exec chezmoi execute-template '{{ (ejsonDecryptWithKey "golden/my-file.ejson" "invalid") }}'
+
+-- golden/keys/df82a403a3b58ebedd09758d3b131ff3113b39bdbfb92110940eb57832774345 --
+4fed3b88a33a4621b30230f1ad17e175e10f8587e37e84da740711c9fecfe16d
+-- golden/my-file.ejson --
+{
+        "_public_key": "df82a403a3b58ebedd09758d3b131ff3113b39bdbfb92110940eb57832774345",
+        "key1": "EJ[1:t1Ql8sPo+fpQxHSxarJYDctfjXwfB9+OMH4BK/0CQEE=:9lajUfn0rbr/fbVYHi0yF/BH64htU4yF:8ydfFcJ7UO6rg7TGO2vqT19NBSk02Q==]",
+        "key2": "EJ[1:t1Ql8sPo+fpQxHSxarJYDctfjXwfB9+OMH4BK/0CQEE=:vmOdZjp4gqY0pmjeVb/BQQaFzW17wK5f:7UtzdtHcrwvwZdjqm4Jmn9GHxFkR1Q==]"
+}
+-- home_set_invalid_key/user/.config/chezmoi/chezmoi.yaml --
+ejson:
+  key: "foo"
+-- home_set_valid_key/user/.config/chezmoi/chezmoi.yaml --
+ejson:
+  key: "4fed3b88a33a4621b30230f1ad17e175e10f8587e37e84da740711c9fecfe16d"
+-- home_set_valid_keydir/user/.config/chezmoi/chezmoi.yaml --
+ejson:
+  keyDir: "golden/keys"


### PR DESCRIPTION
<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer/contributing-changes/

-->
This adds support for [ejson](https://github.com/Shopify/ejson) which allows to store secrets in a git repository using asymmetric encryption. Since this is basically encrypted json, once decrypted it can be parsed pretty easily and made accessible to `chezmoi` as the full JSON data structure.

**Note:** I put this as part of the password managers, as it feels like it'd be used in a similar way (this does not encrypt full files like `age` or `gpg` but keeps the structured JSON view and only encrypts the values, i.e. encrypts secrets and not files).

e.g.

```bash
$ ejson keygen
Public Key:
d5f0647bc4eea75296381787c55d52996873f156874885d685ddaf26f3e61f13
Private Key:
xxxxxxxxxxxxxxx
```
```bash
$ cat /tmp/ejson-test.ejson
{
	"_public_key": "d5f0647bc4eea75296381787c55d52996873f156874885d685ddaf26f3e61f13",
	"test": "value",
	"password": "this is me"
}
```
```bash
$ ejson encrypt /tmp/ejson-test.ejson
Wrote 349 bytes to /tmp/ejson-test.ejson.
```
```bash
$ cat /tmp/ejson-test.ejson
{
	"_public_key": "d5f0647bc4eea75296381787c55d52996873f156874885d685ddaf26f3e61f13",
	"test": "EJ[1:JRfDTIvV+/MdH5mK9bjo24s8Sk3zt5TANINbvGLJllw=:I2Dz0WOXA8yWgcC1mj+KormMq+4ZHmuJ:QDMyYLhLUJiz6bNHzWI8vD42jRXR]",
	"password": "EJ[1:JRfDTIvV+/MdH5mK9bjo24s8Sk3zt5TANINbvGLJllw=:Gln2YPhBMv0L7zneR/n2kWImImbNbW3j:7PwFn84jC3og8GPlUpA0gVDzS+kdXgJwx1s=]"
}
```
```bash
$ echo "xxxxxxxxxxxxxxx" > /tmp/d5f0647bc4eea75296381787c55d52996873f156874885d685ddaf26f3e61f13
```
```bash
$ EJSON_KEYDIR=/tmp ./chezmoi execute-template '{{ ejsonDecrypt "/tmp/ejson-test.ejson" }}'
map[_public_key:d5f0647bc4eea75296381787c55d52996873f156874885d685ddaf26f3e61f13 password:this is me test:value]
```
```bash
$ EJSON_KEYDIR=/tmp ./chezmoi execute-template '{{ (ejsonDecrypt "/tmp/ejson-test.ejson").password }}'
this is me
```