### PR TITLE
fix: Update goreleaser changelog

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -112,13 +112,19 @@ archives:
 changelog:
   groups:
   - title: Features
-    regexp: '^feat'
+    regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'
     order: 0
   - title: Fixes
-    regexp: '^fix'
+    regexp: '^.*?fix(\([[:word:]]+\))??!?:.+$'
     order: 1
+  - title: Documentation updates
+    regexp: '^.*?docs?(\([[:word:]]+\))??!?:.+$'
+    order: 2
   - title: Other
     order: 999
+  filters:
+    exclude:
+      - '^.*?chore(\([[:word:]]+\))??!?:.+$'
 
 checksum:
   extra_files:


### PR DESCRIPTION
Fixes https://github.com/twpayne/chezmoi/issues/3188.

Untested at the moment. [`goreleaser changelog` is a pro feature](https://goreleaser.com/cmd/goreleaser_changelog/) and I'm not sure how else to test it.

I can re-include `chore`s if preferred.