### PR TITLE
chore: Handle garbage stderr output from Bitwarden CLI

### DIFF
--- a/internal/cmd/doctorcmd.go
+++ b/internal/cmd/doctorcmd.go
@@ -304,7 +304,7 @@ func (c *Config) runDoctorCmd(cmd *cobra.Command, args []string) error {
 			ifNotSet:    checkResultWarning,
 			ifNotExist:  checkResultInfo,
 			versionArgs: []string{"--version"},
-			versionRx:   regexp.MustCompile(`^(\d+\.\d+\.\d+)`),
+			versionRx:   regexp.MustCompile(`(?m)^(\d+\.\d+\.\d+)$`),
 		},
 		&binaryCheck{
 			name:        "bitwarden-secrets-command",

--- a/internal/cmd/testdata/scripts/doctor_unix.txtar
+++ b/internal/cmd/testdata/scripts/doctor_unix.txtar
@@ -92,7 +92,9 @@ echo "(devel)"
 -- bin/bw --
 #!/bin/sh
 
-echo "1.12.1"
+echo '(node:84023) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.' 1>&2
+echo '(Use `node --trace-deprecation ...` to show where the warning was created)' 1>&2
+echo "2023.10.0"
 -- bin/bws --
 #!/bin/sh
 


### PR DESCRIPTION
Refs #3339.

In this issue the output from `chezmoi doctor` included:

```
warning   bitwarden-command    found /opt/homebrew/bin/bw, cannot parse version from (node:1388) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
2023.10.0
```

Further investigation shows that the Bitwarden CLI writes a bunch of garbage to stderr:

```console
$ uname
Darwin
$ brew install bitwarden-cli
==> Downloading https://ghcr.io/v2/homebrew/core/bitwarden-cli/manifests/2023.10
######################################################################### 100.0%
==> Fetching bitwarden-cli
==> Downloading https://ghcr.io/v2/homebrew/core/bitwarden-cli/blobs/sha256:d028
######################################################################### 100.0%
==> Pouring bitwarden-cli--2023.10.0.arm64_sonoma.bottle.tar.gz
==> Caveats
zsh completions have been installed to:
  /opt/homebrew/share/zsh/site-functions
==> Summary
🍺  /opt/homebrew/Cellar/bitwarden-cli/2023.10.0: 8,125 files, 45.4MB
==> Running `brew cleanup bitwarden-cli`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
$ bw --version
(node:84023) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
2023.10.0
$ bw --version 2>/dev/null
2023.10.0
```

Rather than ignoring the output to stderr (because some programs use stdout for version output, some stderr), this PR changes the version regexp to ignore Bitwarden CLI's garbage. 