### PR TITLE
feat: Support nushell scripts on Windows

### DIFF
--- a/assets/chezmoi.io/docs/reference/target-types.md
+++ b/assets/chezmoi.io/docs/reference/target-types.md
@@ -109,6 +109,7 @@ The default script interpreters are:
 
 | Extension | Command      | Arguments |
 | --------- | ------------ | --------- |
+| `.nu`     | `nu`         | *none*    |
 | `.pl`     | `perl`       | *none*    |
 | `.py`     | `python3`    | *none*    |
 | `.ps1`    | `powershell` | `-NoLogo` |

--- a/internal/cmd/util_windows.go
+++ b/internal/cmd/util_windows.go
@@ -17,6 +17,9 @@ var defaultInterpreters = map[string]*chezmoi.Interpreter{
 	"cmd": {},
 	"com": {},
 	"exe": {},
+	"nu": {
+		Command: "nu",
+	},
 	"pl": {
 		Command: "perl",
 	},


### PR DESCRIPTION
I've started writing scripts in [Nushell](https://www.nushell.sh/), then they can run on Windows, Linux, MacOS at once.

This just adds the mapping so Windows knows what to do with the file extension.