### PR TITLE
chore: Connect stderr when running commands

### DIFF
--- a/internal/chezmoitest/chezmoitest.go
+++ b/internal/chezmoitest/chezmoitest.go
@@ -4,6 +4,7 @@ package chezmoitest
 import (
 	"fmt"
 	"io/fs"
+	"os"
 	"os/exec"
 	"regexp"
 	"runtime"
@@ -49,6 +50,8 @@ func GPGGenerateKey(command, homeDir string) (key, passphrase string, err error)
 		"--pinentry-mode", "loopback",
 		"--quick-generate-key", key,
 	)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
 	err = chezmoilog.LogCmdRun(cmd)
 	return
 }

--- a/internal/cmd/doctorcmd.go
+++ b/internal/cmd/doctorcmd.go
@@ -576,6 +576,7 @@ func (c *dirCheck) Run(system chezmoi.System, homeDirAbsPath chezmoi.AbsPath) (c
 			"status",
 			"--porcelain=v2",
 		)
+		cmd.Stderr = os.Stderr
 		output, err := cmd.Output()
 		if err != nil {
 			gitStatus = gitStatusError

--- a/internal/cmd/doctorcmd_unix.go
+++ b/internal/cmd/doctorcmd_unix.go
@@ -5,6 +5,7 @@ package cmd
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"os/exec"
 	"runtime"
 
@@ -43,6 +44,7 @@ func (unameCheck) Run(system chezmoi.System, homeDirAbsPath chezmoi.AbsPath) (ch
 		return checkResultSkipped, ""
 	}
 	cmd := exec.Command("uname", "-a")
+	cmd.Stderr = os.Stderr
 	data, err := chezmoilog.LogCmdOutput(cmd)
 	if err != nil {
 		return checkResultFailed, err.Error()

--- a/internal/cmds/execute-template/main.go
+++ b/internal/cmds/execute-template/main.go
@@ -118,7 +118,9 @@ func run() error {
 	// FIXME we should use chezmoi's template functions if/when needed,
 	// for now we use a bespoke output function
 	funcMap["output"] = func(name string, args ...string) string {
-		out, err := exec.Command(name, args...).Output()
+		cmd := exec.Command(name, args...)
+		cmd.Stderr = os.Stderr
+		out, err := cmd.Output()
 		if err != nil {
 			panic(err)
 		}

--- a/internal/cmds/generate-install.sh/main.go
+++ b/internal/cmds/generate-install.sh/main.go
@@ -41,7 +41,9 @@ type platformValue struct {
 type platformSet map[platform]platformValue
 
 func goToolDistList() (platformSet, error) {
-	data, err := exec.Command("go", "tool", "dist", "list", "-json").Output()
+	cmd := exec.Command("go", "tool", "dist", "list", "-json")
+	cmd.Stderr = os.Stderr
+	data, err := cmd.Output()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Before this, stderr was occasionally unconnected when running commands, meaning that error information was lost. With this PR it should be visible more often, making debugging of commands easier.