### PR TITLE
docs: Clarify prefix order for regular files

### DIFF
--- a/assets/chezmoi.io/docs/reference/source-state-attributes.md
+++ b/assets/chezmoi.io/docs/reference/source-state-attributes.md
@@ -44,7 +44,7 @@ prefixes is important.
 | ---------------- | ----------- | --------------------------------------------------------------------------------- | ---------------- |
 | Directory        | Directory   | `external_`, `exact_`, `private_`, `readonly_`, `dot_`                            | *none*           |
 | Remove directory | Directory   | `remove_`, `dot_`                                                                 | *none*           |
-| Regular file     | File        | `encrypted_`, `private_`, `executable_`, `empty_`, `dot_`                         | `.tmpl`          |
+| Regular file     | File        | `encrypted_`, `private_`, `readonly_`, `empty_`, `executable_`, `dot_`            | `.tmpl`          |
 | Create file      | File        | `create_`, `encrypted_`, `private_`, `readonly_`, `empty_`, `executable_`, `dot_` | `.tmpl`          |
 | Modify file      | File        | `modify_`, `encrypted_`, `private_`, `readonly_`, `executable_`, `dot_`           | `.tmpl`          |
 | Remove file      | File        | `remove_`, `dot_`                                                                 | *none*           |


### PR DESCRIPTION
Based on the implementation here: https://github.com/twpayne/chezmoi/blob/6effb0ab449d0a22403e3fbf8a8d5b103604f7eb/internal/chezmoi/attr.go#L241-L246

I believe the prefix order for regular files is:
- `encrypted_`
- `private_`
- `readonly_`
- `empty_`
- `executable_`

The drift between the documentation and the implementation looks like it happened in two steps:

- `readonly_` was added to the implementation but excluded from the docs in #1403 
- `empty_` was added to the docs but in the wrong order by #2997 

Thanks for the awesome tool @twpayne !!!