### PR TITLE
chore: Fix isExecutable tests on Windows

### DIFF
--- a/internal/cmd/main_test.go
+++ b/internal/cmd/main_test.go
@@ -653,6 +653,9 @@ func setup(env *testscript.Env) error {
 
 	env.Setenv("HOME", homeDir)
 	env.Setenv("PATH", prependDirToPath(binDir, env.Getenv("PATH")))
+	if runtime.GOOS == "windows" {
+		env.Setenv("PATHEXT", ".COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC;.CPL")
+	}
 	env.Setenv("CHEZMOICONFIGDIR", path.Join(absSlashHomeDir, ".config", "chezmoi"))
 	env.Setenv("CHEZMOISOURCEDIR", path.Join(absSlashHomeDir, ".local", "share", "chezmoi"))
 	env.Setenv("CHEZMOI_GITHUB_TOKEN", os.Getenv("CHEZMOI_GITHUB_TOKEN"))

--- a/internal/cmd/testdata/scripts/templatefuncs.txtar
+++ b/internal/cmd/testdata/scripts/templatefuncs.txtar
@@ -1,6 +1,7 @@
 [!windows] chmod 755 bin/chezmoi-output-test
 [!windows] chmod 755 bin/generate-color-formats
 [!windows] chmod 755 bin/ioreg
+[!windows] chmod 755 bin/executable
 [windows] unix2dos bin/chezmoi-output-test.cmd
 
 symlink $HOME/symlink -> dir
@@ -69,12 +70,13 @@ exec chezmoi execute-template '{{ dict "key" "value" | jq ".key" | first }}'
 stdout ^value$
 
 # test isExecutable template function positive test case
-[!windows] exec chezmoi execute-template '{{ if isExecutable "/bin/echo" }}executable{{end}}'
-[!windows] stdout ^executable$
+[!windows] exec chezmoi execute-template '{{ isExecutable "bin/executable" }}'
+[windows] exec chezmoi execute-template '{{ isExecutable "bin/executable.cmd" }}'
+stdout ^true$
 
 # test isExecutable template function negative test case
-[!windows] exec chezmoi execute-template '{{ if isExecutable "/etc/fstat" }}executable{{end}}'
-[!windows] stdout ^$
+exec chezmoi execute-template '{{ isExecutable "bin/not-executable" }}'
+stdout ^false$
 
 # test lookPath template function to find in PATH
 exec chezmoi execute-template '{{ lookPath "go" }}'
@@ -160,6 +162,9 @@ set out=%*
 set out=%out:\=%
 echo %out%
 endlocal
+-- bin/executable --
+#!/bin/sh
+-- bin/executable.cmd --
 -- bin/generate-color-formats --
 #!/bin/sh
 
@@ -202,6 +207,7 @@ echo '        <key>IOKitBuildVersion</key>'
 echo '        <string>Darwin Kernel Version 21.1.0: Wed Oct 13 17:33:24 PDT 2021; root:xnu-8019.41.5~1/RELEASE_ARM64_T8101</string>'
 echo '</dict>'
 echo '</plist>'
+-- bin/not-executable --
 -- golden/comment --
 # line1
 # line2


### PR DESCRIPTION
Refs #3157. cc @arran4 

The issue was that the `PATHEXT` environment variable was not set in the tests. In the end, it wasn't a line ending issue because the contents of the files are never used.