### PR TITLE
fix: Make stdinIsATTY return false if --no-tty is passed

### DIFF
--- a/internal/cmd/inittemplatefuncs.go
+++ b/internal/cmd/inittemplatefuncs.go
@@ -13,6 +13,9 @@ func (c *Config) exitInitTemplateFunc(code int) string {
 }
 
 func (c *Config) stdinIsATTYInitTemplateFunc() bool {
+	if c.noTTY {
+		return false
+	}
 	file, ok := c.stdin.(*os.File)
 	if !ok {
 		return false


### PR DESCRIPTION
Fixes #3299.