### PR TITLE
refactor: Allow `mkdocs build` from any origin

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -257,7 +257,7 @@ jobs:
         pip3 install mkdocs==${{ env.MKDOCS_VERSION }}
         pip3 install -r assets/chezmoi.io/requirements.txt
     - name: build-website
-      run: ( cd assets/chezmoi.io && mkdocs build )
+      run: mkdocs build -f assets/chezmoi.io/mkdocs.yml
       env:
         CHEZMOI_GITHUB_TOKEN: ${{ secrets.CHEZMOI_GITHUB_TOKEN }}
   test-windows:
@@ -410,7 +410,7 @@ jobs:
       run: |
         pip3 install mkdocs==${{ env.MKDOCS_VERSION }}
         pip3 install -r assets/chezmoi.io/requirements.txt
-        ( cd assets/chezmoi.io && mkdocs build )
+        mkdocs build -f assets/chezmoi.io/mkdocs.yml
       env:
         CHEZMOI_GITHUB_TOKEN: ${{ secrets.CHEZMOI_GITHUB_TOKEN }}
     - name: push-chezmoi.io

--- a/assets/chezmoi.io/docs/hooks.py
+++ b/assets/chezmoi.io/docs/hooks.py
@@ -22,12 +22,13 @@ templates = [
 
 
 def on_pre_build(config, **kwargs):
-    docs_dir = PurePosixPath(config['docs_dir'])
+    config_dir = Path(config.config_file_path).parent
+    docs_dir = PurePosixPath(config.docs_dir)
     for src_path in templates:
         output_path = docs_dir.joinpath(src_path)
         template_path = output_path.parent / (output_path.name + '.tmpl')
         data_path = output_path.parent / (output_path.name + '.yaml')
-        args = ['go', 'run', '../../internal/cmds/execute-template']
+        args = ['go', 'run', Path(config_dir, '../../internal/cmds/execute-template')]
         if Path(data_path).exists():
             args.extend(['-data', data_path])
         args.extend(['-output', output_path, template_path])
@@ -50,15 +51,16 @@ def on_files(files, config, **kwargs):
 
 
 def on_post_build(config, **kwargs):
-    site_dir = config['site_dir']
+    config_dir = Path(config.config_file_path).parent
+    site_dir = config.site_dir
 
     # copy GitHub pages config
-    utils.copy_file('CNAME', Path(site_dir, 'CNAME'))
+    utils.copy_file(Path(config_dir, 'CNAME'), Path(site_dir, 'CNAME'))
 
     # copy installation scripts
-    utils.copy_file('../scripts/install.sh', Path(site_dir, 'get'))
-    utils.copy_file('../scripts/install-local-bin.sh', Path(site_dir, 'getlb'))
-    utils.copy_file('../scripts/install.ps1', Path(site_dir, 'get.ps1'))
+    utils.copy_file(Path(config_dir, '../scripts/install.sh'), Path(site_dir, 'get'))
+    utils.copy_file(Path(config_dir, '../scripts/install-local-bin.sh'), Path(site_dir, 'getlb'))
+    utils.copy_file(Path(config_dir, '../scripts/install.ps1'), Path(site_dir, 'get.ps1'))
 
     # copy cosign.pub
-    utils.copy_file('../cosign/cosign.pub', Path(site_dir, 'cosign.pub'))
+    utils.copy_file(Path(config_dir, '../cosign/cosign.pub'), Path(site_dir, 'cosign.pub'))


### PR DESCRIPTION
-by anchoring to the config path instead of the current working directory.

The background for this is that I'm trying to build a whole bunch of random mkdocs sites to make sure my changes to mkdocs itself aren't disruptive.
https://github.com/mkdocs/regressions/actions/runs/6826747067/job/18567342675