### PR TITLE
chore: Generate release notes from git log, not GitHub

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -110,7 +110,15 @@ archives:
   name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}-musl_{{ .Arch }}'
 
 changelog:
-  use: github-native
+  groups:
+  - title: Features
+    regexp: '^feat'
+    order: 0
+  - title: Fixes
+    regexp: '^fix'
+    order: 1
+  - title: Other
+    order: 999
 
 checksum:
   extra_files:


### PR DESCRIPTION
Fixes #3125.

GitHub-generated release notes seem to incorrectly credit PR authors, not commit authors.

Refs #2438.