### PR TITLE
fix: Prevent AppleDouble file creation in .txtar

### DIFF
--- a/internal/cmd/testdata/scripts/external.txtar
+++ b/internal/cmd/testdata/scripts/external.txtar
@@ -1,5 +1,6 @@
 symlink archive/dir/symlink -> file
-exec tar czf www/archive.tar.gz archive
+[!darwin] exec tar czf www/archive.tar.gz archive
+[darwin] exec tar czf www/archive.tar.gz --no-mac-metadata archive
 
 httpd www
 

--- a/internal/cmd/testdata/scripts/externalarchiveinclude.txtar
+++ b/internal/cmd/testdata/scripts/externalarchiveinclude.txtar
@@ -1,7 +1,8 @@
 symlink archive/symlink1 -> file1
 symlink archive/symlink2 -> file2
 mkdir www
-exec tar czf www/archive.tar.gz archive
+[!darwin] exec tar czf www/archive.tar.gz archive
+[darwin] exec tar czf www/archive.tar.gz --no-mac-metadata archive
 
 httpd www
 

--- a/internal/cmd/testdata/scripts/externalencrypted.txtar
+++ b/internal/cmd/testdata/scripts/externalencrypted.txtar
@@ -4,7 +4,8 @@
 mkgpgconfig
 
 # use chezmoi's encryption to encrypt a file and an archive
-exec tar czf $HOME/archive.tar.gz archive
+[!darwin] exec tar czf $HOME/archive.tar.gz archive
+[darwin] exec tar czf $HOME/archive.tar.gz --no-mac-metadata archive
 exec chezmoi add --encrypt $HOME${/}.file $HOME${/}archive.tar.gz
 mkdir www
 cp $CHEZMOISOURCEDIR/encrypted_dot_file.asc www/.file.asc

--- a/internal/cmd/testdata/scripts/import.txtar
+++ b/internal/cmd/testdata/scripts/import.txtar
@@ -1,6 +1,7 @@
 mkhomedir
 symlink archive/.dir/.symlink -> .file
-exec tar czf archive.tar.gz archive
+[!darwin] exec tar czf archive.tar.gz archive
+[darwin] exec tar czf archive.tar.gz --no-mac-metadata archive
 
 # test that chezmoi import imports an archive
 exec chezmoi import --strip-components=1 archive.tar.gz

--- a/internal/cmd/testdata/scripts/importxz.txtar
+++ b/internal/cmd/testdata/scripts/importxz.txtar
@@ -1,6 +1,7 @@
 [(openbsd||windows)] skip 'tar does not support XZ compression'
 [!exec:xz] skip 'xz not found in $PATH'
-exec tar cJf archive.tar.xz archive
+[!darwin] exec tar cJf archive.tar.xz archive
+[darwin] exec tar cJf archive.tar.xz --no-mac-metadata archive
 
 # test that chezmoi import imports a tar.xz archive
 exec chezmoi import --destination=$HOME${/}.dir --strip-components=1 archive.tar.xz

--- a/internal/cmd/testdata/scripts/issue2427.txtar
+++ b/internal/cmd/testdata/scripts/issue2427.txtar
@@ -1,5 +1,6 @@
 symlink archive/dir/symlink -> file
-exec tar czf www/archive.tar.gz archive
+[!darwin] exec tar czf www/archive.tar.gz archive
+[darwin] exec tar czf www/archive.tar.gz --no-mac-metadata archive
 
 httpd www
 


### PR DESCRIPTION
Related to #3220 and fixes it for tests run on macOS (but does not fix the underlying issue).

Any time we create an archive with `exec tar c…` in a `txtar` test file, particularly where the golden contents will be compared, we need to have a separate command for `darwin` platforms:

```txtar
[!darwin] tar cfz archive.tar.gz archive
[darwin] tar cfz archive.tar.gz --no-mac-metadata archive
```

Otherwise, the actual output will be incorrect compared to the golden version on macOS because of the presence of
[AppleDouble](https://en.wikipedia.org/wiki/AppleSingle_and_AppleDouble_formats) files. As a developer on macOS, this is helpful because it will give me an improved test cycle before submitting for CI.

<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer/contributing-changes/

-->
