### PR TITLE
feat!: switch to adrg/xdg library over go-xdg

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,6 @@ require (
 	github.com/twpayne/go-pinentry v0.3.0
 	github.com/twpayne/go-shell v0.4.0
 	github.com/twpayne/go-vfs/v5 v5.0.1
-	github.com/twpayne/go-xdg/v6 v6.1.2
 	github.com/ulikunitz/xz v0.5.11
 	github.com/withfig/autocomplete-tools/integrations/cobra v1.2.1
 	github.com/zalando/go-keyring v0.2.3
@@ -69,6 +68,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.2.1 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/ProtonMail/go-crypto v1.0.0 // indirect
+	github.com/adrg/xdg v0.4.0 // indirect
 	github.com/alecthomas/chroma v0.10.0 // indirect
 	github.com/alecthomas/repr v0.3.0 // indirect
 	github.com/alessio/shellescape v1.4.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/ProtonMail/go-crypto v1.0.0 h1:LRuvITjQWX+WIfr930YHG2HNfjR1uOfyf5vE0k
 github.com/ProtonMail/go-crypto v1.0.0/go.mod h1:EjAoLdwvbIOoOQr3ihjnSoLZRtE8azugULFRteWMNc0=
 github.com/Shopify/ejson v1.4.1 h1:zGGojGJNTdIWza/kOT8gd2HKCg3ZkSi3CZ1ZX70NHsw=
 github.com/Shopify/ejson v1.4.1/go.mod h1:VZMUtDzvBW/PAXRUF5fzp1ffb1ucT8MztrZXXLYZurw=
+github.com/adrg/xdg v0.4.0 h1:RzRqFcjH4nE5C6oTAxhBtoE2IRyjBSa62SCbyPidvls=
+github.com/adrg/xdg v0.4.0/go.mod h1:N6ag73EX4wyxeaoeHctc1mas01KZgsj5tYiAIwqJE/E=
 github.com/alecthomas/assert/v2 v2.5.0 h1:OJKYg53BQx06/bMRBSPDCO49CbCDNiUQXwdoNrt6x5w=
 github.com/alecthomas/assert/v2 v2.5.0/go.mod h1:fw5suVxB+wfYJ3291t0hRTqtGzFYdSwstnRQdaQx2DM=
 github.com/alecthomas/chroma v0.10.0 h1:7XDcGkCQopCNKjZHfYrNLraA+M7e0fMiJ/Mfikbfjek=
@@ -433,8 +435,6 @@ github.com/twpayne/go-vfs/v4 v4.3.0 h1:rTqFzzOQ/6ESKTSiwVubHlCBedJDOhQyVSnw8rQNZ
 github.com/twpayne/go-vfs/v4 v4.3.0/go.mod h1:tq2UVhnUepesc0lSnPJH/jQ8HruGhzwZe2r5kDFpEIw=
 github.com/twpayne/go-vfs/v5 v5.0.1 h1:5g2H6D/r4BlukZn21ysaPqracmsNb2lRCoiJt55tjqk=
 github.com/twpayne/go-vfs/v5 v5.0.1/go.mod h1:x4tZII+nP25/KlZ2lTPXxnTiS1ZSE10yNJ/mGiBoR8s=
-github.com/twpayne/go-xdg/v6 v6.1.2 h1:KbfCsAP4bBR5+dzfTIh/M9onOPCSqlYsIER79IKwt+s=
-github.com/twpayne/go-xdg/v6 v6.1.2/go.mod h1:BFHclQaEPLq3jRRYjf1PdFzUEvAfPeLjNymIO/7/7o4=
 github.com/ulikunitz/xz v0.5.11 h1:kpFauv27b6ynzBNT/Xy+1k+fK4WswhN/6PN5WhFAGw8=
 github.com/ulikunitz/xz v0.5.11/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/urfave/cli v1.22.4 h1:u7tSpNPPswAFymm8IehJhy4uJMlUuU/GmqSkvJ1InXA=
@@ -513,6 +513,7 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220204135822-1c1b9b1eba6a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/cmd/config_test.go
+++ b/internal/cmd/config_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/alecthomas/assert/v2"
 	vfs "github.com/twpayne/go-vfs/v5"
-	xdg "github.com/twpayne/go-xdg/v6"
 
 	"github.com/twpayne/chezmoi/v2/internal/chezmoi"
 	"github.com/twpayne/chezmoi/v2/internal/chezmoitest"
@@ -249,16 +248,14 @@ func withTestUser(t *testing.T, username string) configOption {
 		config.SourceDirAbsPath = config.homeDirAbsPath.JoinString(".local", "share", "chezmoi")
 		config.DestDirAbsPath = config.homeDirAbsPath
 		config.Umask = 0o22
-		configHome := filepath.Join(config.homeDir, ".config")
-		dataHome := filepath.Join(config.homeDir, ".local", "share")
-		config.bds = &xdg.BaseDirectorySpecification{
-			ConfigHome: configHome,
-			ConfigDirs: []string{configHome},
-			DataHome:   dataHome,
-			DataDirs:   []string{dataHome},
-			CacheHome:  filepath.Join(config.homeDir, ".cache"),
-			RuntimeDir: filepath.Join(config.homeDir, ".run"),
-		}
+
+		config.xdgConfigHome = filepath.Join(config.homeDir, ".config")
+		config.xdgConfigDirs = []string{config.xdgConfigHome}
+		config.xdgDataHome = filepath.Join(config.homeDir, ".local", "share")
+		config.xdgDataDirs = []string{config.xdgDataHome}
+		config.xdgCacheHome = filepath.Join(config.homeDir, ".cache")
+		config.xdgRuntimeDir = filepath.Join(config.homeDir, ".run")
+
 		return nil
 	}
 }

