### PR TITLE
chore(editorconfig): Remove quotes from editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,13 +1,13 @@
 root = true
 
 [*]
-charset = "utf-8"
-end_of_line = "lf"
+charset = utf-8
+end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
 [*.ps1]
-charset = "utf-8"
-end_of_line = "crlf"
+charset = utf-8
+end_of_line = crlf
 insert_final_newline = true
 trim_trailing_whitespace = true


### PR DESCRIPTION
Values in .editorconfig should _not_ be quoted.
