### PR TITLE
feat: Add Path Separator and Path List Separator to provided template values

### DIFF
--- a/assets/chezmoi.io/docs/reference/templates/variables.md
+++ b/assets/chezmoi.io/docs/reference/templates/variables.md
@@ -2,33 +2,35 @@
 
 chezmoi provides the following automatically-populated variables:
 
-| Variable                   | Type     | Value                                                                                                                          |
-| -------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `.chezmoi.arch`            | string   | Architecture, e.g. `amd64`, `arm`, etc. as returned by [runtime.GOARCH](https://pkg.go.dev/runtime?tab=doc#pkg-constants)      |
-| `.chezmoi.args`            | []string | The arguments passed to the `chezmoi` command, starting with the program command                                               |
-| `.chezmoi.cacheDir`        | string   | The cache directory                                                                                                            |
-| `.chezmoi.config`          | object   | The configuration, as read from the config file                                                                                |
-| `.chezmoi.configFile`      | string   | The path to the configuration file used by chezmoi                                                                             |
-| `.chezmoi.executable`      | string   | The path to the `chezmoi` executable, if available                                                                             |
-| `.chezmoi.fqdnHostname`    | string   | The fully-qualified domain name hostname of the machine chezmoi is running on                                                  |
-| `.chezmoi.gid`             | string   | The primary group ID                                                                                                           |
-| `.chezmoi.group`           | string   | The group of the user running chezmoi                                                                                          |
-| `.chezmoi.homeDir`         | string   | The home directory of the user running chezmoi                                                                                 |
-| `.chezmoi.hostname`        | string   | The hostname of the machine chezmoi is running on, up to the first `.`                                                         |
-| `.chezmoi.kernel`          | string   | Contains information from `/proc/sys/kernel`. Linux only, useful for detecting specific kernels (e.g. Microsoft's WSL kernel)  |
-| `.chezmoi.os`              | string   | Operating system, e.g. `darwin`, `linux`, etc. as returned by [runtime.GOOS](https://pkg.go.dev/runtime?tab=doc#pkg-constants) |
-| `.chezmoi.osRelease`       | string   | The information from `/etc/os-release`, Linux only, run `chezmoi data` to see its output                                       |
-| `.chezmoi.sourceDir`       | string   | The source directory                                                                                                           |
-| `.chezmoi.sourceFile`      | string   | The path of the template relative to the source directory                                                                      |
-| `.chezmoi.targetFile`      | string   | The absolute path of the target file for the template                                                                          |
-| `.chezmoi.uid`             | string   | The user ID                                                                                                                    |
-| `.chezmoi.username`        | string   | The username of the user running chezmoi                                                                                       |
-| `.chezmoi.version.builtBy` | string   | The program that built the `chezmoi` executable, if set                                                                        |
-| `.chezmoi.version.commit`  | string   | The git commit at which the `chezmoi` executable was built, if set                                                             |
-| `.chezmoi.version.date`    | string   | The timestamp at which the `chezmoi` executable was built, if set                                                              |
-| `.chezmoi.version.version` | string   | The version of chezmoi                                                                                                         |
-| `.chezmoi.windowsVersion`  | object   | Windows version information, if running on Windows                                                                             |
-| `.chezmoi.workingTree`     | string   | The working tree of the source directory                                                                                       |
+| Variable                      | Type     | Value                                                                                                                                                 |
+|-------------------------------| -------- |-------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `.chezmoi.arch`               | string   | Architecture, e.g. `amd64`, `arm`, etc. as returned by [runtime.GOARCH](https://pkg.go.dev/runtime?tab=doc#pkg-constants)                             |
+| `.chezmoi.args`               | []string | The arguments passed to the `chezmoi` command, starting with the program command                                                                      |
+| `.chezmoi.cacheDir`           | string   | The cache directory                                                                                                                                   |
+| `.chezmoi.config`             | object   | The configuration, as read from the config file                                                                                                       |
+| `.chezmoi.configFile`         | string   | The path to the configuration file used by chezmoi                                                                                                    |
+| `.chezmoi.executable`         | string   | The path to the `chezmoi` executable, if available                                                                                                    |
+| `.chezmoi.fqdnHostname`       | string   | The fully-qualified domain name hostname of the machine chezmoi is running on                                                                         |
+| `.chezmoi.gid`                | string   | The primary group ID                                                                                                                                  |
+| `.chezmoi.group`              | string   | The group of the user running chezmoi                                                                                                                 |
+| `.chezmoi.homeDir`            | string   | The home directory of the user running chezmoi                                                                                                        |
+| `.chezmoi.hostname`           | string   | The hostname of the machine chezmoi is running on, up to the first `.`                                                                                |
+| `.chezmoi.kernel`             | string   | Contains information from `/proc/sys/kernel`. Linux only, useful for detecting specific kernels (e.g. Microsoft's WSL kernel)                         |
+| `.chezmoi.os`                 | string   | Operating system, e.g. `darwin`, `linux`, etc. as returned by [runtime.GOOS](https://pkg.go.dev/runtime?tab=doc#pkg-constants)                        |
+| `.chezmoi.osRelease`          | string   | The information from `/etc/os-release`, Linux only, run `chezmoi data` to see its output                                                              |
+| `.chezmoi.pathListSeparator`  | string   | The path list separator, typically `;` on Windows and `:` on other systems. Used to separate paths in environment varialbes. ie `/bin:/sbin:/usr/bin` |
+| `.chezmoi.pathSeparator`      | string   | The path separator, typically `\` on windows and `/` on unix. Used to separate files and directories in a path. ie `c:\see\dos\run`                   |
+| `.chezmoi.sourceDir`          | string   | The source directory                                                                                                                                  |
+| `.chezmoi.sourceFile`         | string   | The path of the template relative to the source directory                                                                                             |
+| `.chezmoi.targetFile`         | string   | The absolute path of the target file for the template                                                                                                 |
+| `.chezmoi.uid`                | string   | The user ID                                                                                                                                           |
+| `.chezmoi.username`           | string   | The username of the user running chezmoi                                                                                                              |
+| `.chezmoi.version.builtBy`    | string   | The program that built the `chezmoi` executable, if set                                                                                               |
+| `.chezmoi.version.commit`     | string   | The git commit at which the `chezmoi` executable was built, if set                                                                                    |
+| `.chezmoi.version.date`       | string   | The timestamp at which the `chezmoi` executable was built, if set                                                                                     |
+| `.chezmoi.version.version`    | string   | The version of chezmoi                                                                                                                                |
+| `.chezmoi.windowsVersion`     | object   | Windows version information, if running on Windows                                                                                                    |
+| `.chezmoi.workingTree`        | string   | The working tree of the source directory                                                                                                              |
 
 `.chezmoi.windowsVersion` contains the following keys populated from the
 registry key `Computer\HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -249,27 +249,29 @@ type Config struct {
 }
 
 type templateData struct {
-	arch           string
-	args           []string
-	cacheDir       chezmoi.AbsPath
-	command        string
-	config         map[string]any
-	configFile     chezmoi.AbsPath
-	executable     chezmoi.AbsPath
-	fqdnHostname   string
-	gid            string
-	group          string
-	homeDir        chezmoi.AbsPath
-	hostname       string
-	kernel         map[string]any
-	os             string
-	osRelease      map[string]any
-	sourceDir      chezmoi.AbsPath
-	uid            string
-	username       string
-	version        map[string]any
-	windowsVersion map[string]any
-	workingTree    chezmoi.AbsPath
+	arch              string
+	args              []string
+	cacheDir          chezmoi.AbsPath
+	command           string
+	config            map[string]any
+	configFile        chezmoi.AbsPath
+	executable        chezmoi.AbsPath
+	fqdnHostname      string
+	gid               string
+	group             string
+	homeDir           chezmoi.AbsPath
+	hostname          string
+	kernel            map[string]any
+	os                string
+	osRelease         map[string]any
+	pathListSeparator string
+	pathSeparator     string
+	sourceDir         chezmoi.AbsPath
+	uid               string
+	username          string
+	version           map[string]any
+	windowsVersion    map[string]any
+	workingTree       chezmoi.AbsPath
 }
 
 // A configOption sets and option on a Config.
@@ -1395,27 +1397,29 @@ func (c *Config) getTemplateDataMap(cmd *cobra.Command) map[string]any {
 
 	return map[string]any{
 		"chezmoi": map[string]any{
-			"arch":           templateData.arch,
-			"args":           templateData.args,
-			"cacheDir":       templateData.cacheDir.String(),
-			"command":        templateData.command,
-			"config":         templateData.config,
-			"configFile":     templateData.configFile.String(),
-			"executable":     templateData.executable.String(),
-			"fqdnHostname":   templateData.fqdnHostname,
-			"gid":            templateData.gid,
-			"group":          templateData.group,
-			"homeDir":        templateData.homeDir.String(),
-			"hostname":       templateData.hostname,
-			"kernel":         templateData.kernel,
-			"os":             templateData.os,
-			"osRelease":      templateData.osRelease,
-			"sourceDir":      templateData.sourceDir.String(),
-			"uid":            templateData.uid,
-			"username":       templateData.username,
-			"version":        templateData.version,
-			"windowsVersion": templateData.windowsVersion,
-			"workingTree":    templateData.workingTree.String(),
+			"arch":              templateData.arch,
+			"args":              templateData.args,
+			"cacheDir":          templateData.cacheDir.String(),
+			"command":           templateData.command,
+			"config":            templateData.config,
+			"configFile":        templateData.configFile.String(),
+			"executable":        templateData.executable.String(),
+			"fqdnHostname":      templateData.fqdnHostname,
+			"gid":               templateData.gid,
+			"group":             templateData.group,
+			"homeDir":           templateData.homeDir.String(),
+			"hostname":          templateData.hostname,
+			"kernel":            templateData.kernel,
+			"os":                templateData.os,
+			"osRelease":         templateData.osRelease,
+			"pathListSeparator": templateData.pathListSeparator,
+			"pathSeparator":     templateData.pathSeparator,
+			"sourceDir":         templateData.sourceDir.String(),
+			"uid":               templateData.uid,
+			"username":          templateData.username,
+			"version":           templateData.version,
+			"windowsVersion":    templateData.windowsVersion,
+			"workingTree":       templateData.workingTree.String(),
 		},
 	}
 }
@@ -2263,24 +2267,26 @@ func (c *Config) newTemplateData(cmd *cobra.Command) *templateData {
 	sourceDirAbsPath, _ := c.getSourceDirAbsPath(nil)
 
 	return &templateData{
-		arch:         runtime.GOARCH,
-		args:         os.Args,
-		cacheDir:     c.CacheDirAbsPath,
-		command:      cmd.Name(),
-		config:       c.ConfigFile.toMap(),
-		configFile:   c.configFileAbsPath,
-		executable:   chezmoi.NewAbsPath(executable),
-		fqdnHostname: fqdnHostname,
-		gid:          gid,
-		group:        group,
-		homeDir:      c.homeDirAbsPath,
-		hostname:     hostname,
-		kernel:       kernel,
-		os:           runtime.GOOS,
-		osRelease:    osRelease,
-		sourceDir:    sourceDirAbsPath,
-		uid:          uid,
-		username:     username,
+		arch:              runtime.GOARCH,
+		args:              os.Args,
+		cacheDir:          c.CacheDirAbsPath,
+		command:           cmd.Name(),
+		config:            c.ConfigFile.toMap(),
+		configFile:        c.configFileAbsPath,
+		executable:        chezmoi.NewAbsPath(executable),
+		fqdnHostname:      fqdnHostname,
+		gid:               gid,
+		group:             group,
+		homeDir:           c.homeDirAbsPath,
+		hostname:          hostname,
+		kernel:            kernel,
+		os:                runtime.GOOS,
+		osRelease:         osRelease,
+		pathListSeparator: string(os.PathListSeparator),
+		pathSeparator:     string(os.PathSeparator),
+		sourceDir:         sourceDirAbsPath,
+		uid:               uid,
+		username:          username,
 		version: map[string]any{
 			"builtBy": c.versionInfo.BuiltBy,
 			"commit":  c.versionInfo.Commit,


### PR DESCRIPTION
This change exports a provided variable from Go which practically makes it free in terms of implementation costs.

This functionality would be implemented by hand by most people without variance when it is provided to Chezmoi by Go.

References: https://github.com/twpayne/chezmoi/pull/3162

There seems to be reference to this here too: 
https://github.com/twpayne/chezmoi/pull/3261#issuecomment-1734136510
