### PR TITLE
feat: lookOnePath for variant file lookup

### DIFF
--- a/assets/chezmoi.io/docs/reference/templates/functions/lookOnePath.md
+++ b/assets/chezmoi.io/docs/reference/templates/functions/lookOnePath.md
@@ -1,0 +1,28 @@
+# `lookOnePath` *file-list*
+
+`lookOnePath` searches for an executable from *file-list* in the directories
+named by the `PATH` environment variable. If file contains a slash, it is tried
+directly and the `PATH` is not consulted. The result may be an absolute path or
+a path relative to the current directory. If an executable from *file-list* is
+not found, `lookOnePath` returns an empty string.
+
+`lookOnePath` is not hermetic: its return value depends on the state of the
+environment and the filesystem at the moment the template is executed. Exercise
+caution when using it in your templates.
+
+The return value of the first successful call to `lookOnePath` is cached, and
+future calls to `lookOnePath` for the same *file-list* will return this
+path.
+
+`lookOnePath` is provided as an alternative to
+[`lookPath`](/reference/templates/functions/lookPath) so that you can look for
+one of several variant executables.
+
+!!! example
+
+    ```
+    {{ if $ls_alt := lookOnePath (list "eza" "exa") }}
+    echo {{ $ls_alt }} is in $PATH
+    {{ end }}
+    ```
+

--- a/assets/chezmoi.io/mkdocs.yml
+++ b/assets/chezmoi.io/mkdocs.yml
@@ -202,6 +202,7 @@ nav:
       - isExecutable: reference/templates/functions/isExecutable.md
       - joinPath: reference/templates/functions/joinPath.md
       - jq: reference/templates/functions/jq.md
+      - lookOnePath: reference/templates/functions/lookOnePath.md
       - lookPath: reference/templates/functions/lookPath.md
       - lstat: reference/templates/functions/lstat.md
       - mozillaInstallHash: reference/templates/functions/mozillaInstallHash.md

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -441,6 +441,7 @@ func newConfig(options ...configOption) (*Config, error) {
 		"keyring":                  c.keyringTemplateFunc,
 		"lastpass":                 c.lastpassTemplateFunc,
 		"lastpassRaw":              c.lastpassRawTemplateFunc,
+		"lookOnePath":              c.lookOnePathTemplateFunc,
 		"lookPath":                 c.lookPathTemplateFunc,
 		"lstat":                    c.lstatTemplateFunc,
 		"mozillaInstallHash":       c.mozillaInstallHashTemplateFunc,

--- a/internal/cmd/templatefuncs.go
+++ b/internal/cmd/templatefuncs.go
@@ -349,6 +349,24 @@ func (c *Config) lookPathTemplateFunc(file string) string {
 	}
 }
 
+func (c *Config) lookOnePathTemplateFunc(fileList []any) string {
+	files, err := anySliceToStringSlice(fileList)
+	if err != nil {
+		panic(err)
+	}
+
+	switch path, err := chezmoi.LookOnePath(files); {
+	case err == nil:
+		return path
+	case errors.Is(err, exec.ErrNotFound):
+		return ""
+	case errors.Is(err, fs.ErrNotExist):
+		return ""
+	default:
+		panic(err)
+	}
+}
+
 func (c *Config) isExecutableTemplateFunc(file string) bool {
 	switch fileInfo, err := c.fileSystem.Stat(file); {
 	case err == nil:

--- a/internal/cmd/testdata/scripts/templatefuncs.txtar
+++ b/internal/cmd/testdata/scripts/templatefuncs.txtar
@@ -118,6 +118,10 @@ stdout go$exe
 exec chezmoi execute-template '{{ lookPath "/non-existing-file" }}'
 ! stdout .
 
+# test lookPath template function to find in PATH with a list
+exec chezmoi execute-template '{{ lookOnePath (list "no-go" "go") }}'
+stdout go$exe
+
 # test lstat template function
 exec chezmoi execute-template '{{ (joinPath .chezmoi.homeDir "symlink" | lstat).type }}'
 stdout ^symlink$

--- a/internal/cmds/lint-whitespace/main.go
+++ b/internal/cmds/lint-whitespace/main.go
@@ -20,6 +20,7 @@ var (
 		regexp.MustCompile(`\A\.vagrant\z`),
 		regexp.MustCompile(`\A\.vscode\z`),
 		regexp.MustCompile(`\Aassets/chezmoi\.io/site\z`),
+		regexp.MustCompile(`\Aassets/chezmoi\.io/.venv\z`),
 		regexp.MustCompile(`\Aassets/scripts/install\.ps1\z`),
 		regexp.MustCompile(`\Acompletions/chezmoi\.ps1\z`),
 		regexp.MustCompile(`\Adist\z`),


### PR DESCRIPTION
This replaces code like this:

```
{{ $program := or (lookPath "eza") (lookPath "exa") | base }}
```

with code like this:

```
{{ $program := lookOnePath (list "era" "exa") | base }}
```

This changes the underlying `chezmoi.LookPath` to always use `[]string`
and reduce code duplication, but the performance hit should be minimal
for normal use cases of `lookPath`.

Closes: #3256