### PR TITLE
fix: add missing command annotations

### DIFF
--- a/internal/cmd/agecmd.go
+++ b/internal/cmd/agecmd.go
@@ -25,10 +25,9 @@ type ageCmdConfig struct {
 
 func (c *Config) newAgeCmd() *cobra.Command {
 	ageCmd := &cobra.Command{
-		Use:         "age",
-		Args:        cobra.NoArgs,
-		Short:       "Interact with age",
-		Annotations: newAnnotations(),
+		Use:   "age",
+		Args:  cobra.NoArgs,
+		Short: "Interact with age",
 	}
 
 	ageDecryptCmd := &cobra.Command{

--- a/internal/cmd/helpcmd.go
+++ b/internal/cmd/helpcmd.go
@@ -9,12 +9,14 @@ import (
 
 func (c *Config) newHelpCmd() *cobra.Command {
 	helpCmd := &cobra.Command{
-		Use:         "help [command]",
-		Short:       "Print help about a command",
-		Long:        mustLongHelp("help"),
-		Example:     example("help"),
-		RunE:        c.runHelpCmd,
-		Annotations: newAnnotations(),
+		Use:     "help [command]",
+		Short:   "Print help about a command",
+		Long:    mustLongHelp("help"),
+		Example: example("help"),
+		RunE:    c.runHelpCmd,
+		Annotations: newAnnotations(
+			doesNotRequireValidConfig,
+		),
 	}
 
 	return helpCmd

--- a/internal/cmd/internaltestcmd.go
+++ b/internal/cmd/internaltestcmd.go
@@ -21,6 +21,9 @@ func (c *Config) newInternalTestCmd() *cobra.Command {
 		Args:  cobra.MinimumNArgs(1),
 		Short: "Run promptBool",
 		RunE:  c.runInternalTestPromptBoolCmd,
+		Annotations: newAnnotations(
+			doesNotRequireValidConfig,
+		),
 	}
 	internalTestCmd.AddCommand(internalTestPromptBoolCmd)
 
@@ -29,6 +32,9 @@ func (c *Config) newInternalTestCmd() *cobra.Command {
 		Args:  cobra.MinimumNArgs(2),
 		Short: "Run promptChoice",
 		RunE:  c.runInternalTestPromptChoiceCmd,
+		Annotations: newAnnotations(
+			doesNotRequireValidConfig,
+		),
 	}
 	internalTestCmd.AddCommand(internalTestPromptChoiceCmd)
 
@@ -37,6 +43,9 @@ func (c *Config) newInternalTestCmd() *cobra.Command {
 		Args:  cobra.MinimumNArgs(1),
 		Short: "Run promptInt",
 		RunE:  c.runInternalTestPromptIntCmd,
+		Annotations: newAnnotations(
+			doesNotRequireValidConfig,
+		),
 	}
 	internalTestCmd.AddCommand(internalTestPromptIntCmd)
 
@@ -45,6 +54,9 @@ func (c *Config) newInternalTestCmd() *cobra.Command {
 		Args:  cobra.MinimumNArgs(1),
 		Short: "Run promptString",
 		RunE:  c.runInternalTestPromptStringCmd,
+		Annotations: newAnnotations(
+			doesNotRequireValidConfig,
+		),
 	}
 	internalTestCmd.AddCommand(internalTestPromptStringCmd)
 
@@ -53,6 +65,9 @@ func (c *Config) newInternalTestCmd() *cobra.Command {
 		Args:  cobra.NoArgs,
 		Short: "Read a password",
 		RunE:  c.runInternalTestReadPasswordCmd,
+		Annotations: newAnnotations(
+			doesNotRequireValidConfig,
+		),
 	}
 	internalTestCmd.AddCommand(internalTestReadPasswordCmd)
 

--- a/internal/cmd/licensecmd.go
+++ b/internal/cmd/licensecmd.go
@@ -11,13 +11,15 @@ import (
 
 func (c *Config) newLicenseCmd() *cobra.Command {
 	licenseCmd := &cobra.Command{
-		Use:         "license",
-		Short:       "Print license",
-		Long:        mustLongHelp("license"),
-		Example:     example("license"),
-		Args:        cobra.NoArgs,
-		RunE:        c.runLicenseCmd,
-		Annotations: newAnnotations(),
+		Use:     "license",
+		Short:   "Print license",
+		Long:    mustLongHelp("license"),
+		Example: example("license"),
+		Args:    cobra.NoArgs,
+		RunE:    c.runLicenseCmd,
+		Annotations: newAnnotations(
+			doesNotRequireValidConfig,
+		),
 	}
 
 	return licenseCmd

--- a/internal/cmd/secretkeyringcmd.go
+++ b/internal/cmd/secretkeyringcmd.go
@@ -41,6 +41,9 @@ func (c *Config) newSecretKeyringCmd() *cobra.Command {
 		Args:  cobra.NoArgs,
 		Short: "Delete a value from keyring",
 		RunE:  c.runSecretKeyringDeleteCmdE,
+		Annotations: newAnnotations(
+			doesNotRequireValidConfig,
+		),
 	}
 	secretKeyringDeletePersistentFlags := keyringDeleteCmd.PersistentFlags()
 	secretKeyringDeletePersistentFlags.StringVar(
@@ -58,6 +61,9 @@ func (c *Config) newSecretKeyringCmd() *cobra.Command {
 		Args:  cobra.NoArgs,
 		Short: "Get a value from keyring",
 		RunE:  c.runSecretKeyringGetCmdE,
+		Annotations: newAnnotations(
+			doesNotRequireValidConfig,
+		),
 	}
 	secretKeyringGetPersistentFlags := keyringGetCmd.PersistentFlags()
 	secretKeyringGetPersistentFlags.StringVar(
@@ -75,6 +81,9 @@ func (c *Config) newSecretKeyringCmd() *cobra.Command {
 		Args:  cobra.NoArgs,
 		Short: "Set a value in keyring",
 		RunE:  c.runSecretKeyringSetCmdE,
+		Annotations: newAnnotations(
+			doesNotRequireValidConfig,
+		),
 	}
 	secretKeyringSetPersistentFlags := keyringSetCmd.PersistentFlags()
 	secretKeyringSetPersistentFlags.StringVar(


### PR DESCRIPTION
Removed annotations from `cobra.Command` structs that do not set
`RunE` as it does not appear necessary.

Modified the annotation for `help` and `license` to not require valid
config.

Fixes #3424.
