### PR TITLE
feat: Add expand env vars in scriptEnv config

### DIFF
--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -2138,7 +2138,7 @@ func (c *Config) persistentPreRunRootE(cmd *cobra.Command, args []string) error 
 		if strings.HasPrefix(key, "CHEZMOI_") {
 			c.errorf("warning: %s: overriding reserved environment variable", key)
 		}
-		os.Setenv(key, value)
+		os.Setenv(key, os.ExpandEnv(value))
 	}
 
 	if command := c.Hooks[cmd.Name()].Pre; command.Command != "" {


### PR DESCRIPTION
This PR References #3101 add expand env vars in scriptEnv config

```toml
[scriptEnv]
VIRTUAL_ENV = '/path/to/venv'
PATH = '$VIRTUAL_ENV/bin:$PATH'
```
