### PR TITLE
Correct private files support in yadm

### DIFF
--- a/assets/chezmoi.io/docs/comparison-table.md
+++ b/assets/chezmoi.io/docs/comparison-table.md
@@ -17,7 +17,7 @@
 | Source repos                           | Single        | Single            | Multiple          | Multiple                 | Single                       | Single     |
 | dotfiles are...                        | Files         | Symlinks          | Files             | Files                    | Files                        | Files      |
 | Config file                            | Optional      | Required          | Optional          | None                     | Optional                     | Optional   |
-| Private files                          | ✅            | ❌                | ❌                | ❌                       | ✅                           | ❌         |
+| Private files                          | ✅            | ❌                | ❌                | ❌                       | ❌                           | ❌         |
 | Show differences without applying      | ✅            | ❌                | ❌                | ✅                       | ✅                           | ✅         |
 | Whole file encryption                  | ✅            | ❌                | ❌                | ❌                       | ✅                           | ❌         |
 | Password manager integration           | ✅            | ❌                | ❌                | ❌                       | ❌                           | ❌         |


### PR DESCRIPTION
Mention of private files support in yadm is confusing. As per https://yadm.io/docs/faq#directory-creation, the only 2 directories that can optionally be made private are `~/.ssh` and `~/.gnupg`.

It feels that chezmoi is the only dotfiles manager that can attach attributes to files/directories indicating of private permissions?