### PR TITLE
feat: adding `passage` password manager template functions

### DIFF
--- a/assets/chezmoi.io/docs/reference/templates/passage-functions/index.md
+++ b/assets/chezmoi.io/docs/reference/templates/passage-functions/index.md
@@ -1,0 +1,6 @@
+# passage functions
+
+The `passage` template functions return passwords stored in
+[passage](https://github.com/FiloSottile/passage) using the passage CLI
+(`passage`). `passage` is a fork of `pass` that uses the
+[age](https://age-encryption.org) encryption instead of GnuPG.

--- a/assets/chezmoi.io/docs/reference/templates/passage-functions/passage.md
+++ b/assets/chezmoi.io/docs/reference/templates/passage-functions/passage.md
@@ -1,0 +1,15 @@
+# `passage` *pass-name*
+
+`passage` returns passwords stored in
+[passage](https://github.com/FiloSottile/passage) using the passage CLI
+(`passage`). *pass-name* is passed to `passage show $PASS_NAME` and the first
+line of the output of `passage` is returned with the trailing newline
+stripped. The output from `passage` is cached so calling `passage` multiple
+times with the same *pass-name* will only invoke `passage` once.
+
+!!! example
+
+    ```
+    {{ passage "$PASS_NAME" }}
+    ```
+

--- a/assets/chezmoi.io/docs/reference/templates/passage-functions/passageRaw.md
+++ b/assets/chezmoi.io/docs/reference/templates/passage-functions/passageRaw.md
@@ -1,0 +1,7 @@
+# `passageRaw` *pass-name*
+
+`passageRaw` returns passwords stored in
+[passage](https://github.com/FiloSottile/passage) using the pass CLI
+(`passage`). *pass-name* is passed to `passage show $PASS_NAME` and the output
+is returned. The output from `passage` is cached so calling `passageRaw`
+multiple times with the same *pass-name* will only invoke `passage` once.

--- a/assets/chezmoi.io/docs/user-guide/password-managers/passage.md
+++ b/assets/chezmoi.io/docs/user-guide/password-managers/passage.md
@@ -1,0 +1,11 @@
+# passage
+
+chezmoi includes support for [passage](https://github.com/FiloSottile/passage) using the
+passage CLI.
+
+The first line of the output of `passage show $PASS_NAME` is available as the
+`passage` template function, for example:
+
+```
+{{ passage "$PASS_NAME" }}
+```

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -139,6 +139,7 @@ type ConfigFile struct {
 	Lastpass          lastpassConfig          `json:"lastpass"          mapstructure:"lastpass"          yaml:"lastpass"`
 	Onepassword       onepasswordConfig       `json:"onepassword"       mapstructure:"onepassword"       yaml:"onepassword"`
 	Pass              passConfig              `json:"pass"              mapstructure:"pass"              yaml:"pass"`
+	Passage           passageConfig           `json:"passage"           mapstructure:"passage"           yaml:"passage"`
 	Passhole          passholeConfig          `json:"passhole"          mapstructure:"passhole"          yaml:"passhole"`
 	RBW               rbwConfig               `json:"rbw"               mapstructure:"rbw"               yaml:"rbw"`
 	Secret            secretConfig            `json:"secret"            mapstructure:"secret"            yaml:"secret"`
@@ -453,6 +454,8 @@ func newConfig(options ...configOption) (*Config, error) {
 		"onepasswordRead":          c.onepasswordReadTemplateFunc,
 		"output":                   c.outputTemplateFunc,
 		"pass":                     c.passTemplateFunc,
+		"passage":                  c.passageTemplateFunc,
+		"passageRaw":               c.passageRawTemplateFunc,
 		"passFields":               c.passFieldsTemplateFunc,
 		"passhole":                 c.passholeTemplateFunc,
 		"passRaw":                  c.passRawTemplateFunc,
@@ -2696,6 +2699,9 @@ func newConfigFile(bds *xdg.BaseDirectorySpecification) ConfigFile {
 		},
 		Pass: passConfig{
 			Command: "pass",
+		},
+		Passage: passageConfig{
+			Command: "passage",
 		},
 		Passhole: passholeConfig{
 			Command: "ph",

--- a/internal/cmd/passagetemplatefuncs.go
+++ b/internal/cmd/passagetemplatefuncs.go
@@ -1,0 +1,119 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"regexp"
+
+	"github.com/coreos/go-semver/semver"
+
+	"github.com/twpayne/chezmoi/v2/internal/chezmoilog"
+)
+
+var (
+	// just requiring the current ( as of 2023-10-27 ) version of passage.
+	passageMinVersion  = semver.Version{Major: 1, Minor: 7, Patch: 4}
+	passageShowArgs    = []string{"show"}
+	passageVersionArgs = []string{"version"}
+	passageVersionRx   = regexp.MustCompile(`=\s+v(\d+\.\d+\.\d+)`)
+)
+
+type passageConfig struct {
+	Command   string `json:"command" mapstructure:"command" yaml:"command"`
+	versionOK bool
+	cache     map[string]string
+	rawCache  map[string][]byte
+}
+
+func (c *Config) passageTemplateFunc(id string) string {
+	c.passageValid()
+
+	if password, ok := c.Passage.cache[id]; ok {
+		return password
+	}
+
+	output := c.fetchPassage(id)
+	passwordBytes, _, _ := bytes.Cut(output, []byte{'\n'})
+	password := string(passwordBytes)
+
+	if c.Passage.cache == nil {
+		c.Passage.cache = map[string]string{}
+	}
+	c.Passage.cache[id] = password
+
+	return password
+}
+
+func (c *Config) passageRawTemplateFunc(id string) string {
+	c.passageValid()
+
+	if output, ok := c.Passage.rawCache[id]; ok {
+		return string(output)
+	}
+
+	output := c.fetchPassage(id)
+	if c.Passage.rawCache == nil {
+		c.Passage.rawCache = map[string][]byte{}
+	}
+	c.Passage.rawCache[id] = output
+
+	return string(output)
+}
+
+func (c *Config) fetchPassage(id string) []byte {
+	var args []string
+	args = append(args, passageShowArgs...)
+	args = append(args, id)
+	output, err := c.passageOutput(args...)
+	if err != nil {
+		panic(err)
+	}
+	return output
+}
+
+func (c *Config) passageValid() {
+	if !c.Passage.versionOK {
+		if err := c.passageVersionCheck(); err != nil {
+			panic(err)
+		}
+		c.Passage.versionOK = true
+	}
+}
+
+func (c *Config) passageOutput(args ...string) ([]byte, error) {
+	name := c.Passage.Command
+	cmd := exec.Command(name, args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stderr = os.Stderr
+	output, err := chezmoilog.LogCmdOutput(cmd)
+	if err != nil {
+		return nil, newCmdOutputError(cmd, output, err)
+	}
+	return output, nil
+}
+
+func (c *Config) passageVersionCheck() error {
+	output, err := c.passageOutput(passageVersionArgs...)
+	if err != nil {
+		return err
+	}
+	m := passageVersionRx.FindSubmatch(output)
+	if m == nil {
+		return &extractVersionError{
+			output: output,
+		}
+	}
+
+	version, err := semver.NewVersion(string(m[1]))
+	if err != nil {
+		return err
+	}
+	if version.LessThan(passageMinVersion) {
+		return &versionTooOldError{
+			have: version,
+			need: &passageMinVersion,
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Adds support for the [passage](https://github.com/FiloSottile/passage) password manager, a fork of the [pass](https://www.passwordstore.org/) password manager that uses [age](https://age-encryption.org/) instead of GnuPG.

This adds two new template functions: `passage` and `passageRaw`, which function the same as the `pass` and `passRaw` template functions.