### PR TITLE
feat: add cpu and mem info to default data

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -123,6 +123,7 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
+	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pjbgf/sha1cd v0.3.0 // indirect
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -268,6 +268,8 @@ github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/gomega v1.27.10 h1:naR28SdDFlqrG6kScpT8VWpu1xWY5nJRCF3XaYyBjhI=
 github.com/onsi/gomega v1.27.10/go.mod h1:RsS8tutOdbdgzbPtzzATp12yT7kM5I5aElG3evPbQ0M=
+github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 h1:onHthvaw9LFnH4t2DcNVpwGmV9E1BkGknEliJkfwQj0=
+github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58/go.mod h1:DXv8WO4yhMYhSNPKjeNKa5WY9YCIEBRbNzFFPJbWO6Y=
 github.com/pelletier/go-toml/v2 v2.1.0 h1:FnwAJ4oYMvbT/34k9zzHuZNrhlz48GB3/s6at6/MHO4=
 github.com/pelletier/go-toml/v2 v2.1.0/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdUvyaeZurnPPDc=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gregjones/httpcache/diskcache"
 	"github.com/mitchellh/mapstructure"
 	"github.com/muesli/termenv"
+	"github.com/pbnjay/memory"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
@@ -255,6 +256,7 @@ type templateData struct {
 	command           string
 	config            map[string]any
 	configFile        chezmoi.AbsPath
+	cpus              int
 	executable        chezmoi.AbsPath
 	fqdnHostname      string
 	gid               string
@@ -267,6 +269,7 @@ type templateData struct {
 	pathListSeparator string
 	pathSeparator     string
 	sourceDir         chezmoi.AbsPath
+	totalMemoryMB     uint64
 	uid               string
 	username          string
 	version           map[string]any
@@ -1420,6 +1423,7 @@ func (c *Config) getTemplateDataMap(cmd *cobra.Command) map[string]any {
 			"command":           templateData.command,
 			"config":            templateData.config,
 			"configFile":        templateData.configFile.String(),
+			"cpus":              templateData.cpus,
 			"executable":        templateData.executable.String(),
 			"fqdnHostname":      templateData.fqdnHostname,
 			"gid":               templateData.gid,
@@ -1432,6 +1436,7 @@ func (c *Config) getTemplateDataMap(cmd *cobra.Command) map[string]any {
 			"pathListSeparator": templateData.pathListSeparator,
 			"pathSeparator":     templateData.pathSeparator,
 			"sourceDir":         templateData.sourceDir.String(),
+			"totalMemoryMB":     templateData.totalMemoryMB,
 			"uid":               templateData.uid,
 			"username":          templateData.username,
 			"version":           templateData.version,
@@ -2327,6 +2332,7 @@ func (c *Config) newTemplateData(cmd *cobra.Command) *templateData {
 		command:           cmd.Name(),
 		config:            c.ConfigFile.toMap(),
 		configFile:        c.configFileAbsPath,
+		cpus:              runtime.NumCPU(),
 		executable:        chezmoi.NewAbsPath(executable),
 		fqdnHostname:      fqdnHostname,
 		gid:               gid,
@@ -2339,6 +2345,7 @@ func (c *Config) newTemplateData(cmd *cobra.Command) *templateData {
 		pathListSeparator: string(os.PathListSeparator),
 		pathSeparator:     string(os.PathSeparator),
 		sourceDir:         sourceDirAbsPath,
+		totalMemoryMB:     memory.TotalMemory() / (1024 * 1024),
 		uid:               uid,
 		username:          username,
 		version: map[string]any{


### PR DESCRIPTION
This adds cpu count and total memory to the default template data. I intended to use this for some configuration file generation, but found it wasn't available.

```
❯ go run . data | jq '.chezmoi | .cpus, .totalMemoryMB'
10
65536
```

CPU count was easy to get with `runtime.NumCPU()`.

Memory information required a [new dependency](https://github.com/pbnjay/memory). It hasn't been updated in a while, but the code seemed fine for every platform I could understand. I don't know enough about Windows to review that 😅.

Wasn't sure if this should be an issue to discuss, but it was simple enough I figured I'd just open the PR and see what happens!

Not attached to the field names at all, so happy to change.

Thank you!