### PR TITLE
fix: Change init to default to --config if --config-path is absent

### DIFF
--- a/internal/cmd/addcmd.go
+++ b/internal/cmd/addcmd.go
@@ -208,7 +208,7 @@ func (c *Config) runAddCmd(cmd *cobra.Command, args []string, sourceState *chezm
 			ProtectedAbsPaths: []chezmoi.AbsPath{
 				c.CacheDirAbsPath,
 				c.WorkingTreeAbsPath,
-				c.configFileAbsPath,
+				c.getConfigFileAbsPath(),
 				persistentStateFileAbsPath,
 				c.sourceDirAbsPath,
 			},

--- a/internal/cmd/catconfigcmd.go
+++ b/internal/cmd/catconfigcmd.go
@@ -20,7 +20,7 @@ func (c *Config) newCatConfigCmd() *cobra.Command {
 }
 
 func (c *Config) runCatConfigCmd(cmd *cobra.Command, args []string) error {
-	data, err := c.baseSystem.ReadFile(c.configFileAbsPath)
+	data, err := c.baseSystem.ReadFile(c.getConfigFileAbsPath())
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/doctorcmd.go
+++ b/internal/cmd/doctorcmd.go
@@ -191,7 +191,7 @@ func (c *Config) runDoctorCmd(cmd *cobra.Command, args []string) error {
 		&configFileCheck{
 			basename: chezmoiRelPath,
 			bds:      c.bds,
-			expected: c.configFileAbsPath,
+			expected: c.getConfigFileAbsPath(),
 		},
 		&dirCheck{
 			name:    "source-dir",

--- a/internal/cmd/editconfigcmd.go
+++ b/internal/cmd/editconfigcmd.go
@@ -24,5 +24,5 @@ func (c *Config) newEditConfigCmd() *cobra.Command {
 }
 
 func (c *Config) runEditConfigCmd(cmd *cobra.Command, args []string) error {
-	return c.runEditor([]string{c.configFileAbsPath.String()})
+	return c.runEditor([]string{c.getConfigFileAbsPath().String()})
 }

--- a/internal/cmd/editconfigtemplatecmd.go
+++ b/internal/cmd/editconfigtemplatecmd.go
@@ -39,9 +39,9 @@ func (c *Config) runEditConfigTemplateCmd(cmd *cobra.Command, args []string, sou
 			!errors.Is(err, fs.ErrExist) {
 			return err
 		}
-		configFileBase := "." + c.configFileAbsPath.Base() + ".tmpl"
+		configFileBase := "." + c.getConfigFileAbsPath().Base() + ".tmpl"
 		configTemplateAbsPath = c.sourceDirAbsPath.JoinString(configFileBase)
-		switch data, err := c.baseSystem.ReadFile(c.configFileAbsPath); {
+		switch data, err := c.baseSystem.ReadFile(c.getConfigFileAbsPath()); {
 		case errors.Is(err, fs.ErrNotExist):
 			// Do nothing.
 		case err != nil:

--- a/internal/cmd/purgecmd.go
+++ b/internal/cmd/purgecmd.go
@@ -60,7 +60,7 @@ func (c *Config) doPurge(options *doPurgeOptions) error {
 	}
 
 	if options.config {
-		absPaths = append(absPaths, c.configFileAbsPath.Dir(), c.configFileAbsPath)
+		absPaths = append(absPaths, c.getConfigFileAbsPath().Dir(), c.getConfigFileAbsPath())
 	}
 
 	if options.persistentState {

--- a/internal/cmd/testdata/scripts/init.txtar
+++ b/internal/cmd/testdata/scripts/init.txtar
@@ -94,6 +94,14 @@ grep '# edited' $HOME/.file
 
 chhome home10/user
 
+# test chezmoi --config init
+mkgitconfig
+exec chezmoi --config=$HOME/.chezmoi.toml init file://$WORK/home/user/.local/share/chezmoi
+cmp $HOME/.chezmoi.toml golden/chezmoi.toml
+! exists $CHEZMOICONFIGDIR/chezmoi.toml
+
+chhome home10-old/user
+
 # test chezmoi init --config-path
 mkgitconfig
 exec chezmoi init --config-path=$HOME/.chezmoi.toml file://$WORK/home/user/.local/share/chezmoi

--- a/internal/cmd/testdata/scripts/initconfig.txtar
+++ b/internal/cmd/testdata/scripts/initconfig.txtar
@@ -1,0 +1,135 @@
+[windows] skip 'test requires path separator to be forward slash'
+# test the init command with 3 different sets of --config/--config-format options
+
+
+#### test chezmoi init
+
+chhome home1/user
+mkdir $CHEZMOISOURCEDIR
+
+# test that chezmoi init writes the initial config into the defaul config dir
+cp golden/chezmoi1.yaml $CHEZMOISOURCEDIR/.chezmoi.yaml.tmpl
+exec chezmoi init
+cmp $CHEZMOICONFIGDIR/chezmoi.yaml golden/chezmoi1.yaml
+
+# test that chezmoi init writes an updated config into the defaul config dir
+cp golden/chezmoi2.yaml $CHEZMOISOURCEDIR/.chezmoi.yaml.tmpl
+exec chezmoi init
+cmp $CHEZMOICONFIGDIR/chezmoi.yaml golden/chezmoi2.yaml
+
+# test that chezmoi init writes a config of a new format into the defaul config dir
+rm $CHEZMOISOURCEDIR/.chezmoi.yaml.tmpl
+cp golden/chezmoi3.toml $CHEZMOISOURCEDIR/.chezmoi.toml.tmpl
+exec chezmoi init
+cmp $CHEZMOICONFIGDIR/chezmoi.yaml golden/chezmoi2.yaml
+cmp $CHEZMOICONFIGDIR/chezmoi.toml golden/chezmoi3.toml
+
+# check that the last operation broke chezmoi
+! exec chezmoi status
+! stdout .
+cmpenv stderr golden/error1.log
+
+# check that deleting the old config file fixes the issue
+rm $CHEZMOICONFIGDIR/chezmoi.yaml
+exec chezmoi status
+! stdout .
+! stderr .
+
+# check that the state file was written into the default config dir
+exists $CHEZMOICONFIGDIR/chezmoistate.boltdb
+
+
+#### test chezmoi --config=path init
+
+chhome home2/user
+mkdir $CHEZMOISOURCEDIR
+
+# test that chezmoi --config=path init writes the initial config into path
+cp golden/chezmoi1.yaml $CHEZMOISOURCEDIR/.chezmoi.yaml.tmpl
+exec chezmoi --config=$HOME/.chezmoi/athome.yaml init
+cmp $HOME/.chezmoi/athome.yaml golden/chezmoi1.yaml
+
+# test that chezmoi --config=path init writes an updated config into path
+cp golden/chezmoi2.yaml $CHEZMOISOURCEDIR/.chezmoi.yaml.tmpl
+exec chezmoi --config=$HOME/.chezmoi/athome.yaml init
+cmp $HOME/.chezmoi/athome.yaml golden/chezmoi2.yaml
+
+# test that chezmoi --config=path init writes a config of a new format into path
+rm $CHEZMOISOURCEDIR/.chezmoi.yaml.tmpl
+cp golden/chezmoi3.toml $CHEZMOISOURCEDIR/.chezmoi.toml.tmpl
+exec chezmoi --config=$HOME/.chezmoi/athome.yaml init
+cmp $HOME/.chezmoi/athome.yaml golden/chezmoi3.toml
+
+# check that the last operation broke chezmoi
+! exec chezmoi --config=$HOME/.chezmoi/athome.yaml status
+! stdout .
+cmpenv stderr golden/error2.log
+
+# check that renaming the file and updating the config path fixes the issue
+mv $HOME/.chezmoi/athome.yaml $HOME/.chezmoi/athome.toml
+exec chezmoi --config=$HOME/.chezmoi/athome.toml status
+! stdout .
+! stderr .
+
+# check that the state file was written next to the config file
+exists $HOME/.chezmoi/chezmoistate.boltdb
+
+# check that nothing was ever written into the default config dir
+! exists $CHEZMOICONFIGDIR/chezmoi.toml
+! exists $CHEZMOICONFIGDIR/chezmoistate.boltdb
+
+
+#### test chezmoi --config=path --config-format=format init
+
+chhome home3/user
+mkdir $CHEZMOISOURCEDIR
+
+# test that chezmoi --config=path --config-format=format init writes the initial config into path
+cp golden/chezmoi1.yaml $CHEZMOISOURCEDIR/.chezmoi.yaml.tmpl
+exec chezmoi --config=$HOME/.chezmoi/athome.txt --config-format=yaml init
+cmp $HOME/.chezmoi/athome.txt golden/chezmoi1.yaml
+
+# test that chezmoi --config=path --config-format=format init writes an updated config into path
+cp golden/chezmoi2.yaml $CHEZMOISOURCEDIR/.chezmoi.yaml.tmpl
+exec chezmoi --config=$HOME/.chezmoi/athome.txt --config-format=yaml init
+cmp $HOME/.chezmoi/athome.txt golden/chezmoi2.yaml
+
+# test that chezmoi --config=path --config-format=format init writes a config of a new format into path
+rm $CHEZMOISOURCEDIR/.chezmoi.yaml.tmpl
+cp golden/chezmoi3.toml $CHEZMOISOURCEDIR/.chezmoi.toml.tmpl
+exec chezmoi --config=$HOME/.chezmoi/athome.txt --config-format=yaml init
+cmp $HOME/.chezmoi/athome.txt golden/chezmoi3.toml
+
+# check that the last operation broke chezmoi
+! exec chezmoi --config=$HOME/.chezmoi/athome.txt --config-format=yaml status
+! stdout .
+cmpenv stderr golden/error3.log
+
+# check that updating the config format fixes the issue
+exec chezmoi --config=$HOME/.chezmoi/athome.txt --config-format=toml status
+! stdout .
+! stderr .
+
+# check that the state file was written next to the config file
+exists $HOME/.chezmoi/chezmoistate.boltdb
+
+# check that nothing was ever written into the default config dir
+! exists $CHEZMOICONFIGDIR/chezmoi.toml
+! exists $CHEZMOICONFIGDIR/chezmoistate.boltdb
+
+
+-- golden/chezmoi1.yaml --
+data:
+    email: "mail1@example.com"
+-- golden/chezmoi2.yaml --
+data:
+    email: "mail2@example.com"
+-- golden/chezmoi3.toml --
+[data]
+    email = "mail3@example.com"
+-- golden/error1.log --
+chezmoi: multiple config files: $CHEZMOICONFIGDIR/chezmoi.toml and $CHEZMOICONFIGDIR/chezmoi.yaml
+-- golden/error2.log --
+chezmoi: invalid config: $HOME/.chezmoi/athome.yaml: yaml: unmarshal errors: line 1: cannot unmarshal !!seq into map[string]interface {}
+-- golden/error3.log --
+chezmoi: invalid config: $HOME/.chezmoi/athome.txt: yaml: unmarshal errors: line 1: cannot unmarshal !!seq into map[string]interface {}

--- a/internal/cmd/testdata/scripts/issue3127.txtar
+++ b/internal/cmd/testdata/scripts/issue3127.txtar
@@ -1,0 +1,27 @@
+mkdir $CHEZMOISOURCEDIR
+
+# test that chezmoi --config=path init --config-path=path writes the initial config into path
+cp golden/config1.toml $CHEZMOISOURCEDIR/.chezmoi.toml.tmpl
+exec chezmoi --config=$HOME/config/athome.toml init --config-path=$HOME/config/athome.toml
+cmp $HOME/config/athome.toml golden/config1.toml
+
+# test that chezmoi --config=path init --config-path=path writes an updated config into path
+cp golden/config2.toml $CHEZMOISOURCEDIR/.chezmoi.toml.tmpl
+exec chezmoi --config=$HOME/config/athome.toml init --config-path=$HOME/config/athome.toml
+cmp $HOME/config/athome.toml golden/config2.toml
+
+# test that chezmoi --config=path init writes an updated config into path
+cp golden/config3.toml $CHEZMOISOURCEDIR/.chezmoi.toml.tmpl
+exec chezmoi --config=$HOME/config/athome.toml init
+cmp $HOME/config/athome.toml golden/config3.toml
+
+
+-- golden/config1.toml --
+[data]
+    email = "mail1@example.com"
+-- golden/config2.toml --
+[data]
+    email = "mail2@example.com"
+-- golden/config3.toml --
+[data]
+    email = "mail3@example.com"


### PR DESCRIPTION
Here is an updated version of my previous PR. I have checked that it does what's expected and that it doesn't break any existing tests.

It should still be considered as a proof of concept rather than something ready to be submitted. My claim is that it contains the required logic to achieve the desired goal without breaking any existing behavior but that's about it. I haven't tried to add tests, yet. More importantly some changes, like in particular the replacement of `configFileAbsPath` with `configFileAbsPathDefault` and `configFileAbsPathExplicit`, look ugly. Note also that I have no experience programming in Go.

The main benefit of this change is that it becomes possible to use `chezmoi` with an alternate config simply by defining an alias like the following one:

`alias chezmoi2="chezmoi --config=<path-to-alternate-config>"`

This works for all commands, including the initial `init` command.

Fixes #3127.

