### PR TITLE
feat: Ignore AppleDouble files in externals

### DIFF
--- a/assets/chezmoi.io/docs/reference/special-files-and-directories/chezmoiexternal-format.md
+++ b/assets/chezmoi.io/docs/reference/special-files-and-directories/chezmoiexternal-format.md
@@ -19,27 +19,28 @@ will create them as regular directories.
 
 Entries may have the following fields:
 
-| Variable          | Type     | Default value | Description                                                      |
-| ----------------- | -------- | ------------- | ---------------------------------------------------------------- |
-| `type`            | string   | *none*        | External type (`file`, `archive`, `archive-file`, or `git-repo`) |
-| `encrypted`       | bool     | `false`       | Whether the external is encrypted                                |
-| `exact`           | bool     | `false`       | Add `exact_` attribute to directories in archive                 |
-| `exclude`         | []string | *none*        | Patterns to exclude from archive                                 |
-| `executable`      | bool     | `false`       | Add `executable_` attribute to file                              |
-| `format`          | string   | *autodetect*  | Format of archive                                                |
-| `path`            | string   | *none*        | Path to file in archive                                          |
-| `include`         | []string | *none*        | Patterns to include from archive                                 |
-| `refreshPeriod`   | duration | `0`           | Refresh period                                                   |
-| `stripComponents` | int      | `0`           | Number of leading directory components to strip from archives    |
-| `url`             | string   | *none*        | URL                                                              |
-| `checksum.sha256` | string   | *none*        | Expected SHA256 checksum of data                                 |
-| `checksum.sha384` | string   | *none*        | Expected SHA384 checksum of data                                 |
-| `checksum.sha512` | string   | *none*        | Expected SHA512 checksum of data                                 |
-| `checksum.size`   | int      | *none*        | Expected size of data                                            |
-| `clone.args`      | []string | *none*        | Extra args to `git clone`                                        |
-| `filter.command`  | string   | *none*        | Command to filter contents                                       |
-| `filter.args`     | []string | *none*        | Extra args to command to filter contents                         |
-| `pull.args`       | []string | *none*        | Extra args to `git pull`                                         |
+| Variable                     | Type     | Default value | Description                                                      |
+| ---------------------------- | -------- | ------------- | ---------------------------------------------------------------- |
+| `type`                       | string   | *none*        | External type (`file`, `archive`, `archive-file`, or `git-repo`) |
+| `encrypted`                  | bool     | `false`       | Whether the external is encrypted                                |
+| `exact`                      | bool     | `false`       | Add `exact_` attribute to directories in archive                 |
+| `exclude`                    | []string | *none*        | Patterns to exclude from archive                                 |
+| `executable`                 | bool     | `false`       | Add `executable_` attribute to file                              |
+| `format`                     | string   | *autodetect*  | Format of archive                                                |
+| `path`                       | string   | *none*        | Path to file in archive                                          |
+| `include`                    | []string | *none*        | Patterns to include from archive                                 |
+| `refreshPeriod`              | duration | `0`           | Refresh period                                                   |
+| `stripComponents`            | int      | `0`           | Number of leading directory components to strip from archives    |
+| `url`                        | string   | *none*        | URL                                                              |
+| `checksum.sha256`            | string   | *none*        | Expected SHA256 checksum of data                                 |
+| `checksum.sha384`            | string   | *none*        | Expected SHA384 checksum of data                                 |
+| `checksum.sha512`            | string   | *none*        | Expected SHA512 checksum of data                                 |
+| `checksum.size`              | int      | *none*        | Expected size of data                                            |
+| `clone.args`                 | []string | *none*        | Extra args to `git clone`                                        |
+| `filter.command`             | string   | *none*        | Command to filter contents                                       |
+| `filter.args`                | []string | *none*        | Extra args to command to filter contents                         |
+| `pull.args`                  | []string | *none*        | Extra args to `git pull`                                         |
+| `archive.extractAppleDouble` | bool     | `false`       | If `true`, AppleDouble files are extracted                       |
 
 If any of the optional `checksum.sha256`, `checksum.sha384`, or
 `checksum.sha512` fields are set, chezmoi will verify that the downloaded data
