### PR TITLE
docs: Add missing `jsonc` to some formats

### DIFF
--- a/assets/chezmoi.io/docs/reference/special-files-and-directories/chezmoi-format-tmpl.md
+++ b/assets/chezmoi.io/docs/reference/special-files-and-directories/chezmoi-format-tmpl.md
@@ -2,7 +2,7 @@
 
 If a file called `.chezmoi.$FORMAT.tmpl` exists then `chezmoi init` will use it
 to create an initial config file. `$FORMAT` must be one of the supported
-config file formats, e.g. `json`, `toml`, or `yaml`.
+config file formats, e.g. `json`, `jsonc`, `toml`, or `yaml`.
 
 !!! example
 

--- a/assets/chezmoi.io/docs/reference/special-files-and-directories/chezmoiexternal-format.md
+++ b/assets/chezmoi.io/docs/reference/special-files-and-directories/chezmoiexternal-format.md
@@ -6,7 +6,7 @@ inside `.chezmoiroot`), it is interpreted as a list of external files and
 archives to be included as if they were in the source state.
 
 `$FORMAT` must be one of chezmoi's supported configuration file formats, e.g.
-`json`, `toml`, or `yaml`.
+`json`, `jsonc`, `toml`, or `yaml`.
 
 `.chezmoiexternal.$FORMAT` is interpreted as a template. This allows different
 externals to be included on different machines.

--- a/assets/chezmoi.io/docs/user-guide/setup.md
+++ b/assets/chezmoi.io/docs/user-guide/setup.md
@@ -98,8 +98,8 @@ operations](https://github.blog/2020-12-15-token-authentication-requirements-for
 `chezmoi init` can also create a config file automatically, if one does not
 already exist. If your repo contains a file called `.chezmoi.$FORMAT.tmpl`
 where `$FORMAT` is one of the supported config file formats (e.g. `json`,
-`toml`, or `yaml`) then `chezmoi init` will execute that template to generate
-your initial config file.
+`jsonc`, `toml`, or `yaml`) then `chezmoi init` will execute that template to
+generate your initial config file.
 
 Specifically, if you have `.chezmoi.toml.tmpl` that looks like this:
 

--- a/assets/chezmoi.io/docs/user-guide/templating.md
+++ b/assets/chezmoi.io/docs/user-guide/templating.md
@@ -31,8 +31,8 @@ These come from a variety of sources (later data overwrite earlier ones):
 * Variables populated by chezmoi are in `.chezmoi`, for example `.chezmoi.os`.
 
 * Variables created by you in the `.chezmoidata.$FORMAT` configuration file.
-  The various supported formats (json, toml and yaml) are read in alphabetical
-  order.
+  The various supported formats (`json`, `jsonc`, `toml` and `yaml`) are read in
+  alphabetical order.
 
 * Variables created by you in the `data` section of the configuration file.
 


### PR DESCRIPTION
I _think_ these changes are correct. I wasn't sure if `jsonc` was only supported for the config file or not.