### PR TITLE
chore: Deprecate `--autotemplate`

### DIFF
--- a/assets/chezmoi.io/docs/reference/commands/add.md
+++ b/assets/chezmoi.io/docs/reference/commands/add.md
@@ -4,7 +4,7 @@ Add *target*s to the source state. If any target is already in the source
 state, then its source state is replaced with its current state in the
 destination directory.
 
-## `--autotemplate`
+## `--autotemplate` (deprecated)
 
 Automatically generate a template by replacing strings that match variable
 values from the `data` section of the config file with their respective config
@@ -16,6 +16,9 @@ This implies the `--template` option.
     `--autotemplate` uses a greedy algorithm which occasionally generates
     templates with unwanted variable substitutions. Carefully review any
     templates it generates.
+
+    `--autotemplate` has been deprecated and will be removed in a future
+    release of chezmoi.
 
 ## `--encrypt`
 

--- a/pkg/cmd/addcmd.go
+++ b/pkg/cmd/addcmd.go
@@ -53,6 +53,10 @@ func (c *Config) newAddCmd() *cobra.Command {
 	flags.BoolVarP(&c.Add.template, "template", "T", c.Add.template, "Add files as templates")
 	flags.BoolVar(&c.Add.TemplateSymlinks, "template-symlinks", c.Add.TemplateSymlinks, "Add symlinks with target in source or home dirs as templates") //nolint:lll
 
+	if err := flags.MarkDeprecated("autotemplate", "it will be removed in a future release"); err != nil {
+		panic(err)
+	}
+
 	registerExcludeIncludeFlagCompletionFuncs(addCmd)
 
 	return addCmd

--- a/pkg/cmd/testdata/scripts/addautotemplate.txtar
+++ b/pkg/cmd/testdata/scripts/addautotemplate.txtar
@@ -1,5 +1,6 @@
 # test that chezmoi add --autotemplate on a file with a replacement creates a template in the source directory
 exec chezmoi add --autotemplate $HOME${/}.template
+stderr 'deprecated'
 cmp $CHEZMOISOURCEDIR/dot_template.tmpl golden/dot_template.tmpl
 
 # test that chezmoi add --autotemplate on a symlink with a replacement creates a template in the source directory


### PR DESCRIPTION
Remove `--autotemplate` from `chezmoi --help` and print a message when it is used.

> > @twpayne Should `--autotemplate` be deprecated for removal in v3?
> Yes, I think it was too ambitious and too fragile.

Resolves #2873 and other related issues.