### PR TITLE
feat: Add re-add --recursive flag and make it the default

### DIFF
--- a/assets/chezmoi.io/docs/reference/commands/re-add.md
+++ b/assets/chezmoi.io/docs/reference/commands/re-add.md
@@ -2,10 +2,14 @@
 
 Re-add modified files in the target state, preserving any `encrypted_`
 attributes. chezmoi will not overwrite templates, and all entries that are not
-files are ignored.
+files are ignored. Directories are recursed into by default.
 
 If no *target*s are specified then all modified files are re-added. If one or
 more *target*s are given then only those targets are re-added.
+
+## `-r`, `--recursive`
+
+Recursively add files in subdirectories.
 
 !!! hint
 
@@ -16,4 +20,5 @@ more *target*s are given then only those targets are re-added.
     ```console
     $ chezmoi re-add
     $ chezmoi re-add ~/.bashrc
+    $ chezmoi re-add --recursive=false ~/.config/git
     ```

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -364,7 +364,8 @@ func newConfig(options ...configOption) (*Config, error) {
 			recursive: true,
 		},
 		reAdd: reAddCmdConfig{
-			filter: chezmoi.NewEntryTypeFilter(chezmoi.EntryTypesAll, chezmoi.EntryTypesNone),
+			filter:    chezmoi.NewEntryTypeFilter(chezmoi.EntryTypesAll, chezmoi.EntryTypesNone),
+			recursive: true,
 		},
 		unmanaged: unmanagedCmdConfig{
 			pathStyle: chezmoi.PathStyleRelative,

--- a/internal/cmd/testdata/scripts/re-add.txtar
+++ b/internal/cmd/testdata/scripts/re-add.txtar
@@ -21,3 +21,11 @@ exec chezmoi re-add ~/.dir/file
 grep -count=1 '# edited' $CHEZMOISOURCEDIR/dot_file
 grep -count=2 '# edited' $CHEZMOISOURCEDIR/dot_dir/file
 grep -count=1 '# edited' $CHEZMOISOURCEDIR/dot_dir/exact_subdir/file
+
+# test that chezmoi re-add --recursive=false does not recurse into subdirectories
+exec chezmoi re-add --recursive=false ~/.dir/subdir
+grep -count=1 '# edited' $CHEZMOISOURCEDIR/dot_dir/exact_subdir/file
+
+# test that chezmoi re-add is recursive by default
+exec chezmoi re-add ~/.dir/subdir
+grep -count=2 '# edited' $CHEZMOISOURCEDIR/dot_dir/exact_subdir/file


### PR DESCRIPTION
Fixes #3490.

@bryango would you be able to test this? You'll find pre-built chezmoi binaries in the artifacts section of the checks run by GitHub Actions on this PR. Sorry, there's no way to provide a direct link.

Technically, this is a backwards-incompatible change because the default behavior of `chezmoi re-add` changes from not-recursive to recursive. However, I think this is OK because the use case that it breaks is using `chezmoi re-add` on a directory where you want re-add the directory itself but not its contents. I suspect that this use case is sufficiently rare that it's OK to make this change with only a patch version bump, especially as `chezmoi re-add` is likely used interactively rather than scripted.