### PR TITLE
fix: Only set $CHEZMOI_VERBOSE when --verbose is set

### DIFF
--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -1918,10 +1918,12 @@ func (c *Config) persistentPreRunRootE(cmd *cobra.Command, args []string) error 
 		"SOURCE_DIR":    templateData.SourceDir.String(),
 		"UID":           templateData.UID,
 		"USERNAME":      templateData.Username,
-		"VERBOSE":       strconv.FormatBool(c.Verbose),
 		"WORKING_TREE":  templateData.WorkingTree.String(),
 	} {
 		scriptEnv = append(scriptEnv, "CHEZMOI_"+key+"="+value)
+	}
+	if c.Verbose {
+		scriptEnv = append(scriptEnv, "CHEZMOI_VERBOSE=1")
 	}
 	for groupKey, group := range map[string]map[string]any{
 		"KERNEL":          templateData.Kernel,

--- a/pkg/cmd/testdata/scripts/scriptenv.txtar
+++ b/pkg/cmd/testdata/scripts/scriptenv.txtar
@@ -6,7 +6,7 @@ stdout ^WORK=${WORK@R}$
 [darwin] stdout ^CHEZMOI_OS=darwin$
 [linux] stdout ^CHEZMOI_OS=linux$
 stdout ^CHEZMOI_SOURCE_DIR=${CHEZMOISOURCEDIR@R}/home$
-stdout ^CHEZMOI_VERBOSE=false$
+stdout ^CHEZMOI_VERBOSE=$
 stdout ^SCRIPTENV_KEY=SCRIPTENV_VALUE$
 
 # test that chezmoi passes along --verbose in scripts
@@ -15,7 +15,7 @@ stdout ^WORK=${WORK@R}$
 [darwin] stdout ^CHEZMOI_OS=darwin$
 [linux] stdout ^CHEZMOI_OS=linux$
 stdout ^CHEZMOI_SOURCE_DIR=${CHEZMOISOURCEDIR@R}/home$
-stdout ^CHEZMOI_VERBOSE=true$
+stdout ^CHEZMOI_VERBOSE=1$
 stdout ^SCRIPTENV_KEY=SCRIPTENV_VALUE$
 
 -- home/user/.config/chezmoi/chezmoi.toml --


### PR DESCRIPTION
Follow up to #2875.