### PR TITLE
chore: Simplify code by using strings.EqualFold, time.Before

### DIFF
--- a/pkg/cmd/autobool.go
+++ b/pkg/cmd/autobool.go
@@ -46,7 +46,7 @@ func (b autoBool) MarshalYAML() (any, error) {
 
 // Set implements github.com/spf13/pflag.Value.Set.
 func (b *autoBool) Set(s string) error {
-	if strings.ToLower(s) == "auto" {
+	if strings.EqualFold(s, "auto") {
 		b.auto = true
 		return nil
 	}

--- a/pkg/cmd/config_test.go
+++ b/pkg/cmd/config_test.go
@@ -243,7 +243,7 @@ func withTestUser(t *testing.T, username string) configOption {
 		var err error
 		config.homeDirAbsPath, err = chezmoi.NormalizePath(config.homeDir)
 		if err != nil {
-			panic(err)
+			t.Fatal(err)
 		}
 		config.CacheDirAbsPath = config.homeDirAbsPath.JoinString(".cache", "chezmoi")
 		config.SourceDirAbsPath = config.homeDirAbsPath.JoinString(".local", "share", "chezmoi")

--- a/pkg/cmd/githubtemplatefuncs.go
+++ b/pkg/cmd/githubtemplatefuncs.go
@@ -56,7 +56,7 @@ func (c *Config) gitHubKeysTemplateFunc(user string) []*github.Key {
 		switch ok, err := chezmoi.PersistentStateGet(c.persistentState, gitHubKeysStateBucket, gitHubKeysKey, &gitHubKeysValue); { //nolint:lll
 		case err != nil:
 			panic(err)
-		case ok && !now.After(gitHubKeysValue.RequestedAt.Add(c.GitHub.RefreshPeriod)):
+		case ok && now.Before(gitHubKeysValue.RequestedAt.Add(c.GitHub.RefreshPeriod)):
 			return gitHubKeysValue.Keys
 		}
 	}
@@ -117,7 +117,7 @@ func (c *Config) gitHubLatestReleaseTemplateFunc(ownerRepo string) *github.Repos
 		switch ok, err := chezmoi.PersistentStateGet(c.persistentState, gitHubLatestReleaseStateBucket, gitHubLatestReleaseKey, &gitHubLatestReleaseStateValue); { //nolint:lll
 		case err != nil:
 			panic(err)
-		case ok && !now.After(gitHubLatestReleaseStateValue.RequestedAt.Add(c.GitHub.RefreshPeriod)):
+		case ok && now.Before(gitHubLatestReleaseStateValue.RequestedAt.Add(c.GitHub.RefreshPeriod)):
 			return gitHubLatestReleaseStateValue.Release
 		}
 	}
@@ -170,7 +170,7 @@ func (c *Config) gitHubLatestTagTemplateFunc(userRepo string) *github.Repository
 		switch ok, err := chezmoi.PersistentStateGet(c.persistentState, gitHubLatestTagStateBucket, gitHubLatestTagKey, &gitHubLatestTagValue); { //nolint:lll
 		case err != nil:
 			panic(err)
-		case ok && !now.After(gitHubLatestTagValue.RequestedAt.Add(c.GitHub.RefreshPeriod)):
+		case ok && now.Before(gitHubLatestTagValue.RequestedAt.Add(c.GitHub.RefreshPeriod)):
 			return gitHubLatestTagValue.Tag
 		}
 	}


### PR DESCRIPTION
Re-opens #3034. The original branch was deleted so I couldn't simply re-open the original PR.

Thanks for this @alexandear!

@bradenhilton was right in https://github.com/twpayne/chezmoi/pull/3034#issuecomment-1586907929 that this subtly changes the semantics of refresh periods, but refresh periods are more guidelines than rules and as Go records timestamps in nanoseconds, the chances of hitting this are minuscule and it wouldn't matter anyway.