### PR TITLE
fix: Parse hostnames from all loopback addresses in /etc/hosts

### DIFF
--- a/pkg/chezmoi/chezmoi.go
+++ b/pkg/chezmoi/chezmoi.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"net"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -296,7 +297,7 @@ func etcHostsFQDNHostname(fileSystem vfs.FS) (string, error) {
 		text = strings.TrimSpace(text)
 		text, _, _ = strings.Cut(text, "#")
 		fields := whitespaceRx.Split(text, -1)
-		if len(fields) >= 2 && fields[0] == "127.0.1.1" {
+		if len(fields) > 1 && net.ParseIP(fields[0]).IsLoopback() && strings.Contains(fields[1], ".") {
 			return fields[1], nil
 		}
 	}

--- a/pkg/chezmoi/chezmoi_test.go
+++ b/pkg/chezmoi/chezmoi_test.go
@@ -53,6 +53,31 @@ func TestEtcHostsFQDNHostname(t *testing.T) {
 			expected: "host.example.com",
 		},
 		{
+			name: "etc_hosts_loopback_ipv4",
+			root: map[string]any{
+				"/etc/hosts": chezmoitest.JoinLines(
+					`invalid localhost`,
+					`127.0.0.1 localhost`,
+					`::1 localhost`,
+					`127.0.0.2 host.example.com host`,
+				),
+			},
+			f:        etcHostsFQDNHostname,
+			expected: "host.example.com",
+		},
+		{
+			name: "etc_hosts_loopback_ipv6",
+			root: map[string]any{
+				"/etc/hosts": chezmoitest.JoinLines(
+					`127.0.0.1 localhost`,
+					`::1 localhost`,
+					`::1 host.example.com host`,
+				),
+			},
+			f:        etcHostsFQDNHostname,
+			expected: "host.example.com",
+		},
+		{
 			name: "etc_hosts_whitespace_and_comments",
 			root: map[string]any{
 				"/etc/hosts": chezmoitest.JoinLines(


### PR DESCRIPTION
Fixes #3054.