### PR TITLE
Move default `chezmoistate.boltdb` to `$XDG_STATE_HOME`

### DIFF
--- a/assets/chezmoi.io/docs/reference/configuration-file/variables.md.yaml
+++ b/assets/chezmoi.io/docs/reference/configuration-file/variables.md.yaml
@@ -33,9 +33,9 @@ sections:
       description: Default pager CLI command
     persistentState:
       default: >-
-        `$XDG_CONFIG_HOME/chezmoi/chezmoi.boltdb` <br/>
-        `$HOME/.config/chezmoi/chezmoi.boltdb` <br/>
-        `%USERPROFILE%/.config/chezmoi/chezmoi.boltdb`
+        `$XDG_STATE_HOME/chezmoi/chezmoi.boltdb` <br/>
+        `$HOME/.local/state/chezmoi/chezmoi.boltdb` <br/>
+        `%USERPROFILE%/.local/state/chezmoi/chezmoi.boltdb`
       description: Location of the persistent state file
     progress:
       type: bool

--- a/assets/chezmoi.io/docs/reference/configuration-file/variables.md.yaml
+++ b/assets/chezmoi.io/docs/reference/configuration-file/variables.md.yaml
@@ -33,9 +33,9 @@ sections:
       description: Default pager CLI command
     persistentState:
       default: >-
