### PR TITLE
feat: Build for Android (Termux)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -41,6 +41,7 @@ builds:
   env:
   - CGO_ENABLED=0
   goos:
+  - android
   - darwin
   - freebsd
   - linux
@@ -68,6 +69,12 @@ builds:
   - -X main.date={{ .Date }}
   - -X main.builtBy=goreleaser
   ignore:
+  - goos: android
+    goarch: '386'
+  - goos: android
+    goarch: amd64
+  - goos: android
+    goarch: arm
   - goos: darwin
     goarch: '386'
   - goos: linux

--- a/assets/chezmoi.io/docs/install.md.tmpl
+++ b/assets/chezmoi.io/docs/install.md.tmpl
@@ -222,6 +222,7 @@ pre-built binary and shell completions.
 {{- end }}
     [`amd64` (glibc)](https://github.com/twpayne/chezmoi/releases/download/v{{ $version }}/chezmoi_{{ $version }}_linux-glibc_amd64.tar.gz)
     [`amd64` (musl)](https://github.com/twpayne/chezmoi/releases/download/v{{ $version }}/chezmoi_{{ $version }}_linux-musl_amd64.tar.gz)
+    [`arm64` (Termux)](https://github.com/twpayne/chezmoi/releases/download/v{{ $version }}/chezmoi_{{ $version }}_android_arm64.tar.gz)
 
 === "macOS"
 

--- a/assets/scripts/install-local-bin.sh
+++ b/assets/scripts/install-local-bin.sh
@@ -118,6 +118,13 @@ get_goos() {
 	os="$(uname -s | tr '[:upper:]' '[:lower:]')"
 	case "${os}" in
 	cygwin_nt*) goos="windows" ;;
+	linux)
+		if is_command termux-info; then
+			goos=android
+		else
+			goos=linux
+		fi
+		;;
 	mingw*) goos="windows" ;;
 	msys_nt*) goos="windows" ;;
 	*) goos="${os}" ;;
@@ -142,6 +149,7 @@ get_goarch() {
 
 check_goos_goarch() {
 	case "${1}" in
+	android/arm64) return 0 ;;
 	darwin/amd64) return 0 ;;
 	darwin/arm64) return 0 ;;
 	freebsd/386) return 0 ;;

--- a/assets/scripts/install.sh
+++ b/assets/scripts/install.sh
@@ -118,6 +118,13 @@ get_goos() {
 	os="$(uname -s | tr '[:upper:]' '[:lower:]')"
 	case "${os}" in
 	cygwin_nt*) goos="windows" ;;
+	linux)
+		if is_command termux-info; then
+			goos=android
+		else
+			goos=linux
+		fi
+		;;
 	mingw*) goos="windows" ;;
 	msys_nt*) goos="windows" ;;
 	*) goos="${os}" ;;
@@ -142,6 +149,7 @@ get_goarch() {
 
 check_goos_goarch() {
 	case "${1}" in
+	android/arm64) return 0 ;;
 	darwin/amd64) return 0 ;;
 	darwin/arm64) return 0 ;;
 	freebsd/386) return 0 ;;

--- a/internal/cmds/generate-install.sh/install.sh.tmpl
+++ b/internal/cmds/generate-install.sh/install.sh.tmpl
@@ -118,6 +118,13 @@ get_goos() {
 	os="$(uname -s | tr '[:upper:]' '[:lower:]')"
 	case "${os}" in
 	cygwin_nt*) goos="windows" ;;
+	linux)
+		if is_command termux-info; then
+			goos=android
+		else
+			goos=linux
+		fi
+		;;
 	mingw*) goos="windows" ;;
 	msys_nt*) goos="windows" ;;
 	*) goos="${os}" ;;


### PR DESCRIPTION
Fixes #3507.

@Grimler91, as a Termux contributor, is checking for the existence of a `termux-info` command a good way to detect Termux? As far as I can tell, `uname -a` on Termux returns `Linux`.