### PR TITLE
Change init to default to --config if --config-path is absent.

### DIFF
--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -748,7 +748,7 @@ func (c *Config) createAndReloadConfigFile(cmd *cobra.Command) error {
 	// Write the config.
 	configPath := c.init.configPath
 	if c.init.configPath.Empty() {
-		configPath = chezmoi.NewAbsPath(c.bds.ConfigHome).Join(chezmoiRelPath, configTemplate.targetRelPath)
+		configPath = c.configFileAbsPath
 	}
 	if err := chezmoi.MkdirAll(c.baseSystem, configPath.Dir(), fs.ModePerm); err != nil {
 		return err


### PR DESCRIPTION
Fixes #3127

My understanding is that `configFileAbsPath` is initialized [here](https://github.com/twpayne/chezmoi/blob/85983f06931e86b157a877287a82d8b6faca8eea/internal/cmd/config.go#L502) where the value of `c.bds.ConfigHome` is already taken into account. Furthermore, `configFileAbsPath` is overridden with the value of the `--config` option [here](https://github.com/twpayne/chezmoi/blob/85983f06931e86b157a877287a82d8b6faca8eea/internal/cmd/config.go#L1555). Thus, using `configFileAbsPath` should ensure that in the absence of a `--config-path` option the `init` command defaults to the value of the `--config` option, if it's present, and only otherwise defaults to the platform's default.

NOTE: I haven't tested this at all. I don't have a local fork of chezmoi, nor a setup to build and test it.
