### PR TITLE
docs: Add admonitions linking remove and forget

### DIFF
--- a/assets/chezmoi.io/docs/reference/commands/forget.md
+++ b/assets/chezmoi.io/docs/reference/commands/forget.md
@@ -8,3 +8,8 @@ have entries in the source state. They cannot be externals.
     ```console
     $ chezmoi forget ~/.bashrc
     ```
+
+!!! info
+
+    To remove targets from both the source state and destination directory, use
+    [`remove`](/reference/commands/remov).

--- a/assets/chezmoi.io/docs/reference/commands/remove.md
+++ b/assets/chezmoi.io/docs/reference/commands/remove.md
@@ -5,3 +5,8 @@ Remove *target*s from both the source state and the destination directory.
 ## `-f`, `--force`
 
 Remove without prompting.
+
+!!! info
+
+    To remove targets only from the source state, use
+    [`forget`](/reference/commands/forget).

--- a/assets/chezmoi.io/docs/reference/commands/rm.md
+++ b/assets/chezmoi.io/docs/reference/commands/rm.md
@@ -1,3 +1,3 @@
 # `rm` *target*...
 
-`rm` is an alias for `remove`.
+`rm` is an alias for [`remove`](/reference/commands/remove).


### PR DESCRIPTION
As suggested in #3362, this should improve discoverability by
cross-linking between the two types of target removal.

<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer/contributing-changes/

-->
