### PR TITLE
feat: Use Goreleaser's Chocolatey support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,7 @@ on:
 env:
   ACTIONLINT_VERSION: 1.6.25
   AGE_VERSION: 1.1.1
+  CHOCOLATEY_VERSION: 2.2.2
   GO_VERSION: 1.21.1
   GOFUMPT_VERSION: 0.4.0
   GOLANGCI_LINT_VERSION: 1.54.2
@@ -185,6 +186,11 @@ jobs:
         # https://bugs.launchpad.net/snapcraft/+bug/1889741
         mkdir -p "${HOME}/.cache/snapcraft/download"
         mkdir -p "${HOME}/.cache/snapcraft/stage-packages"
+        mkdir -p /opt/chocolatey
+        wget -q -O - "https://github.com/chocolatey/choco/releases/download/${CHOCOLATEY_VERSION}/chocolatey.v${CHOCOLATEY_VERSION}.tar.gz" | tar -xz -C "/opt/chocolatey"
+        echo '#!/bin/bash' >> /usr/local/bin/choco
+        echo 'mono /opt/chocolatey/choco.exe $@' >> /usr/local/bin/choco
+        chmod +x /usr/local/bin/choco
     - name: create-syso
       run: |
         make create-syso
@@ -387,6 +393,11 @@ jobs:
         # https://bugs.launchpad.net/snapcraft/+bug/1889741
         mkdir -p "${HOME}/.cache/snapcraft/download"
         mkdir -p "${HOME}/.cache/snapcraft/stage-packages"
+        mkdir -p /opt/chocolatey
+        wget -q -O - "https://github.com/chocolatey/choco/releases/download/${CHOCOLATEY_VERSION}/chocolatey.v${CHOCOLATEY_VERSION}.tar.gz" | tar -xz -C "/opt/chocolatey"
+        echo '#!/bin/bash' >> /usr/local/bin/choco
+        echo 'mono /opt/chocolatey/choco.exe $@' >> /usr/local/bin/choco
+        chmod +x /usr/local/bin/choco
     - name: check-snapcraft-credentials
       run: snapcraft whoami
       env:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -200,6 +200,32 @@ nfpms:
   - apk
   bindir: /usr/bin
 
+chocolateys:
+- owners: twpayne
+  authors: Tom Payne
+  project_url: https://chezmoi.io
+  url_template: "https://github.com/twpayne/chezmoi/releases/download/v{{ .Version }}/{{ .ArtifactName }}"
+  icon_url: https://github.com/twpayne/chezmoi/raw/master/assets/images/logo-144px.png
+  copyright: Copyright © Tom Payne, 2018-2023
+  license_url: https://github.com/twpayne/chezmoi/blob/master/LICENSE
+  project_source_url: https://github.com/twpayne/chezmoi
+  docs_url: https://chezmoi.io
+  bug_tracker_url: https://github.com/twpayne/chezmoi/issues
+  tags: configuration dotfile dotfiles
+  summary: Manage your dotfiles across multiple diverse machines, securely.
+  description: |
+    ## What does chezmoi do?
+
+    chezmoi helps you manage your personal configuration files (dotfiles, like `~/.gitconfig`) across multiple machines.
+
+    chezmoi is helpful if you have spent time customizing the tools you use (e.g. shells, editors, and version control systems) and want to keep machines running different accounts (e.g. home and work) and/or different operating systems (e.g. Linux, macOS, and Windows) in sync, while still being able to easily cope with differences from machine to machine.
+
+    chezmoi scales from the trivial (e.g. copying a few dotfiles onto a Raspberry Pi, development container, or virtual machine) to complex long-lived multi-machine development environments (e.g. keeping any number of home and work, Linux, macOS, and Windows machines in sync). In all cases you only need to maintain a single source of truth (a single branch in git) and getting started only requires adding a single binary to your machine (which you can do with `curl`, `wget`, or `scp`).
+
+    chezmoi has strong support for security, allowing you to manage secrets (e.g. passwords, access tokens, and private keys) securely and seamlessly using a password manager and/or encrypt whole files with your favorite encryption tool.
+  release_notes: "https://github.com/twpayne/chezmoi/releases/tag/v{{ .Version }}"
+  api_key: '{{ .Env.CHOCOLATEY_API_KEY }}'
+
 release:
   extra_files:
   - glob: ./assets/cosign/cosign.pub


### PR DESCRIPTION
Mostly done I believe.

Without `url_template`, the URLs in `chocolateyinstall.ps1` point to my fork instead of this repo.

My local `chezmoi.nuspec` file contains `&#xA;` instead of newlines. I'm hoping this is just because I'm on Windows at the moment. I'm attempting to upload the choco files as artifacts to confirm. This should be removed before merging.

I'll also run the artifacts through [Chocolatey .nuspec Checker](https://community.chocolatey.org/packages/choco-nuspec-checker) pending their successful upload and post the output.

I'm not sure what would happen when attempting to publish, due to the existing package.
