### PR TITLE
docs: add warning for GitHub SSH key deletion

### DIFF
--- a/assets/chezmoi.io/docs/reference/templates/github-functions/gitHubKeys.md
+++ b/assets/chezmoi.io/docs/reference/templates/github-functions/gitHubKeys.md
@@ -13,6 +13,14 @@ The returned value is a slice of structs with `.ID` and `.Key` fields.
     by using the `-v` / `--verbose` option when running `chezmoi apply` or
     `chezmoi update`.
 
+    Additionally, GitHub automatically [removes keys which haven't been used in
+    the last
+    year](https://docs.github.com/en/authentication/troubleshooting-ssh/deleted-or-missing-ssh-keys).
+    This may cause your keys to be removed from `~/.ssh/authorized_keys`
+    suddenly, and without any warning or indication of the removal. You should
+    provide one or more keys in plain text alongside this function to avoid
+    unknowingly losing remote access to your machine.
+
 !!! example
 
     ```


### PR DESCRIPTION
<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer/contributing-changes/

-->

I (used to) use just the `gitHubKeys` function to populate my `~/.ssh/authorized_keys` file, but as I usually access GitHub over HTTPS, GitHub removed one of my SSH Keys due to it being "[stale](https://docs.github.com/en/authentication/troubleshooting-ssh/deleted-or-missing-ssh-keys)". If I didn't have another key on a different device, I would have lost access to machines which I exclusively interact with over SSH. 

As such, this pr expands upon the existing warning in the documentation to advise users to have other keys alongside the `gitHubKeys` output to prevent the same mistake I made.