@@ -65,6 +66,12 @@ members of archive. The optional string field `format` sets the archive format.
 The supported archive formats are `tar`, `tar.gz`, `tgz`, `tar.bz2`, `tbz2`,
 `xz`, `.tar.zst`, and `zip`. If `format` is not specified then chezmoi will
 guess the format using firstly the path of the URL and secondly its contents.
+
+When `type` is `archive` or `archive-file`, the optional setting
+`archive.extractAppleDouble` controls whether
+[AppleDouble](https://en.wikipedia.org/wiki/AppleSingle_and_AppleDouble_formats)
+files are extracted. It is `false` by default, so AppleDouble files will not
+be extracted.
 
 The optional `include` and `exclude` fields are lists of patterns specify which
 archive members to include or exclude respectively. Patterns match paths in the

--- a/internal/cmd/testdata/scripts/external.txtar
+++ b/internal/cmd/testdata/scripts/external.txtar
@@ -1,5 +1,8 @@
 symlink archive/dir/symlink -> file
+[darwin] exec xattr -w -s io.chezmoi.test metadata-test archive/dir archive/dir/symlink archive/dir/file
 exec tar czf www/archive.tar.gz archive
+# Force the collection of the Mac metadata for the home15/user test
+[darwin] exec tar czf www/archive-mac-metadata.tar.gz --mac-metadata archive
 
 httpd www
 
@@ -116,6 +119,12 @@ chhome home14/user
 exec chezmoi apply
 cmp $HOME/.file golden/dir/file
 
+[darwin] chhome home15/user
+
+# test that chezmoi managed --include=externals lists external targets including AppleDouble files
+[darwin] exec chezmoi managed --include=externals
+[darwin] cmp stdout golden/managed-appledouble
+
 -- archive/dir/file --
 # contents of dir/file
 -- golden/.file --
@@ -125,6 +134,14 @@ cmp $HOME/.file golden/dir/file
 -- golden/managed --
 .dir
 .dir/dir
+.dir/dir/file
+.dir/dir/symlink
+-- golden/managed-appledouble --
+.dir
+.dir/._dir
+.dir/dir
+.dir/dir/._file
+.dir/dir/._symlink
 .dir/dir/file
 .dir/dir/symlink
 -- home/user/.local/share/chezmoi/.chezmoiexternal.toml --
@@ -168,6 +185,14 @@ cmp $HOME/.file golden/dir/file
     url = "{{ env "HTTPD_URL" }}/archive.tar.gz"
     path = "dir/file"
     stripComponents = 1
+-- home15/user/.dir/file --
+-- home15/user/.local/share/chezmoi/.chezmoiexternal.yaml --
+.dir:
+    type: archive
+    url: {{ env "HTTPD_URL" }}/archive-mac-metadata.tar.gz
+    archive:
+      extractAppleDoubleFiles: true
+    stripComponents: 1
 -- home2/user/.local/share/chezmoi/.chezmoiexternal.toml --
 [".file"]
     type = "file"

--- a/internal/cmds/lint-whitespace/main.go
+++ b/internal/cmds/lint-whitespace/main.go
@@ -20,6 +20,7 @@ var (
 		regexp.MustCompile(`\A\.vagrant\z`),
 		regexp.MustCompile(`\A\.vscode\z`),
 		regexp.MustCompile(`\Aassets/chezmoi\.io/site\z`),
+		regexp.MustCompile(`/.venv\z`),
 		regexp.MustCompile(`\Aassets/scripts/install\.ps1\z`),
 		regexp.MustCompile(`\Acompletions/chezmoi\.ps1\z`),
 		regexp.MustCompile(`\Adist\z`),


### PR DESCRIPTION
This is somewhere between a fix and a feature because it is a potential bug if an archive contains AppleDouble data, as such data would automatically be written out as parallel `._FILE` files and not reintegrated. I've marked it as a feature because it requires new configuration options.

With this change, we are still not reintegrating the data, but we are explicitly _ignoring_ the data unless `EXTERNAL.archive.extractAppleDoubleFiles = true`. There are tools such as https://github.com/SiviourBla/appledouble that can theoretically reintegrate this using `copyfile(3)` on macOS.

This checks that the extracted file name will be `._*` before trying to determine whether the file is an AppleDouble file.

Resolves: #3220
Closes: #3221