-        `$XDG_STATE_HOME/chezmoi/chezmoi.boltdb` <br/>
-        `$HOME/.local/state/chezmoi/chezmoi.boltdb` <br/>
-        `%USERPROFILE%/.local/state/chezmoi/chezmoi.boltdb`
+        `$XDG_STATE_HOME/chezmoi/chezmoistate.boltdb` <br/>
+        `$HOME/.local/state/chezmoi/chezmoistate.boltdb` <br/>
+        `%USERPROFILE%/.local/state/chezmoi/chezmoistate.boltdb`
       description: Location of the persistent state file
     progress:
       type: bool

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -288,8 +288,8 @@ type configState struct {
 }
 
 var (
-	chezmoiRelPath             = chezmoi.NewRelPath("chezmoi")
-	httpCacheDirRelPath        = chezmoi.NewRelPath("httpcache")
+	chezmoiRelPath      = chezmoi.NewRelPath("chezmoi")
+	httpCacheDirRelPath = chezmoi.NewRelPath("httpcache")
 
 	configStateKey = []byte("configState")
 
@@ -2169,7 +2169,7 @@ func (c *Config) persistentStateFile() (chezmoi.AbsPath, error) {
 		return c.PersistentStateAbsPath, nil
 	}
 
-        // Fallback to XDG Base Directory Specification default.
+	// Fallback to XDG Base Directory Specification default.
 	stateHomeAbsPath, err := chezmoi.NewAbsPathFromExtPath(c.bds.StateHome, c.homeDirAbsPath)
 	if err != nil {
 		return chezmoi.EmptyAbsPath, err

--- a/internal/cmd/main_test.go
+++ b/internal/cmd/main_test.go
@@ -120,11 +120,13 @@ func cmdChHome(ts *testscript.TestScript, neg bool, args []string) {
 		homeDir          = ts.MkAbs(args[0])
 		chezmoiConfigDir = path.Join(homeDir, ".config", "chezmoi")
 		chezmoiSourceDir = path.Join(homeDir, ".local", "share", "chezmoi")
+                chezmoiStateDir  = path.Join(homeDir, ".local", "state", "chezmoi")
 	)
 	ts.Check(os.MkdirAll(homeDir, fs.ModePerm))
 	ts.Setenv("HOME", homeDir)
 	ts.Setenv("CHEZMOICONFIGDIR", chezmoiConfigDir)
 	ts.Setenv("CHEZMOISOURCEDIR", chezmoiSourceDir)
+        ts.Setenv("CHEZMOISTATEDIR", chezmoiStateDir)
 	if runtime.GOOS == "windows" {
 		ts.Setenv("USERPROFILE", homeDir)
 	}
@@ -658,6 +660,7 @@ func setup(env *testscript.Env) error {
 	}
 	env.Setenv("CHEZMOICONFIGDIR", path.Join(absSlashHomeDir, ".config", "chezmoi"))
 	env.Setenv("CHEZMOISOURCEDIR", path.Join(absSlashHomeDir, ".local", "share", "chezmoi"))
+        env.Setenv("CHEZMOISTATEDIR", path.Join(absSlashHomeDir, ".local", "state", "chezmoi"))
 	env.Setenv("CHEZMOI_GITHUB_TOKEN", os.Getenv("CHEZMOI_GITHUB_TOKEN"))
 
 	switch runtime.GOOS {

--- a/internal/cmd/main_test.go
+++ b/internal/cmd/main_test.go
@@ -120,13 +120,13 @@ func cmdChHome(ts *testscript.TestScript, neg bool, args []string) {
 		homeDir          = ts.MkAbs(args[0])
 		chezmoiConfigDir = path.Join(homeDir, ".config", "chezmoi")
 		chezmoiSourceDir = path.Join(homeDir, ".local", "share", "chezmoi")
-                chezmoiStateDir  = path.Join(homeDir, ".local", "state", "chezmoi")
+		chezmoiStateDir  = path.Join(homeDir, ".local", "state", "chezmoi")
 	)
 	ts.Check(os.MkdirAll(homeDir, fs.ModePerm))
 	ts.Setenv("HOME", homeDir)
 	ts.Setenv("CHEZMOICONFIGDIR", chezmoiConfigDir)
 	ts.Setenv("CHEZMOISOURCEDIR", chezmoiSourceDir)
-        ts.Setenv("CHEZMOISTATEDIR", chezmoiStateDir)
+	ts.Setenv("CHEZMOISTATEDIR", chezmoiStateDir)
 	if runtime.GOOS == "windows" {
 		ts.Setenv("USERPROFILE", homeDir)
 	}
@@ -660,7 +660,7 @@ func setup(env *testscript.Env) error {
 	}
 	env.Setenv("CHEZMOICONFIGDIR", path.Join(absSlashHomeDir, ".config", "chezmoi"))
 	env.Setenv("CHEZMOISOURCEDIR", path.Join(absSlashHomeDir, ".local", "share", "chezmoi"))
-        env.Setenv("CHEZMOISTATEDIR", path.Join(absSlashHomeDir, ".local", "state", "chezmoi"))
+	env.Setenv("CHEZMOISTATEDIR", path.Join(absSlashHomeDir, ".local", "state", "chezmoi"))
 	env.Setenv("CHEZMOI_GITHUB_TOKEN", os.Getenv("CHEZMOI_GITHUB_TOKEN"))
 
 	switch runtime.GOOS {

--- a/internal/cmd/testdata/scripts/applystate.txtar
+++ b/internal/cmd/testdata/scripts/applystate.txtar
@@ -4,8 +4,8 @@ mksourcedir
 
 # test that chezmoi apply does not modify the state if nothing needs to be done
 exec chezmoi apply --force
-exec sha256sum $CHEZMOICONFIGDIR/chezmoistate.boltdb
+exec sha256sum $CHEZMOISTATEDIR/chezmoistate.boltdb
 cp stdout chezmoistate.boltdb-sha256-pre-apply
 exec chezmoi apply --force
-exec sha256sum $CHEZMOICONFIGDIR/chezmoistate.boltdb
+exec sha256sum $CHEZMOISTATEDIR/chezmoistate.boltdb
 cmp stdout chezmoistate.boltdb-sha256-pre-apply

--- a/internal/cmd/testdata/scripts/edgecasesumask.txtar
+++ b/internal/cmd/testdata/scripts/edgecasesumask.txtar
@@ -4,12 +4,12 @@ mkhomedir
 
 # test that chezmoi add --dry-run does not modify anything
 exec chezmoi add --dry-run $HOME${/}.file
-! exists $CHEZMOICONFIGDIR/chezmoistate.boltdb
+! exists $CHEZMOISTATEDIR/chezmoistate.boltdb
 ! exists $CHEZMOISOURCEDIR/dot_file
 
 # test that chezmoi add updates the persistent state
 exec chezmoi add $HOME${/}.file
-exists $CHEZMOICONFIGDIR/chezmoistate.boltdb
+exists $CHEZMOISTATEDIR/chezmoistate.boltdb
 exists $CHEZMOISOURCEDIR/dot_file
 exec chezmoi state dump
 stdout 634a4dd193c7b3b926d2e08026aa81a416fd41cec52854863b974af422495663 # sha256sum of "# contents of .file\n"

--- a/internal/cmd/testdata/scripts/initconfig.txtar
+++ b/internal/cmd/testdata/scripts/initconfig.txtar
@@ -30,8 +30,8 @@ exec chezmoi status
 ! stdout .
 ! stderr .
 
-# check that the state file was written into the default config dir
-exists $CHEZMOICONFIGDIR/chezmoistate.boltdb
+# check that the state file was written into the default state dir
+exists $CHEZMOISTATEDIR/chezmoistate.boltdb
 
 chhome home2/user
 
@@ -64,12 +64,8 @@ exec chezmoi --config=$HOME/.chezmoi/athome.toml status
 ! stdout .
 ! stderr .
 
-# check that the state file was written next to the config file
-exists $HOME/.chezmoi/chezmoistate.boltdb
-
 # check that nothing was ever written into the default config dir
 ! exists $CHEZMOICONFIGDIR/chezmoi.toml
-! exists $CHEZMOICONFIGDIR/chezmoistate.boltdb
 
 chhome home3/user
 
@@ -101,12 +97,8 @@ exec chezmoi --config=$HOME/.chezmoi/athome.txt --config-format=toml status
 ! stdout .
 ! stderr .
 
-# check that the state file was written next to the config file
-exists $HOME/.chezmoi/chezmoistate.boltdb
-
 # check that nothing was ever written into the default config dir
 ! exists $CHEZMOICONFIGDIR/chezmoi.toml
-! exists $CHEZMOICONFIGDIR/chezmoistate.boltdb
 
 -- golden/chezmoi1.yaml --
 data:

--- a/internal/cmd/testdata/scripts/state_unix.txtar
+++ b/internal/cmd/testdata/scripts/state_unix.txtar
@@ -3,11 +3,11 @@
 # test that the persistent state is only created on demand
 exec chezmoi state dump --format=yaml
 cmp stdout golden/dump.yaml
-! exists $CHEZMOICONFIGDIR/chezmoistate.boltdb
+! exists $CHEZMOISTATEDIR/chezmoistate.boltdb
 
 # test that chezmoi apply updates the persistent state
 exec chezmoi apply --force
-exists $CHEZMOICONFIGDIR/chezmoistate.boltdb
+exists $CHEZMOISTATEDIR/chezmoistate.boltdb
 
 # test that the persistent state records that script was run
 exec chezmoi state dump --format=yaml
@@ -25,15 +25,15 @@ exec chezmoi state dump --format=yaml
 
 # test that chezmoi state reset removes the persistent state
 exec chezmoi --force state reset
-! exists $CHEZMOICONFIGDIR/chezmoistate.boltdb
+! exists $CHEZMOISTATEDIR/chezmoistate.boltdb
 
 # test that the --persistent-state option sets the persistent state file
 exec chezmoi apply --force
 stdout script
-exec chezmoi apply --force --persistent-state=$CHEZMOICONFIGDIR${/}chezmoistate2.boltdb
-exists $CHEZMOICONFIGDIR${/}chezmoistate2.boltdb
+exec chezmoi apply --force --persistent-state=$CHEZMOISTATEDIR${/}chezmoistate2.boltdb
+exists $CHEZMOISTATEDIR${/}chezmoistate2.boltdb
 stdout script
-exec chezmoi state dump --format=yaml --persistent-state=$CHEZMOICONFIGDIR${/}chezmoistate2.boltdb
+exec chezmoi state dump --format=yaml --persistent-state=$CHEZMOISTATEDIR${/}chezmoistate2.boltdb
 stdout 70396a619400b7f78dbb83ab8ddb76ffe0b8e31557e64bab2ca9677818a52135:
 stdout runAt:
 

--- a/internal/cmd/testdata/scripts/state_windows.txtar
+++ b/internal/cmd/testdata/scripts/state_windows.txtar
@@ -3,11 +3,11 @@
 # test that the persistent state is only created on demand
 exec chezmoi state dump --format=yaml
 cmp stdout golden/dump.yaml
-! exists $CHEZMOICONFIGDIR/chezmoistate.boltdb
+! exists $CHEZMOISTATEDIR/chezmoistate.boltdb
 
 # test that chezmoi apply updates the persistent state
 exec chezmoi apply --force
-exists $CHEZMOICONFIGDIR/chezmoistate.boltdb
+exists $CHEZMOISTATEDIR/chezmoistate.boltdb
 
 # test that the persistent state records that script was run
 exec chezmoi state dump --format=yaml
@@ -16,7 +16,7 @@ stdout runAt:
 
 # test that chezmoi state reset removes the persistent state
 exec chezmoi --force state reset
-! exists $CHEZMOICONFIGDIR/chezmoistate.boltdb
+! exists $CHEZMOISTATEDIR/chezmoistate.boltdb
 
 -- golden/dump.yaml --
 configState: {}


### PR DESCRIPTION
Hey, thanks for making Chezmoi, it's a very neat dotfile manager. I figured I'd make a PR to it, however, as there was one small thing bugging me about its compliance with the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).

As `chezmoistate.boltdb` is not actually a _config_ file, but a persistent _state_ file, it makes far more sense to move this to `XDG_STATE_HOME` by default in order to not clutter the config directory, and as per the most recent version of the spec.

> The `$XDG_STATE_HOME` contains state data that should persist between (application) restarts, but that is not important or portable enough to the user that it should be stored in `$XDG_DATA_HOME`. It may contain:
> - actions history (logs, history, recently used files, …)
> - current state of the application that can be reused on a restart (view, layout, open files, undo history, …

Tests have been adapted in order to now look for the new state directory created by Chezmoi by default, with a couple of the tests in `initconfig.txtar` removed as the state file is now completely independent of the config file location.

I hope you're happy with my contribution. Keep up the good work!