--- a/internal/cmd/doctorcmd.go
+++ b/internal/cmd/doctorcmd.go
@@ -18,11 +18,11 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/adrg/xdg"
 	"github.com/coreos/go-semver/semver"
 	"github.com/google/go-github/v58/github"
 	"github.com/spf13/cobra"
 	"github.com/twpayne/go-shell"
-	"github.com/twpayne/go-xdg/v6"
 
 	"github.com/twpayne/chezmoi/v2/internal/chezmoi"
 	"github.com/twpayne/chezmoi/v2/internal/chezmoilog"
@@ -89,7 +89,6 @@ type binaryCheck struct {
 // readable.
 type configFileCheck struct {
 	basename chezmoi.RelPath
-	bds      *xdg.BaseDirectorySpecification
 	expected chezmoi.AbsPath
 }
 
@@ -190,7 +189,6 @@ func (c *Config) runDoctorCmd(cmd *cobra.Command, args []string) error {
 		upgradeMethodCheck{},
 		&configFileCheck{
 			basename: chezmoiRelPath,
-			bds:      c.bds,
 			expected: c.getConfigFileAbsPath(),
 		},
 		&dirCheck{
@@ -512,7 +510,7 @@ func (c *configFileCheck) Name() string {
 
 func (c *configFileCheck) Run(system chezmoi.System, homeDirAbsPath chezmoi.AbsPath) (checkResult, string) {
 	filenameAbsPaths := make(map[chezmoi.AbsPath]struct{})
-	for _, dir := range append([]string{c.bds.ConfigHome}, c.bds.ConfigDirs...) {
+	for _, dir := range append([]string{xdg.ConfigHome}, xdg.ConfigDirs...) {
 		configDirAbsPath, err := chezmoi.NewAbsPathFromExtPath(dir, homeDirAbsPath)
 		if err != nil {
 			return checkResultFailed, err.Error()

--- a/internal/cmd/mackupcmd_darwin.go
+++ b/internal/cmd/mackupcmd_darwin.go
@@ -91,7 +91,7 @@ func (c *Config) runMackupAddCmd(cmd *cobra.Command, args []string, sourceState 
 			addArg := c.DestDirAbsPath.Join(filename)
 			addArgs = append(addArgs, addArg.String())
 		}
-		configHomeAbsPath := chezmoi.NewAbsPath(c.bds.ConfigHome)
+		configHomeAbsPath := chezmoi.NewAbsPath(c.xdgConfigHome)
 		for _, filename := range config.XDGConfigurationFiles {
 			addArg := configHomeAbsPath.Join(filename)
 			addArgs = append(addArgs, addArg.String())


### PR DESCRIPTION
Concerns were brought up in #3528 regarding the use of Unix-like XDGBDS paths on systems such as Windows and macOS, which use alternative schemes such as `%APPDATA%` etc. and `~/Library/Preferences` etc.

As requested in https://github.com/twpayne/chezmoi/discussions/2673#discussioncomment-8337931, this PR aims to address those concerns by switching to a library [known to provide these alternative paths](https://github.com/adrg/xdg) on such systems with their own scheme, rather than the in-house solution `go-xdg` which falls back exclusively onto the XDGBDS defaults while ignoring alternative schemes.

WIP: A migration path will probably need to be considered for existing users making use of the XDG defaults on systems such as Windows. Also, tests need to be adapted for Windows and macOS.