### PR TITLE
docs: Improve developer experience under fish

### DIFF
--- a/assets/chezmoi.io/docs/developer/developing-locally.md
+++ b/assets/chezmoi.io/docs/developer/developing-locally.md
@@ -26,7 +26,6 @@ $ go build
     package github.com/twpayne/chezmoi/v2: build constraints exclude all Go files in /home/twp/src/github.com/twpayne/chezmoi
     ```
 
-
 Run all tests:
 
 ```console
@@ -49,3 +48,23 @@ Run a set of smoketests, including cross-compilation, tests, and linting:
 ```console
 $ make smoketest
 ```
+
+!!! hint
+
+    If you use `fish` as your primary shell, you may get warnings from Fish
+    during tests:
+
+    ```
+    error: can not save history
+    warning-path: Unable to locate data directory derived from $HOME: '/home/user/.local/share/fish'.
+    warning-path: The error was 'Operation not supported'.
+    warning-path: Please set $HOME to a directory where you have write access.
+    ```
+
+    These can be avoided with by running tests with `SHELL=bash` or `SHELL=zsh`:
+
+    ```console
+    $ SHELL=bash make test
+    $ SHELL=zsh make smoketest
+    $ SHELL=bash go test ./...
+    ```


### PR DESCRIPTION
The added documentation serves as the rationale for this documentation change:

If you use `fish` as your primary shell, you may get warnings from Fish during the `.txtar` tests:

```
error: can not save history
warning-path: Unable to locate data directory derived from $HOME: '/home/user/.local/share/fish'.
warning-path: The error was 'Operation not supported'.
warning-path: Please set $HOME to a directory where you have write access.
```

These can be avoided with by running tests with `SHELL=bash` or `SHELL=zsh`:

```console
$ SHELL=bash make test
$ SHELL=zsh make smoketest
$ SHELL=bash go test ./...
```

---

As a note, I tried to make `make test` re-execute when under `fish`, but it requires some GNU make magic that may not work on all systems:

```Makefile
.PHONY: test
test:
ifeq ($(shell echo $$SHELL | grep -c fish$$),1)
	SHELL=$(SHELL) $(MAKE) test
else
	${GO} test -ldflags="-X github.com/twpayne/chezmoi/v2/internal/chezmoitest.umaskStr=0o022" ./...
	${GO} test -ldflags="-X github.com/twpayne/chezmoi/v2/internal/chezmoitest.umaskStr=0o002" ./...
endif
```

This can be added to this PR or made as a separate PR, if desired.

<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer/contributing-changes/

-->
