### PR TITLE
fix: Fix age/rage check in doctor command

### DIFF
--- a/internal/cmd/doctorcmd.go
+++ b/internal/cmd/doctorcmd.go
@@ -266,7 +266,7 @@ func (c *Config) runDoctorCmd(cmd *cobra.Command, args []string) error {
 		&binaryCheck{
 			name:        "age-command",
 			binaryname:  c.Age.Command,
-			versionArgs: []string{"-version"},
+			versionArgs: []string{"--version"},
 			versionRx:   regexp.MustCompile(`(\d+\.\d+\.\d+\S*)`),
 			ifNotSet:    checkResultWarning,
 			ifNotExist:  checkResultInfo,


### PR DESCRIPTION
<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer/contributing-changes/

-->
This is a very small PR.

The larger context of this PR is in #3551. In short, `chezmoi doctor` tries to pass `-version` to `rage` during checks. While `-version` works fine for `age`, it is not supported in `rage`.

Given that both `age` and `rage` support `--version`, this PR changes the flag passed during `chezmoi doctor` checks.


Fixes #3551.
