### PR TITLE
fix: Always use forward slashes to separate Windows paths

### DIFF
--- a/internal/chezmoi/abspath.go
+++ b/internal/chezmoi/abspath.go
@@ -32,7 +32,7 @@ func (ps AbsPaths) Swap(i, j int)      { ps[i], ps[j] = ps[j], ps[i] }
 // NewAbsPath returns a new AbsPath.
 func NewAbsPath(absPath string) AbsPath {
 	return AbsPath{
-		absPath: absPath,
+		absPath: filepath.ToSlash(absPath),
 	}
 }
 


### PR DESCRIPTION
Fixes #3473.