### PR TITLE
Set BINDIR to absolute path in install scripts

### DIFF
--- a/assets/chezmoi.io/docs/install.md.tmpl
+++ b/assets/chezmoi.io/docs/install.md.tmpl
@@ -130,7 +130,7 @@ repology.org](https://repology.org/project/chezmoi/versions).
 
 ## One-line binary install
 
-Install the correct binary for your operating system and architecture in `./bin`
+Install the correct binary for your operating system and architecture in `$HOME/bin`
 with a single command:
 
 === "curl"
@@ -170,7 +170,7 @@ with a single command:
 
 !!! hint
 
-    If you want to install chezmoi in `./.local/bin` instead of `./bin` you can
+    If you want to install chezmoi in `$HOME/.local/bin` instead of `$HOME/bin` you can
     use `get.chezmoi.io/lb` or `chezmoi.io/getlb` instead.
 
 !!! hint
@@ -179,7 +179,7 @@ with a single command:
     for example:
 
     ```sh
-    sh -c "$(curl -fsLS get.chezmoi.io)" -- -b $HOME/.local/bin
+    sh -c "$(curl -fsLS get.chezmoi.io)" -- -b .local/bin
     ```
 
 ## Download a pre-built Linux package

--- a/assets/scripts/install-local-bin.sh
+++ b/assets/scripts/install-local-bin.sh
@@ -7,7 +7,7 @@
 
 set -e
 
-BINDIR="${BINDIR:-.local/bin}"
+BINDIR="${BINDIR:-$HOME/.local/bin}"
 CHEZMOI_USER_REPO="${CHEZMOI_USER_REPO:-twpayne/chezmoi}"
 TAGARG=latest
 LOG_LEVEL=2

--- a/assets/scripts/install.ps1
+++ b/assets/scripts/install.ps1
@@ -222,7 +222,7 @@ function unpack-file {
     Install the Chezmoi dotfile manager
 
     .DESCRIPTION
-    Installs Chezmoi to the given directory, defaulting to ./bin
+    Installs Chezmoi to the given directory, defaulting to %USERPROFILE%/bin
 
     You can specify a particular git tag using the -Tag option.
 
@@ -235,7 +235,7 @@ function Install-Chezmoi {
     param(
         [Parameter(Mandatory = $false)]
         [string]
-        $BinDir = (Join-Path (Resolve-Path '.') 'bin'),
+        $BinDir = (Join-Path (Resolve-Path '%USERPROFILE%') 'bin'),
 
         [Parameter(Mandatory = $false)]
         [string] $Tag = 'latest',

--- a/assets/scripts/install.sh
+++ b/assets/scripts/install.sh
@@ -7,7 +7,7 @@
 
 set -e
 
-BINDIR="${BINDIR:-./bin}"
+BINDIR="${BINDIR:-$HOME/bin}"
 CHEZMOI_USER_REPO="${CHEZMOI_USER_REPO:-twpayne/chezmoi}"
 TAGARG=latest
 LOG_LEVEL=2

--- a/internal/cmds/generate-install.sh/install.sh.tmpl
+++ b/internal/cmds/generate-install.sh/install.sh.tmpl
@@ -7,7 +7,7 @@
 
 set -e
 
-BINDIR="${BINDIR:-{{ .BinDir }}}"
+BINDIR="${BINDIR:-$HOME/{{ .BinDir }}}"
 CHEZMOI_USER_REPO="${CHEZMOI_USER_REPO:-twpayne/chezmoi}"
 TAGARG=latest
 LOG_LEVEL=2

--- a/internal/cmds/generate-install.sh/main.go
+++ b/internal/cmds/generate-install.sh/main.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	binDir = flag.String("b", "./bin", "binary directory")
+	binDir = flag.String("b", "bin", "binary directory")
 	output = flag.String("o", "", "output")
 )
 


### PR DESCRIPTION
Dear twpayne,

I was surprised to see that the one-line binary install scripts install the tool in 'bin' (resp '.local/bin') directory, _relative_ to the current working directory. After reading again the doc chezmoi.io/install, the section "One-line binary install", I understood this behaviour is intentional, and the scripts indeed provide a way to install the tool in e.g. '$HOME/.local/bin'.

However, I would assume that most users expect the install scripts' default target to be '$HOME/bin' (resp '$HOME/.local/bin') directory. Provided the scripts keep a way for them to specify a custom one, I would think this is fair.

Apologies if there are mistakes in the code, I tested as much as I could, but I'm no Go nor Powershell programmer.

Thank you for your attention