### PR TITLE
chore: Use http.NoBody instead of nil

### DIFF
--- a/pkg/chezmoi/sourcestate.go
+++ b/pkg/chezmoi/sourcestate.go
@@ -1411,7 +1411,7 @@ func (s *SourceState) getExternalDataRaw(
 		}
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, external.URL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, external.URL, http.NoBody)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/upgradecmd.go
+++ b/pkg/cmd/upgradecmd.go
@@ -237,7 +237,7 @@ func (c *Config) getChecksums(ctx context.Context, rr *github.RepositoryRelease)
 }
 
 func (c *Config) downloadURL(ctx context.Context, url string) ([]byte, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR refactors code by using https://pkg.go.dev/net/http#NoBody instead of `nil`.