### PR TITLE
docs: Document how to escape `{{` and `}}` in templates

### DIFF
--- a/assets/chezmoi.io/docs/user-guide/tools/diff.md
+++ b/assets/chezmoi.io/docs/user-guide/tools/diff.md
@@ -18,7 +18,7 @@ specify:
 !!! hint
 
     If you generate your config file from a config file template, then you'll
-    need to escape the `{{` and `}}` as `{{"{{"}}` and `{{"}}"}}`. That way 
+    need to escape the `{{` and `}}` as `{{"{{"}}` and `{{"}}"}}`. That way
     your generated config file contains the `{{` and `}}` you expect.
 
 ## Don't show scripts in the diff output

--- a/assets/chezmoi.io/docs/user-guide/tools/diff.md
+++ b/assets/chezmoi.io/docs/user-guide/tools/diff.md
@@ -18,8 +18,8 @@ specify:
 !!! hint
 
     If you generate your config file from a config file template, then you'll
-    need to escape the `{{` and `}}` in your config file template so that they
-    appear in your generated config file.
+    need to escape the `{{` and `}}` as `{{"{{"}}` and `{{"}}"}}`. That way 
+    your generated config file contains the `{{` and `}}` you expect.
 
 ## Don't show scripts in the diff output
 

--- a/assets/chezmoi.io/docs/user-guide/tools/merge.md
+++ b/assets/chezmoi.io/docs/user-guide/tools/merge.md
@@ -18,5 +18,5 @@ state, source state, and target state respectively. For example, to use
 !!! hint
 
     If you generate your config file from a config file template, then you'll
-    need to escape the `{{` and `}}` in your config file template so that they
-    appear in your generated config file.
+    need to escape the `{{` and `}}` as `{{"{{"}}` and `{{"}}"}}`. That way 
+    your generated config file contains the `{{` and `}}` you expect.

--- a/assets/chezmoi.io/docs/user-guide/tools/merge.md
+++ b/assets/chezmoi.io/docs/user-guide/tools/merge.md
@@ -18,5 +18,5 @@ state, source state, and target state respectively. For example, to use
 !!! hint
 
     If you generate your config file from a config file template, then you'll
-    need to escape the `{{` and `}}` as `{{"{{"}}` and `{{"}}"}}`. That way 
+    need to escape the `{{` and `}}` as `{{"{{"}}` and `{{"}}"}}`. That way
     your generated config file contains the `{{` and `}}` you expect.


### PR DESCRIPTION
I ran into this today and had to google a bit until I found the [answer on Stackoverflow](https://stackoverflow.com/q/17641887/110204).

Somewhat surprisingly, the [documentation](https://pkg.go.dev/text/template) doesn't seem to explain this directly: instead it just says that an "argument" can be a value like a Boolean, a string, etc, and a "pipeline" is a series of "commands" and, finally, a "command" can be a single "argument" :smile: 