### PR TITLE
docs: Remove reference to tar and /dev/stdin so code works on Windows

### DIFF
--- a/assets/chezmoi.io/docs/user-guide/include-files-from-elsewhere.md
+++ b/assets/chezmoi.io/docs/user-guide/include-files-from-elsewhere.md
@@ -124,8 +124,7 @@ and `$ENTRY.filter.args` variables in `.chezmoiexternal.$FORMAT`, for example:
     executable = true
     refreshPeriod = "168h"
     [".local/bin/age".filter]
-        command = "tar"
-        args = ["--extract", "--file", "/dev/stdin", "--gzip", "--to-stdout", "age/age"]
+        args = ["--extract", "--gzip", "--to-stdout", "age/age"]
 ```
 
 This will extract the single archive member `age/age` from the given URL (which


### PR DESCRIPTION
<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer/contributing-changes/

-->
Unsure why `command = "tar"` doesn't work on windows, but for some reason it wants to read from a tape, not stdin.

Windows doesn't have /dev/stdin so any commands referencing it fail. It is the default anyway, so no need to specify it.