### PR TITLE
fix: Set CHEZMOI_SOURCE_DIR env var in init when using .chezmoiroot

### DIFF
--- a/pkg/cmd/config.go
+++ b/pkg/cmd/config.go
@@ -674,6 +674,9 @@ func (c *Config) createAndReloadConfigFile(cmd *cobra.Command) error {
 		return err
 	}
 	c.templateData.sourceDir = sourceDirAbsPath
+	c.runEnv = append(c.runEnv, "CHEZMOI_SOURCE_DIR="+sourceDirAbsPath.String())
+	realSystem := c.baseSystem.(*chezmoi.RealSystem) //nolint:forcetypeassert
+	realSystem.SetScriptEnv(c.runEnv)
 
 	// Find config template, execute it, and create config file.
 	configTemplate, err := c.findConfigTemplate()
@@ -690,7 +693,7 @@ func (c *Config) createAndReloadConfigFile(cmd *cobra.Command) error {
 		return err
 	}
 
-	// Validate the configMap.
+	// Validate the config file.
 	var configFile ConfigFile
 	if err := c.decodeConfigBytes(configTemplate.format, configFileContents, &configFile); err != nil {
 		return fmt.Errorf("%s: %w", configTemplate.sourceAbsPath, err)

--- a/pkg/cmd/testdata/scripts/issue2865.txtar
+++ b/pkg/cmd/testdata/scripts/issue2865.txtar
@@ -12,7 +12,8 @@ chhome home2/user
 # test that .chezmoi.sourceDir is set correctly when .chezmoiroot is present (chezmoi init --apply in a clean home directory)
 mkgitconfig
 exec chezmoi init --apply file://$WORK/home/user/.local/share/chezmoi
-stdout '/.local/share/chezmoi/home$'
+stdout '\.chezmoi\.sourceDir=.*/\.local/share/chezmoi/home$'
+stdout 'CHEZMOI_SOURCE_DIR=.*/\.local/share/chezmoi/home$'
 
 # test that .chezmoi.sourceDir is set correctly in config file
 exec chezmoi execute-template '{{ .testDir }}'
@@ -30,8 +31,10 @@ home
 .chezmoiscripts/echo.ps1
 {{- end }}
 -- home/user/.local/share/chezmoi/home/.chezmoiscripts/run_once_echo.ps1.tmpl --
-Write-Host {{ .chezmoi.sourceDir | quote }}
+Write-Host .chezmoi.sourceDir={{ .chezmoi.sourceDir }}
+Write-Host CHEZMOI_SOURCE_DIR=$Env:CHEZMOI_SOURCE_DIR
 -- home/user/.local/share/chezmoi/home/.chezmoiscripts/run_once_echo.sh.tmpl --
 #!/bin/sh
 
-echo {{ .chezmoi.sourceDir | quote }}
+echo .chezmoi.sourceDir={{ .chezmoi.sourceDir }}
+echo CHEZMOI_SOURCE_DIR=${CHEZMOI_SOURCE_DIR}


### PR DESCRIPTION
Refs #2865.