### PR TITLE
fix: Change where fish completions are installed

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -159,7 +159,7 @@ nfpms:
       - src: completions/chezmoi-completion.bash
         dst: /usr/share/bash-completion/completions/chezmoi
       - src: completions/chezmoi.fish
-        dst: /usr/share/fish/completions/chezmoi.fish
+        dst: /usr/share/fish/vendor_completions.d/chezmoi.fish
       - src: completions/chezmoi.zsh
         dst: /usr/share/zsh/vendor-completions/_chezmoi
     rpm:
@@ -175,7 +175,7 @@ nfpms:
       - src: completions/chezmoi-completion.bash
         dst: /usr/share/bash-completion/completions/chezmoi
       - src: completions/chezmoi.fish
-        dst: /usr/share/fish/completions/chezmoi.fish
+        dst: /usr/share/fish/vendor_completions.d/chezmoi.fish
       - src: completions/chezmoi.zsh
         dst: /usr/share/zsh/site-functions/_chezmoi
 - id: apks


### PR DESCRIPTION
According to the fish documentation[1], `/usr/share/fish/vendor_completions.d/` is the proper place for third-parties to install completion files.

[1] https://fishshell.com/docs/current/completions.html

<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer/contributing-changes/

-->
