### PR TITLE
docs: Linuxbrew -> Homebrew

### DIFF
--- a/assets/chezmoi.io/docs/install.md.tmpl
+++ b/assets/chezmoi.io/docs/install.md.tmpl
@@ -107,7 +107,7 @@ chezmoi is available in many cross-platform package managers:
     asdf plugin add chezmoi && asdf install chezmoi {{ $version }}
     ```
 
-=== "Linuxbrew"
+=== "Homebrew"
 
     ```sh
     brew install chezmoi


### PR DESCRIPTION
[Homebrew on Linux was formerly referred to as Linuxbrew](https://docs.brew.sh/Homebrew-on-Linux). The two projects got merged.

<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer/contributing-changes/

-->
