### PR TITLE
feat: 1Password Secrets Automation Support

### DIFF
--- a/assets/chezmoi.io/docs/reference/configuration-file/variables.md.yaml
+++ b/assets/chezmoi.io/docs/reference/configuration-file/variables.md.yaml
@@ -329,6 +329,9 @@ sections:
       type: bool
       default: '`true`'
       description: Prompt for sign-in when no valid session is available
+    mode:
+      default: '`account`'
+      description: See [1Password Secrets Automation](../../user-guide/password-managers/1password.md#secrets-automation)
   pass:
     command:
       default: '`pass`'

--- a/assets/chezmoi.io/docs/reference/templates/1password-functions/index.md
+++ b/assets/chezmoi.io/docs/reference/templates/1password-functions/index.md
@@ -4,16 +4,14 @@ The `onepassword*` template functions return structured data from
 [1Password](https://1password.com/) using the [1Password
 CLI](https://developer.1password.com/docs/cli) (`op`).
 
-!!! warning
+!!! info
 
-    When using the 1Password CLI with biometric authentication, account
-    shorthand names are not available. In order to assist with this, chezmoi
-    supports multiple derived values from `op account list` that can be changed
-    into the appropriate 1Password *account-uuid*.
+    When using the 1Password CLI with biometric authentication, chezmoi derives
+    values from `op account list` that can resolves into the appropriate
+    1Password *account-uuid*.
 
-    ### Example
-
-    If `op account list --format=json` returns the following structure:
+    As an example, if `op account list --format=json` returns the following
+    structure:
 
     ```json
     [
@@ -44,3 +42,11 @@ CLI](https://developer.1password.com/docs/cli) (`op`).
     `account1.1password.ca` will not be a valid lookup value, but `my@account1`,
     `my@account1.1password.ca`, `your@account1`, and
     `your@account1.1password.ca` would all be valid lookups.
+
+!!! warning
+
+    Chezmoi has experimental support for [1Password secrets
+    automation](../../user-guide/password-managers/1password.md#secrets-automation)
+    modes. These modes change how the 1Password CLI works and affect all
+    functions. Most notably, `account` parameters are not allowed on all
+    1Password template functions.

--- a/assets/chezmoi.io/docs/reference/templates/1password-functions/onepassword.md
+++ b/assets/chezmoi.io/docs/reference/templates/1password-functions/onepassword.md
@@ -1,4 +1,4 @@
-# `onepassword` *uuid* [*vault-uuid* [*account-name*]]
+# `onepassword` *uuid* [*vault* [*account*]]
 
 `onepassword` returns structured data from [1Password](https://1password.com/)
 using the [1Password
@@ -6,8 +6,8 @@ CLI](https://support.1password.com/command-line-getting-started/) (`op`).
 *uuid* is passed to `op item get $UUID --format json` and the output from `op`
 is parsed as JSON. The output from `op` is cached so calling `onepassword`
 multiple times with the same *uuid* will only invoke `op` once. If the optional
-*vault-uuid* is supplied, it will be passed along to the `op item get` call,
-which can significantly improve performance. If the optional *account-name* is
+*vault* is supplied, it will be passed along to the `op item get` call,
+which can significantly improve performance. If the optional *account* is
 supplied, it will be passed along to the `op item get` call, which will help it
 look in the right account, in case you have multiple accounts (e.g., personal
 and work accounts).
@@ -38,13 +38,8 @@ config variable.
     {{ end }}
     ```
 
-    !!! info
+!!! warning
 
-        For 1Password CLI 1.x.
-
-        ```
-        {{ (onepassword "$UUID").details.password }}
-        {{ (onepassword "$UUID" "$VAULT_UUID").details.password }}
-        {{ (onepassword "$UUID" "$VAULT_UUID" "$ACCOUNT_NAME").details.password }}
-        {{ (onepassword "$UUID" "" "$ACCOUNT_NAME").details.password }}
-        ```
+    When using [1Password secrets
+    automation](../../user-guide/password-managers/1password.md#secrets-automation),
+    the *account* parameter is not allowed.

--- a/assets/chezmoi.io/docs/reference/templates/1password-functions/onepasswordDetailsFields.md
+++ b/assets/chezmoi.io/docs/reference/templates/1password-functions/onepasswordDetailsFields.md
@@ -1,4 +1,4 @@
-# `onepasswordDetailsFields` *uuid* [*vault-uuid* [*account-name*]]
+# `onepasswordDetailsFields` *uuid* [*vault* [*account*]]
 
 `onepasswordDetailsFields` returns structured data from
 [1Password](https://1password.com/) using the [1Password
@@ -12,8 +12,8 @@ interactively prompted to sign in.
 
 The output from `op` is cached so calling `onepasswordDetailsFields` multiple
 times with the same *uuid* will only invoke `op` once. If the optional
-*vault-uuid* is supplied, it will be passed along to the `op get` call, which
-can significantly improve performance. If the optional _account-name_ is
+*vault* is supplied, it will be passed along to the `op get` call, which
+can significantly improve performance. If the optional _account_ is
 supplied, it will be passed along to the `op get` call, which will help it look
 in the right account, in case you have multiple accounts (e.g. personal and work
 accounts).
@@ -71,3 +71,10 @@ accounts).
         }
     }
     ```
+
+
+!!! warning
+
+    When using [1Password secrets
+    automation](../../user-guide/password-managers/1password.md#secrets-automation),
+    the *account* parameter is not allowed.

--- a/assets/chezmoi.io/docs/reference/templates/1password-functions/onepasswordDocument.md
+++ b/assets/chezmoi.io/docs/reference/templates/1password-functions/onepasswordDocument.md
@@ -1,13 +1,13 @@
-# `onepasswordDocument` *uuid* [*vault-uuid* [*account-name*]]
+# `onepasswordDocument` *uuid* [*vault* [*account*]]
 
 `onepasswordDocument` returns a document from
 [1Password](https://1password.com/) using the [1Password
 CLI](https://developer.1password.com/docs/cli) (`op`). *uuid* is passed to `op
 get document $UUID` and the output from `op` is returned. The output from `op`
 is cached so calling `onepasswordDocument` multiple times with the same *uuid*
-will only invoke `op` once. If the optional *vault-uuid* is supplied, it will be
+will only invoke `op` once. If the optional *vault* is supplied, it will be
 passed along to the `op get` call, which can significantly improve performance.
-If the optional _account-name_ is supplied, it will be passed along to the `op
+If the optional _account_ is supplied, it will be passed along to the `op
 get` call, which will help it look in the right account, in case you have
 multiple accounts (e.g., personal and work accounts).
 
@@ -22,3 +22,13 @@ interactively prompted to sign in.
     {{- onepasswordDocument "$UUID" "$VAULT_UUID" "$ACCOUNT_NAME" -}}
     {{- onepasswordDocument "$UUID" "" "$ACCOUNT_NAME" -}}
     ```
+
+!!! warning
+
+    When using [1Password Connect](../../user-guide/password-managers/1password.md#1password-connect), `onepasswordDocument` is not available.
+
+!!! warning
+
+    When using [1Password Service
+    Accounts](../../user-guide/password-managers/1password.md#1password-service-accounts),
+    the *account* parameter is not allowed.

--- a/assets/chezmoi.io/docs/reference/templates/1password-functions/onepasswordItemFields.md
+++ b/assets/chezmoi.io/docs/reference/templates/1password-functions/onepasswordItemFields.md
@@ -1,4 +1,4 @@
-# `onepasswordItemFields` *uuid* [*vault-uuid* [*account-name*]]
+# `onepasswordItemFields` *uuid* [*vault* [*account*]]
 
 `onepasswordItemFields` returns structured data from
 [1Password](https://1password.com/) using the [1Password
@@ -72,45 +72,8 @@ interactively prompted to sign in.
     }
     ```
 
-    !!! info
+!!! warning
 
-        For 1Password CLI 1.x, the output is this:
-
-        ```json
-        {
-            "uuid": "$UUID",
-            "details": {
-                "sections": [
-                    {
-                        "name": "linked items",
-                        "title": "Related Items"
-                    },
-                    {
-                        "fields": [
-                            {
-                                "k": "string",
-                                "n": "D4328E0846D2461E8E455D7A07B93397",
-                                "t": "exampleLabel",
-                                "v": "exampleValue"
-                            }
-                          ],
-                        "name": "Section_20E0BD380789477D8904F830BFE8A121",
-                        "title": ""
-                    }
-                ]
-            },
-        }
-        ```
-
-        the return value of `onepasswordItemFields` will be the map:
-
-        ```json
-        {
-            "exampleLabel": {
-                "k": "string",
-                "n": "D4328E0846D2461E8E455D7A07B93397",
-                "t": "exampleLabel",
-                "v": "exampleValue"
-            }
-        }
-        ```
+    When using [1Password secrets
+    automation](../../user-guide/password-managers/1password.md#secrets-automation),
+    the *account* parameter is not allowed.

--- a/assets/chezmoi.io/docs/reference/templates/1password-functions/onepasswordRead.md
+++ b/assets/chezmoi.io/docs/reference/templates/1password-functions/onepasswordRead.md
@@ -21,3 +21,9 @@ interactively prompted to sign in.
     ```console
     $ op read --no-newline op://vault/item/field
     ```
+
+!!! warning
+
+    When using [1Password secrets
+    automation](../../user-guide/password-managers/1password.md#secrets-automation),
+    the *account* parameter is not allowed.

--- a/assets/chezmoi.io/docs/user-guide/password-managers/1password.md
+++ b/assets/chezmoi.io/docs/user-guide/password-managers/1password.md
@@ -32,9 +32,9 @@ Documents can be retrieved with:
 {{- onepasswordDocument "$UUID" -}}
 ```
 
-The output of `op item get $UUID--format json` (`op get item $UUID`) is
-available as the `onepassword` template function. chezmoi parses the JSON output
-and returns it as structured data. For example, if the output is:
+The output of `op item get $UUID --format json` is available as the
+`onepassword` template function. chezmoi parses the JSON output and returns it
+as structured data. For example, if the output is:
 
 ```json
 {
@@ -93,25 +93,6 @@ or:
 {{ end }}
 ```
 
-!!! info
-
-    1Password CLI 1.x returns a simpler structure:
-
-    ```json
-    {
-      "uuid": "$UUID",
-      "details": {
-        "password": "$PASSWORD"
-      }
-    }
-    ```
-
-    This allows for the syntax:
-
-    ```
-    {{ (onepassword "$UUID").details.password }}
-    ```
-
 `onepasswordDetailsFields` returns a reworked version of the structure that
 allows the fields to be queried by key:
 
@@ -146,15 +127,9 @@ Additional fields may be obtained with `onepasswordItemFields`; not all objects
 in 1Password have item fields. This can be tested with:
 
 ```console
-$ chezmoi execute-template "{{ onepasswordItemFields \"$UUID\" | toJson }}" | jq .
+$ chezmoi execute-template "{{ onepasswordItemFields \"$UUID\" | toJson }}" | \
+    jq .
 ```
-
-!!! note
-
-    The extra `-` after the opening `{{` and before the closing `}}` instructs
-    the template language to remove any whitespace before and after the
-    substitution. This removes any trailing newline added by your editor when
-    saving the template.
 
 ## Sign-in prompt
 
@@ -162,7 +137,7 @@ chezmoi will verify the availability and validity of a session token in the
 current environment. If it is missing or expired, you will be interactively
 prompted to sign-in again.
 
-In the past chezmoi used to simply exit with an error when no valid session was
+In the past chezmoi used to exit with an error when no valid session was
 available. If you'd like to restore this behavior, set the `onepassword.prompt`
 configuration variable to `false`, for example:
 
@@ -173,6 +148,71 @@ configuration variable to `false`, for example:
 
 !!! danger
 
-    Do not use prompt on shared machines. A session token verified or acquired
+    Do not use `prompt` on shared machines. A session token verified or acquired
     interactively will be passed to the 1Password CLI through a command line
     parameter, which is visible to other users of the same system.
+
+## Secrets Automation
+
+chezmoi has experimental support for secrets automation with [1Password
+Connect](https://developer.1password.com/docs/connect/) and [1Password Service
+Accounts](https://developer.1password.com/docs/service-accounts). These might be
+used on restricted machines where you cannot or do not wish to install a full
+1Password desktop application.
+
+When these features are used, the behavior of the 1Password CLI changes, so
+chezmoi requires explicit configuration for either connect or service account
+modes using the `onepassword.mode` configuration option. The default, if not
+specified, is `account`:
+
+```toml title="~/.config/chezmoi/chezmoi.toml"
+[onepassword]
+    mode = "account"
+```
+
+In `account` mode, chezmoi will stop with an error if the environment variable
+`OP_SERVICE_ACCOUNT_TOKEN` is set, or if both environment variables
+`OP_CONNECT_HOST` and `OP_CONNECT_TOKEN` are set.
+
+!!! info
+
+    Both 1Password Connect and Service Accounts prevent the CLI from working
+    with multiple accounts. If you need access to secrets from more than one
+    1Password account, do not use these features with chezmoi.
+
+### 1Password Connect
+
+Once 1Password Connect is
+[configured](https://developer.1password.com/docs/connect/connect-cli#requirements),
+and `OP_CONNECT_HOST` and `OP_CONNECT_TOKEN` are properly set, set
+`onepassword.mode` to `connect`.
+
+```toml title="~/.config/chezmoi/chezmoi.toml"
+[onepassword]
+    mode = "connect"
+```
+
+In `connect` mode:
+
+- the `onepasswordDocument` template function is not available,
+- `account` parameters are not allowed in 1Password template functions,
+- chezmoi will stop with an error if one or both of `OP_CONNECT_HOST` and
+  `OP_CONNECT_TOKEN` are unset, or if `OP_SERVICE_ACCOUNT_TOKEN` is set.
+
+### 1Password Service Accounts
+
+Once a 1Password service account has been
+[created](https://developer.1password.com/docs/service-accounts/use-with-1password-cli/#requirements)
+and `OP_SERVICE_ACCOUNT_TOKEN` is properly set, set `onepassword.mode` to
+`service`.
+
+```toml title="~/.config/chezmoi/chezmoi.toml"
+[onepassword]
+    mode = "service"
+```
+
+In `service` mode:
+
+- `account` parameters are not allowed in 1Password template functions,
+- chezmoi will stop with an error if `OP_SERVICE_ACCOUNT_TOKEN` is unset, or if
+  both of `OP_CONNECT_HOST` and `OP_CONNECT_TOKEN` are set.

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -2700,6 +2700,7 @@ func newConfigFile(bds *xdg.BaseDirectorySpecification) ConfigFile {
 		Onepassword: onepasswordConfig{
 			Command: "op",
 			Prompt:  true,
+			Mode:    onepasswordModeAccount,
 		},
 		Pass: passConfig{
 			Command: "pass",

--- a/internal/cmd/testdata/scripts/onepassword2.txtar
+++ b/internal/cmd/testdata/scripts/onepassword2.txtar
@@ -33,58 +33,139 @@ stdout exampleField
 exec chezmoi execute-template '{{ onepasswordRead "op://vault/item/field" "account" }}'
 stdout exampleAccountField
 
+# test onepasswordDocument template function
+exec chezmoi execute-template '{{ onepasswordDocument "exampleDocument" }}'
+stdout 'OK-COMPUTER'
+
+# test onepasswordDocument template function with vault
+exec chezmoi execute-template '{{ onepasswordDocument "exampleDocument" "vault" }}'
+stdout 'OK-VAULT'
+
+# test onepasswordDocument template function with vault and account
+exec chezmoi execute-template '{{ onepasswordDocument "exampleDocument" "vault" "account" }}'
+stdout 'OK-VAULT-ACCOUNT'
+
+# test onepasswordDocument template function with account
+exec chezmoi execute-template '{{ onepasswordDocument "exampleDocument" "" "account" }}'
+stdout 'OK-ACCOUNT'
+
+# test onepassword template function (insufficient parameters)
+! exec chezmoi execute-template '{{ (onepassword).id }}'
+stderr 'expected 1..3 arguments in account mode, got 0'
+
+# test onepassword template function (too many parameters)
+! exec chezmoi execute-template '{{ (onepassword "ExampleLogin" "vault" "account" "extra").id }}'
+stderr 'expected 1..3 arguments in account mode, got 4'
+
+# test onepasswordRead template function (too many parameters)
+! exec chezmoi execute-template '{{ onepasswordRead "op://vault/item/field" "account" "extra" }}'
+stderr 'expected 1..2 arguments, got 3'
+
+# test failure with OP_SERVICE_ACCOUNT_TOKEN set
+env OP_SERVICE_ACCOUNT_TOKEN=x
+! exec chezmoi execute-template '{{ (onepassword "ExampleLogin").id }}'
+stderr 'OP_SERVICE_ACCOUNT_TOKEN is set'
+
+# test failure with OP_CONNECT_HOST and OP_CONNECT_TOKEN set
+env OP_SERVICE_ACCOUNT_TOKEN=
+env OP_CONNECT_HOST=x
+env OP_CONNECT_TOKEN=y
+! exec chezmoi execute-template '{{ (onepassword "ExampleLogin").id }}'
+stderr 'OP_CONNECT_HOST and OP_CONNECT_TOKEN'
+
 -- bin/op --
 #!/bin/sh
 
-case "$*" in
-"--version")
+if [ "$*" = "--version" ]; then
     echo 2.0.0
-    ;;
-"item get --format json ExampleLogin" | "item get --format json ExampleLogin --vault vault --account account_uuid" | "--session thisIsAFakeSessionToken item get --format json ExampleLogin" | "--session thisIsAFakeSessionToken item get --format json ExampleLogin --vault vault --account account_uuid" | "--session thisIsAFakeSessionToken item get --format json ExampleLogin --account account_uuid")
+elif [ "$*" = "item get --format json ExampleLogin --vault vault --account account_uuid" ]; then
     echo '{"id":"wxcplh5udshnonkzg2n4qx262y","title":"ExampleLogin","version":1,"vault":{"id":"tscpxgi6s7c662jtqn3vmw4n5a"},"category":"LOGIN","last_edited_by":"YO4UTYPAD3ZFBNZG5DVAZFBNZM","created_at":"2022-01-17T01:53:50Z","updated_at":"2022-01-17T01:55:35Z","sections":[{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"}],"fields":[{"id":"username","type":"STRING","purpose":"USERNAME","label":"username","value":"exampleuser "},{"id":"password","type":"CONCEALED","purpose":"PASSWORD","label":"password","value":"L8rm1JXJIE1b8YUDWq7h","password_details":{"strength":"EXCELLENT"}},{"id":"notesPlain","type":"STRING","purpose":"NOTES","label":"notesPlain"},{"id":"cqn7oda7wkcsar7rzcr52i2m3u","section":{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"},"type":"STRING","label":"exampleLabel","value":"exampleValue"}],"urls":[{"primary":true,"href":"https://www.example.com/"}]}'
-    ;;
-"account list --format=json")
+elif [ "$*" = "item get --format json ExampleLogin --account account_uuid" ]; then
+    echo '{"id":"wxcplh5udshnonkzg2n4qx262y","title":"ExampleLogin","version":1,"vault":{"id":"tscpxgi6s7c662jtqn3vmw4n5a"},"category":"LOGIN","last_edited_by":"YO4UTYPAD3ZFBNZG5DVAZFBNZM","created_at":"2022-01-17T01:53:50Z","updated_at":"2022-01-17T01:55:35Z","sections":[{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"}],"fields":[{"id":"username","type":"STRING","purpose":"USERNAME","label":"username","value":"exampleuser "},{"id":"password","type":"CONCEALED","purpose":"PASSWORD","label":"password","value":"L8rm1JXJIE1b8YUDWq7h","password_details":{"strength":"EXCELLENT"}},{"id":"notesPlain","type":"STRING","purpose":"NOTES","label":"notesPlain"},{"id":"cqn7oda7wkcsar7rzcr52i2m3u","section":{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"},"type":"STRING","label":"exampleLabel","value":"exampleValue"}],"urls":[{"primary":true,"href":"https://www.example.com/"}]}'
+elif [ "$*" = "--session thisIsAFakeSessionToken item get --format json ExampleLogin --vault vault --account account_uuid" ]; then
+    echo '{"id":"wxcplh5udshnonkzg2n4qx262y","title":"ExampleLogin","version":1,"vault":{"id":"tscpxgi6s7c662jtqn3vmw4n5a"},"category":"LOGIN","last_edited_by":"YO4UTYPAD3ZFBNZG5DVAZFBNZM","created_at":"2022-01-17T01:53:50Z","updated_at":"2022-01-17T01:55:35Z","sections":[{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"}],"fields":[{"id":"username","type":"STRING","purpose":"USERNAME","label":"username","value":"exampleuser "},{"id":"password","type":"CONCEALED","purpose":"PASSWORD","label":"password","value":"L8rm1JXJIE1b8YUDWq7h","password_details":{"strength":"EXCELLENT"}},{"id":"notesPlain","type":"STRING","purpose":"NOTES","label":"notesPlain"},{"id":"cqn7oda7wkcsar7rzcr52i2m3u","section":{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"},"type":"STRING","label":"exampleLabel","value":"exampleValue"}],"urls":[{"primary":true,"href":"https://www.example.com/"}]}'
+elif [ "$*" = "--session thisIsAFakeSessionToken item get --format json ExampleLogin --account account_uuid" ]; then
+    echo '{"id":"wxcplh5udshnonkzg2n4qx262y","title":"ExampleLogin","version":1,"vault":{"id":"tscpxgi6s7c662jtqn3vmw4n5a"},"category":"LOGIN","last_edited_by":"YO4UTYPAD3ZFBNZG5DVAZFBNZM","created_at":"2022-01-17T01:53:50Z","updated_at":"2022-01-17T01:55:35Z","sections":[{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"}],"fields":[{"id":"username","type":"STRING","purpose":"USERNAME","label":"username","value":"exampleuser "},{"id":"password","type":"CONCEALED","purpose":"PASSWORD","label":"password","value":"L8rm1JXJIE1b8YUDWq7h","password_details":{"strength":"EXCELLENT"}},{"id":"notesPlain","type":"STRING","purpose":"NOTES","label":"notesPlain"},{"id":"cqn7oda7wkcsar7rzcr52i2m3u","section":{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"},"type":"STRING","label":"exampleLabel","value":"exampleValue"}],"urls":[{"primary":true,"href":"https://www.example.com/"}]}'
+elif [ "$*" = "item get --format json ExampleLogin" ]; then
+    echo '{"id":"wxcplh5udshnonkzg2n4qx262y","title":"ExampleLogin","version":1,"vault":{"id":"tscpxgi6s7c662jtqn3vmw4n5a"},"category":"LOGIN","last_edited_by":"YO4UTYPAD3ZFBNZG5DVAZFBNZM","created_at":"2022-01-17T01:53:50Z","updated_at":"2022-01-17T01:55:35Z","sections":[{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"}],"fields":[{"id":"username","type":"STRING","purpose":"USERNAME","label":"username","value":"exampleuser "},{"id":"password","type":"CONCEALED","purpose":"PASSWORD","label":"password","value":"L8rm1JXJIE1b8YUDWq7h","password_details":{"strength":"EXCELLENT"}},{"id":"notesPlain","type":"STRING","purpose":"NOTES","label":"notesPlain"},{"id":"cqn7oda7wkcsar7rzcr52i2m3u","section":{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"},"type":"STRING","label":"exampleLabel","value":"exampleValue"}],"urls":[{"primary":true,"href":"https://www.example.com/"}]}'
+elif [ "$*" = "--session thisIsAFakeSessionToken item get --format json ExampleLogin" ]; then
+    echo '{"id":"wxcplh5udshnonkzg2n4qx262y","title":"ExampleLogin","version":1,"vault":{"id":"tscpxgi6s7c662jtqn3vmw4n5a"},"category":"LOGIN","last_edited_by":"YO4UTYPAD3ZFBNZG5DVAZFBNZM","created_at":"2022-01-17T01:53:50Z","updated_at":"2022-01-17T01:55:35Z","sections":[{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"}],"fields":[{"id":"username","type":"STRING","purpose":"USERNAME","label":"username","value":"exampleuser "},{"id":"password","type":"CONCEALED","purpose":"PASSWORD","label":"password","value":"L8rm1JXJIE1b8YUDWq7h","password_details":{"strength":"EXCELLENT"}},{"id":"notesPlain","type":"STRING","purpose":"NOTES","label":"notesPlain"},{"id":"cqn7oda7wkcsar7rzcr52i2m3u","section":{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"},"type":"STRING","label":"exampleLabel","value":"exampleValue"}],"urls":[{"primary":true,"href":"https://www.example.com/"}]}'
+elif [ "$*" = "--session thisIsAFakeSessionToken item get --format json ExampleLogin --vault vault" ]; then
+    echo '{"id":"wxcplh5udshnonkzg2n4qx262y","title":"ExampleLogin","version":1,"vault":{"id":"tscpxgi6s7c662jtqn3vmw4n5a"},"category":"LOGIN","last_edited_by":"YO4UTYPAD3ZFBNZG5DVAZFBNZM","created_at":"2022-01-17T01:53:50Z","updated_at":"2022-01-17T01:55:35Z","sections":[{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"}],"fields":[{"id":"username","type":"STRING","purpose":"USERNAME","label":"username","value":"exampleuser "},{"id":"password","type":"CONCEALED","purpose":"PASSWORD","label":"password","value":"L8rm1JXJIE1b8YUDWq7h","password_details":{"strength":"EXCELLENT"}},{"id":"notesPlain","type":"STRING","purpose":"NOTES","label":"notesPlain"},{"id":"cqn7oda7wkcsar7rzcr52i2m3u","section":{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"},"type":"STRING","label":"exampleLabel","value":"exampleValue"}],"urls":[{"primary":true,"href":"https://www.example.com/"}]}'
+elif [ "$*" = "--session thisIsAFakeSessionToken item get --format json ExampleLogin" ]; then
+    echo '{"id":"wxcplh5udshnonkzg2n4qx262y","title":"ExampleLogin","version":1,"vault":{"id":"tscpxgi6s7c662jtqn3vmw4n5a"},"category":"LOGIN","last_edited_by":"YO4UTYPAD3ZFBNZG5DVAZFBNZM","created_at":"2022-01-17T01:53:50Z","updated_at":"2022-01-17T01:55:35Z","sections":[{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"}],"fields":[{"id":"username","type":"STRING","purpose":"USERNAME","label":"username","value":"exampleuser "},{"id":"password","type":"CONCEALED","purpose":"PASSWORD","label":"password","value":"L8rm1JXJIE1b8YUDWq7h","password_details":{"strength":"EXCELLENT"}},{"id":"notesPlain","type":"STRING","purpose":"NOTES","label":"notesPlain"},{"id":"cqn7oda7wkcsar7rzcr52i2m3u","section":{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"},"type":"STRING","label":"exampleLabel","value":"exampleValue"}],"urls":[{"primary":true,"href":"https://www.example.com/"}]}'
+elif [ "$*" = "account list --format=json" ]; then
     echo '[{"url":"account.1password.com","email":"chezmoi@chezmoi.org","user_uuid":"user_uuid","account_uuid":"account_uuid"}]'
-    ;;
-"signin --raw" | "signin --account account_uuid --raw")
+elif [ "$*" = "signin --account account_uuid --raw" ]; then
     echo 'thisIsAFakeSessionToken'
-    ;;
-"--session thisIsAFakeSessionToken read --no-newline op://vault/item/field")
+elif [ "$*" = "signin --raw" ]; then
+    echo 'thisIsAFakeSessionToken'
+elif [ "$*" = "read --no-newline op://vault/item/field" ]; then
     echo 'exampleField'
-    ;;
-"--session thisIsAFakeSessionToken read --no-newline op://vault/item/field --account account_uuid")
+elif [ "$*" = "--session thisIsAFakeSessionToken read --no-newline op://vault/item/field" ]; then
+    echo 'exampleField'
+elif [ "$*" = "--session thisIsAFakeSessionToken read --no-newline op://vault/item/field --account account_uuid" ]; then
     echo 'exampleAccountField'
-    ;;
-*)
+elif [ "$*" = "document get exampleDocument" ]; then
+    echo 'OK-COMPUTER'
+elif [ "$*" = "document get exampleDocument --vault vault" ]; then
+    echo 'OK-VAULT'
+elif [ "$*" = "--session thisIsAFakeSessionToken document get exampleDocument" ]; then
+    echo 'OK-COMPUTER'
+elif [ "$*" = "--session thisIsAFakeSessionToken document get exampleDocument --vault vault" ]; then
+    echo 'OK-VAULT'
+elif [ "$*" = "--session thisIsAFakeSessionToken document get exampleDocument --account account_uuid" ]; then
+    echo 'OK-ACCOUNT'
+elif [ "$*" = "--session thisIsAFakeSessionToken document get exampleDocument --vault vault --account account_uuid" ]; then
+    echo 'OK-VAULT-ACCOUNT'
+else
     echo [ERROR] 2020/01/01 00:00:00 unknown command \"$*\" for \"op\" 1>&2
     exit 1
-esac
+fi
 -- bin/op.cmd --
 @echo off
 IF "%*" == "--version" (
     echo 2.0.0
-) ELSE IF "%*" == "item get --format json ExampleLogin" (
-    echo.{"id":"wxcplh5udshnonkzg2n4qx262y","title":"ExampleLogin","version":1,"vault":{"id":"tscpxgi6s7c662jtqn3vmw4n5a"},"category":"LOGIN","last_edited_by":"YO4UTYPAD3ZFBNZG5DVAZFBNZM","created_at":"2022-01-17T01:53:50Z","updated_at":"2022-01-17T01:55:35Z","sections":[{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"}],"fields":[{"id":"username","type":"STRING","purpose":"USERNAME","label":"username","value":"exampleuser "},{"id":"password","type":"CONCEALED","purpose":"PASSWORD","label":"password","value":"L8rm1JXJIE1b8YUDWq7h","password_details":{"strength":"EXCELLENT"}},{"id":"notesPlain","type":"STRING","purpose":"NOTES","label":"notesPlain"},{"id":"cqn7oda7wkcsar7rzcr52i2m3u","section":{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"},"type":"STRING","label":"exampleLabel","value":"exampleValue"}],"urls":[{"primary":true,"href":"https://www.example.com/"}]}
 ) ELSE IF "%*" == "item get --format json ExampleLogin --vault vault --account account_uuid" (
     echo.{"id":"wxcplh5udshnonkzg2n4qx262y","title":"ExampleLogin","version":1,"vault":{"id":"tscpxgi6s7c662jtqn3vmw4n5a"},"category":"LOGIN","last_edited_by":"YO4UTYPAD3ZFBNZG5DVAZFBNZM","created_at":"2022-01-17T01:53:50Z","updated_at":"2022-01-17T01:55:35Z","sections":[{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"}],"fields":[{"id":"username","type":"STRING","purpose":"USERNAME","label":"username","value":"exampleuser "},{"id":"password","type":"CONCEALED","purpose":"PASSWORD","label":"password","value":"L8rm1JXJIE1b8YUDWq7h","password_details":{"strength":"EXCELLENT"}},{"id":"notesPlain","type":"STRING","purpose":"NOTES","label":"notesPlain"},{"id":"cqn7oda7wkcsar7rzcr52i2m3u","section":{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"},"type":"STRING","label":"exampleLabel","value":"exampleValue"}],"urls":[{"primary":true,"href":"https://www.example.com/"}]}
 ) ELSE IF "%*" == "item get --format json ExampleLogin --account account_uuid" (
-    echo.{"id":"wxcplh5udshnonkzg2n4qx262y","title":"ExampleLogin","version":1,"vault":{"id":"tscpxgi6s7c662jtqn3vmw4n5a"},"category":"LOGIN","last_edited_by":"YO4UTYPAD3ZFBNZG5DVAZFBNZM","created_at":"2022-01-17T01:53:50Z","updated_at":"2022-01-17T01:55:35Z","sections":[{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"}],"fields":[{"id":"username","type":"STRING","purpose":"USERNAME","label":"username","value":"exampleuser "},{"id":"password","type":"CONCEALED","purpose":"PASSWORD","label":"password","value":"L8rm1JXJIE1b8YUDWq7h","password_details":{"strength":"EXCELLENT"}},{"id":"notesPlain","type":"STRING","purpose":"NOTES","label":"notesPlain"},{"id":"cqn7oda7wkcsar7rzcr52i2m3u","section":{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"},"type":"STRING","label":"exampleLabel","value":"exampleValue"}],"urls":[{"primary":true,"href":"https://www.example.com/"}]}
-) ELSE IF "%*" == "--session thisIsAFakeSessionToken item get --format json ExampleLogin" (
     echo.{"id":"wxcplh5udshnonkzg2n4qx262y","title":"ExampleLogin","version":1,"vault":{"id":"tscpxgi6s7c662jtqn3vmw4n5a"},"category":"LOGIN","last_edited_by":"YO4UTYPAD3ZFBNZG5DVAZFBNZM","created_at":"2022-01-17T01:53:50Z","updated_at":"2022-01-17T01:55:35Z","sections":[{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"}],"fields":[{"id":"username","type":"STRING","purpose":"USERNAME","label":"username","value":"exampleuser "},{"id":"password","type":"CONCEALED","purpose":"PASSWORD","label":"password","value":"L8rm1JXJIE1b8YUDWq7h","password_details":{"strength":"EXCELLENT"}},{"id":"notesPlain","type":"STRING","purpose":"NOTES","label":"notesPlain"},{"id":"cqn7oda7wkcsar7rzcr52i2m3u","section":{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"},"type":"STRING","label":"exampleLabel","value":"exampleValue"}],"urls":[{"primary":true,"href":"https://www.example.com/"}]}
 ) ELSE IF "%*" == "--session thisIsAFakeSessionToken item get --format json ExampleLogin --vault vault --account account_uuid" (
     echo.{"id":"wxcplh5udshnonkzg2n4qx262y","title":"ExampleLogin","version":1,"vault":{"id":"tscpxgi6s7c662jtqn3vmw4n5a"},"category":"LOGIN","last_edited_by":"YO4UTYPAD3ZFBNZG5DVAZFBNZM","created_at":"2022-01-17T01:53:50Z","updated_at":"2022-01-17T01:55:35Z","sections":[{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"}],"fields":[{"id":"username","type":"STRING","purpose":"USERNAME","label":"username","value":"exampleuser "},{"id":"password","type":"CONCEALED","purpose":"PASSWORD","label":"password","value":"L8rm1JXJIE1b8YUDWq7h","password_details":{"strength":"EXCELLENT"}},{"id":"notesPlain","type":"STRING","purpose":"NOTES","label":"notesPlain"},{"id":"cqn7oda7wkcsar7rzcr52i2m3u","section":{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"},"type":"STRING","label":"exampleLabel","value":"exampleValue"}],"urls":[{"primary":true,"href":"https://www.example.com/"}]}
 ) ELSE IF "%*" == "--session thisIsAFakeSessionToken item get --format json ExampleLogin --account account_uuid" (
     echo.{"id":"wxcplh5udshnonkzg2n4qx262y","title":"ExampleLogin","version":1,"vault":{"id":"tscpxgi6s7c662jtqn3vmw4n5a"},"category":"LOGIN","last_edited_by":"YO4UTYPAD3ZFBNZG5DVAZFBNZM","created_at":"2022-01-17T01:53:50Z","updated_at":"2022-01-17T01:55:35Z","sections":[{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"}],"fields":[{"id":"username","type":"STRING","purpose":"USERNAME","label":"username","value":"exampleuser "},{"id":"password","type":"CONCEALED","purpose":"PASSWORD","label":"password","value":"L8rm1JXJIE1b8YUDWq7h","password_details":{"strength":"EXCELLENT"}},{"id":"notesPlain","type":"STRING","purpose":"NOTES","label":"notesPlain"},{"id":"cqn7oda7wkcsar7rzcr52i2m3u","section":{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"},"type":"STRING","label":"exampleLabel","value":"exampleValue"}],"urls":[{"primary":true,"href":"https://www.example.com/"}]}
+) ELSE IF "%*" == "item get --format json ExampleLogin" (
+    echo.{"id":"wxcplh5udshnonkzg2n4qx262y","title":"ExampleLogin","version":1,"vault":{"id":"tscpxgi6s7c662jtqn3vmw4n5a"},"category":"LOGIN","last_edited_by":"YO4UTYPAD3ZFBNZG5DVAZFBNZM","created_at":"2022-01-17T01:53:50Z","updated_at":"2022-01-17T01:55:35Z","sections":[{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"}],"fields":[{"id":"username","type":"STRING","purpose":"USERNAME","label":"username","value":"exampleuser "},{"id":"password","type":"CONCEALED","purpose":"PASSWORD","label":"password","value":"L8rm1JXJIE1b8YUDWq7h","password_details":{"strength":"EXCELLENT"}},{"id":"notesPlain","type":"STRING","purpose":"NOTES","label":"notesPlain"},{"id":"cqn7oda7wkcsar7rzcr52i2m3u","section":{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"},"type":"STRING","label":"exampleLabel","value":"exampleValue"}],"urls":[{"primary":true,"href":"https://www.example.com/"}]}
+) ELSE IF "%*" == "item get --format json ExampleLogin --vault vault" (
+    echo.{"id":"wxcplh5udshnonkzg2n4qx262y","title":"ExampleLogin","version":1,"vault":{"id":"tscpxgi6s7c662jtqn3vmw4n5a"},"category":"LOGIN","last_edited_by":"YO4UTYPAD3ZFBNZG5DVAZFBNZM","created_at":"2022-01-17T01:53:50Z","updated_at":"2022-01-17T01:55:35Z","sections":[{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"}],"fields":[{"id":"username","type":"STRING","purpose":"USERNAME","label":"username","value":"exampleuser "},{"id":"password","type":"CONCEALED","purpose":"PASSWORD","label":"password","value":"L8rm1JXJIE1b8YUDWq7h","password_details":{"strength":"EXCELLENT"}},{"id":"notesPlain","type":"STRING","purpose":"NOTES","label":"notesPlain"},{"id":"cqn7oda7wkcsar7rzcr52i2m3u","section":{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"},"type":"STRING","label":"exampleLabel","value":"exampleValue"}],"urls":[{"primary":true,"href":"https://www.example.com/"}]}
+) ELSE IF "%*" == "--session thisIsAFakeSessionToken item get --format json ExampleLogin --vault vault" (
+    echo.{"id":"wxcplh5udshnonkzg2n4qx262y","title":"ExampleLogin","version":1,"vault":{"id":"tscpxgi6s7c662jtqn3vmw4n5a"},"category":"LOGIN","last_edited_by":"YO4UTYPAD3ZFBNZG5DVAZFBNZM","created_at":"2022-01-17T01:53:50Z","updated_at":"2022-01-17T01:55:35Z","sections":[{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"}],"fields":[{"id":"username","type":"STRING","purpose":"USERNAME","label":"username","value":"exampleuser "},{"id":"password","type":"CONCEALED","purpose":"PASSWORD","label":"password","value":"L8rm1JXJIE1b8YUDWq7h","password_details":{"strength":"EXCELLENT"}},{"id":"notesPlain","type":"STRING","purpose":"NOTES","label":"notesPlain"},{"id":"cqn7oda7wkcsar7rzcr52i2m3u","section":{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"},"type":"STRING","label":"exampleLabel","value":"exampleValue"}],"urls":[{"primary":true,"href":"https://www.example.com/"}]}
+) ELSE IF "%*" == "--session thisIsAFakeSessionToken item get --format json ExampleLogin" (
+    echo.{"id":"wxcplh5udshnonkzg2n4qx262y","title":"ExampleLogin","version":1,"vault":{"id":"tscpxgi6s7c662jtqn3vmw4n5a"},"category":"LOGIN","last_edited_by":"YO4UTYPAD3ZFBNZG5DVAZFBNZM","created_at":"2022-01-17T01:53:50Z","updated_at":"2022-01-17T01:55:35Z","sections":[{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"}],"fields":[{"id":"username","type":"STRING","purpose":"USERNAME","label":"username","value":"exampleuser "},{"id":"password","type":"CONCEALED","purpose":"PASSWORD","label":"password","value":"L8rm1JXJIE1b8YUDWq7h","password_details":{"strength":"EXCELLENT"}},{"id":"notesPlain","type":"STRING","purpose":"NOTES","label":"notesPlain"},{"id":"cqn7oda7wkcsar7rzcr52i2m3u","section":{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"},"type":"STRING","label":"exampleLabel","value":"exampleValue"}],"urls":[{"primary":true,"href":"https://www.example.com/"}]}
 ) ELSE IF "%*" == "account list --format=json" (
     echo.[{"url":"account.1password.com","email":"chezmoi@chezmoi.org","user_uuid":"user_uuid","account_uuid":"account_uuid"}]
+) ELSE IF "%*" == "signin --account account_uuid --raw" (
+    echo thisIsAFakeSessionToken
+) ELSE IF "%*" == "signin --raw" (
+    echo thisIsAFakeSessionToken
+) ELSE IF "%*" == "document get exampleDocument" (
+    echo.OK-COMPUTER
+) ELSE IF "%*" == "document get exampleDocument --vault vault" (
+    echo.OK-VAULT
+) ELSE IF "%*" == "--session thisIsAFakeSessionToken document get exampleDocument" (
+    echo.OK-COMPUTER
+) ELSE IF "%*" == "--session thisIsAFakeSessionToken document get exampleDocument --vault vault" (
+    echo.OK-VAULT
+) ELSE IF "%*" == "--session thisIsAFakeSessionToken document get exampleDocument --account account_uuid" (
+    echo.OK-ACCOUNT
+) ELSE IF "%*" == "--session thisIsAFakeSessionToken document get exampleDocument --vault vault --account account_uuid" (
+    echo.OK-VAULT-ACCOUNT
+) ELSE IF "%*" == "read --no-newline op://vault/item/field" (
+    echo.exampleField
 ) ELSE IF "%*" == "--session thisIsAFakeSessionToken read --no-newline op://vault/item/field" (
     echo.exampleField
 ) ELSE IF "%*" == "--session thisIsAFakeSessionToken read --no-newline op://vault/item/field --account account_uuid" (
     echo.exampleAccountField
-) ELSE IF "%*" == "signin --raw" (
-    echo thisIsAFakeSessionToken
-) ELSE IF "%*" == "signin --account account_uuid --raw" (
-    echo thisIsAFakeSessionToken
 ) ELSE (
     echo.[ERROR] 2020/01/01 00:00:00 unknown command "%*" for "op" 1>&2
     exit /b 1

--- a/internal/cmd/testdata/scripts/onepassword2connect.txtar
+++ b/internal/cmd/testdata/scripts/onepassword2connect.txtar
@@ -1,0 +1,189 @@
+[unix] chmod 755 bin/op
+[windows] unix2dos bin/op.cmd
+
+mkhomedir
+
+# test that mode is properly set and reported
+exec chezmoi execute-template '{{ .chezmoi.config.onepassword.mode }}'
+stdout '^connect$'
+
+# test failure without OP_CONNECT_HOST set
+! exec chezmoi execute-template '{{ (onepassword "ExampleLogin").id }}'
+stderr 'OP_CONNECT_HOST'
+
+env OP_CONNECT_HOST=x
+
+# test failure without OP_CONNECT_TOKEN set
+! exec chezmoi execute-template '{{ (onepassword "ExampleLogin").id }}'
+stderr 'OP_CONNECT_TOKEN'
+
+env OP_CONNECT_TOKEN=y
+
+# test onepassword template function
+exec chezmoi execute-template '{{ (onepassword "ExampleLogin").id }}'
+stdout '^wxcplh5udshnonkzg2n4qx262y$'
+
+# test onepassword template function with vault
+exec chezmoi execute-template '{{ (onepassword "ExampleLogin" "vault").id }}'
+stdout '^wxcplh5udshnonkzg2n4qx262y$'
+
+# test failure onepassword template function with vault and account
+! exec chezmoi execute-template '{{ (onepassword "ExampleLogin" "vault" "account").id }}'
+stderr '1Password account parameters cannot be used in connect mode'
+
+# test onepassword template function with empty vault
+exec chezmoi execute-template '{{ (onepassword "ExampleLogin" "").id }}'
+stdout '^wxcplh5udshnonkzg2n4qx262y$'
+
+# test onepasswordDetailsFields template function
+exec chezmoi execute-template '{{ (onepasswordDetailsFields "ExampleLogin").password.value }}'
+stdout '^L8rm1JXJIE1b8YUDWq7h$'
+
+# test onepasswordItemFields template function
+exec chezmoi execute-template '{{ (onepasswordItemFields "ExampleLogin").exampleLabel.value }}'
+stdout exampleValue
+
+# test onepasswordRead template function
+exec chezmoi execute-template '{{ onepasswordRead "op://vault/item/field" }}'
+stdout exampleField
+
+# test failure onepasswordRead template function with account
+! exec chezmoi execute-template '{{ onepasswordRead "op://vault/item/field" "account" }}'
+stderr '1Password account parameters cannot be used in connect mode'
+
+# test failure onepasswordDocument template function
+! exec chezmoi execute-template '{{ onepasswordDocument "exampleDocument" }}'
+stderr 'onepasswordDocument cannot be used in connect mode'
+
+# test failure with OP_SERVICE_ACCOUNT_TOKEN set
+env OP_SERVICE_ACCOUNT_TOKEN=x
+! exec chezmoi execute-template '{{ (onepassword "ExampleLogin").id }}'
+stderr 'OP_SERVICE_ACCOUNT_TOKEN is set'
+
+-- bin/op --
+#!/bin/sh
+
+if [ "$*" = "--version" ]; then
+    echo 2.0.0
+elif [ "$*" = "item get --format json ExampleLogin --vault vault --account account_uuid" ]; then
+    echo "[ERROR] cannot use accounts with OP_CONNECT_HOST and OP_CONNECT_TOKEN set" 1>&2
+    exit 1
+elif [ "$*" = "item get --format json ExampleLogin --account account_uuid" ]; then
+    echo "[ERROR] cannot use accounts with OP_CONNECT_HOST and OP_CONNECT_TOKEN set" 1>&2
+    exit 1
+elif [ "$*" = "--session thisIsAFakeSessionToken item get --format json ExampleLogin --vault vault --account account_uuid" ]; then
+    echo "[ERROR] cannot use accounts with OP_CONNECT_HOST and OP_CONNECT_TOKEN set" 1>&2
+    exit 1
+elif [ "$*" = "--session thisIsAFakeSessionToken item get --format json ExampleLogin --account account_uuid" ]; then
+    echo "[ERROR] cannot use accounts with OP_CONNECT_HOST and OP_CONNECT_TOKEN set" 1>&2
+    exit 1
+elif [ "$*" = "item get --format json ExampleLogin" ]; then
+    echo '{"id":"wxcplh5udshnonkzg2n4qx262y","title":"ExampleLogin","version":1,"vault":{"id":"tscpxgi6s7c662jtqn3vmw4n5a"},"category":"LOGIN","last_edited_by":"YO4UTYPAD3ZFBNZG5DVAZFBNZM","created_at":"2022-01-17T01:53:50Z","updated_at":"2022-01-17T01:55:35Z","sections":[{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"}],"fields":[{"id":"username","type":"STRING","purpose":"USERNAME","label":"username","value":"exampleuser "},{"id":"password","type":"CONCEALED","purpose":"PASSWORD","label":"password","value":"L8rm1JXJIE1b8YUDWq7h","password_details":{"strength":"EXCELLENT"}},{"id":"notesPlain","type":"STRING","purpose":"NOTES","label":"notesPlain"},{"id":"cqn7oda7wkcsar7rzcr52i2m3u","section":{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"},"type":"STRING","label":"exampleLabel","value":"exampleValue"}],"urls":[{"primary":true,"href":"https://www.example.com/"}]}'
+elif [ "$*" = "item get --format json ExampleLogin --vault vault" ]; then
+    echo '{"id":"wxcplh5udshnonkzg2n4qx262y","title":"ExampleLogin","version":1,"vault":{"id":"tscpxgi6s7c662jtqn3vmw4n5a"},"category":"LOGIN","last_edited_by":"YO4UTYPAD3ZFBNZG5DVAZFBNZM","created_at":"2022-01-17T01:53:50Z","updated_at":"2022-01-17T01:55:35Z","sections":[{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"}],"fields":[{"id":"username","type":"STRING","purpose":"USERNAME","label":"username","value":"exampleuser "},{"id":"password","type":"CONCEALED","purpose":"PASSWORD","label":"password","value":"L8rm1JXJIE1b8YUDWq7h","password_details":{"strength":"EXCELLENT"}},{"id":"notesPlain","type":"STRING","purpose":"NOTES","label":"notesPlain"},{"id":"cqn7oda7wkcsar7rzcr52i2m3u","section":{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"},"type":"STRING","label":"exampleLabel","value":"exampleValue"}],"urls":[{"primary":true,"href":"https://www.example.com/"}]}'
+elif [ "$*" = "--session thisIsAFakeSessionToken item get --format json ExampleLogin --vault vault" ]; then
+    echo "[ERROR] cannot use session tokens with OP_CONNECT_HOST and OP_CONNECT_TOKEN set" 1>&2
+    exit 1
+elif [ "$*" = "--session thisIsAFakeSessionToken item get --format json ExampleLogin" ]; then
+    echo "[ERROR] cannot use session tokens with OP_CONNECT_HOST and OP_CONNECT_TOKEN set" 1>&2
+    exit 1
+elif [ "$*" = "account list --format=json" ]; then
+    echo "[ERROR] cannot use accounts with OP_CONNECT_HOST and OP_CONNECT_TOKEN set" 1>&2
+    exit 1
+elif [ "$*" = "signin --account account_uuid --raw" ]; then
+    echo "[ERROR] cannot sign in with OP_CONNECT_HOST and OP_CONNECT_TOKEN set" 1>&2
+    exit 1
+elif [ "$*" = "signin --raw" ]; then
+    echo "[ERROR] cannot sign in with OP_CONNECT_HOST and OP_CONNECT_TOKEN set" 1>&2
+    exit 1
+elif [ "$*" = "read --no-newline op://vault/item/field" ]; then
+    echo 'exampleField'
+elif [ "$*" = "--session thisIsAFakeSessionToken read --no-newline op://vault/item/field" ]; then
+    echo "[ERROR] cannot use session tokens with OP_CONNECT_HOST and OP_CONNECT_TOKEN set" 1>&2
+    exit 1
+elif [ "$*" = "--session thisIsAFakeSessionToken read --no-newline op://vault/item/field --account account_uuid" ]; then
+    echo "[ERROR] cannot use session tokens or accounts with OP_CONNECT_HOST and OP_CONNECT_TOKEN set" 1>&2
+    exit 1
+elif [ "$*" = "document get exampleDocument" ]; then
+    echo "[ERROR] cannot use document get with OP_CONNECT_HOST and OP_CONNECT_TOKEN set" 1>&2
+    exit 1
+elif [ "$*" = "--session thisIsAFakeSessionToken document get exampleDocument" ]; then
+    echo "[ERROR] cannot use document get with OP_CONNECT_HOST and OP_CONNECT_TOKEN set" 1>&2
+    exit 1
+elif [ "$*" = "--session thisIsAFakeSessionToken document get exampleDocument --vault vault" ]; then
+    echo "[ERROR] cannot use document get with OP_CONNECT_HOST and OP_CONNECT_TOKEN set" 1>&2
+    exit 1
+elif [ "$*" = "--session thisIsAFakeSessionToken document get exampleDocument --account account_uuid" ]; then
+    echo "[ERROR] cannot use document get with OP_CONNECT_HOST and OP_CONNECT_TOKEN set" 1>&2
+    exit 1
+elif [ "$*" = "--session thisIsAFakeSessionToken document get exampleDocument --vault vault --account account_uuid" ]; then
+    echo "[ERROR] cannot use document get with OP_CONNECT_HOST and OP_CONNECT_TOKEN set" 1>&2
+    exit 1
+else
+    echo "[ERROR] 2020/01/01 00:00:00 unknown command \"$*\" for \"op\"" 1>&2
+    exit 1
+fi
+-- bin/op.cmd --
+@echo off
+IF "%*" == "--version" (
+    echo 2.0.0
+) ELSE IF "%*" == "item get --format json ExampleLogin --vault vault --account account_uuid" (
+    echo.[ERROR] cannot use accounts with OP_CONNECT_HOST and OP_CONNECT_TOKEN set 1>&2
+    exit /b 1
+) ELSE IF "%*" == "item get --format json ExampleLogin --account account_uuid" (
+    echo.[ERROR] cannot use accounts with OP_CONNECT_HOST and OP_CONNECT_TOKEN set 1>&2
+    exit /b 1
+) ELSE IF "%*" == "--session thisIsAFakeSessionToken item get --format json ExampleLogin --vault vault --account account_uuid" (
+    echo.[ERROR] cannot use accounts with OP_CONNECT_HOST and OP_CONNECT_TOKEN set 1>&2
+    exit /b 1
+) ELSE IF "%*" == "--session thisIsAFakeSessionToken item get --format json ExampleLogin --account account_uuid" (
+    echo.[ERROR] cannot use accounts with OP_CONNECT_HOST and OP_CONNECT_TOKEN set 1>&2
+    exit /b 1
+) ELSE IF "%*" == "item get --format json ExampleLogin" (
+    echo.{"id":"wxcplh5udshnonkzg2n4qx262y","title":"ExampleLogin","version":1,"vault":{"id":"tscpxgi6s7c662jtqn3vmw4n5a"},"category":"LOGIN","last_edited_by":"YO4UTYPAD3ZFBNZG5DVAZFBNZM","created_at":"2022-01-17T01:53:50Z","updated_at":"2022-01-17T01:55:35Z","sections":[{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"}],"fields":[{"id":"username","type":"STRING","purpose":"USERNAME","label":"username","value":"exampleuser "},{"id":"password","type":"CONCEALED","purpose":"PASSWORD","label":"password","value":"L8rm1JXJIE1b8YUDWq7h","password_details":{"strength":"EXCELLENT"}},{"id":"notesPlain","type":"STRING","purpose":"NOTES","label":"notesPlain"},{"id":"cqn7oda7wkcsar7rzcr52i2m3u","section":{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"},"type":"STRING","label":"exampleLabel","value":"exampleValue"}],"urls":[{"primary":true,"href":"https://www.example.com/"}]}
+) ELSE IF "%*" == "item get --format json ExampleLogin --vault vault" (
+    echo.{"id":"wxcplh5udshnonkzg2n4qx262y","title":"ExampleLogin","version":1,"vault":{"id":"tscpxgi6s7c662jtqn3vmw4n5a"},"category":"LOGIN","last_edited_by":"YO4UTYPAD3ZFBNZG5DVAZFBNZM","created_at":"2022-01-17T01:53:50Z","updated_at":"2022-01-17T01:55:35Z","sections":[{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"}],"fields":[{"id":"username","type":"STRING","purpose":"USERNAME","label":"username","value":"exampleuser "},{"id":"password","type":"CONCEALED","purpose":"PASSWORD","label":"password","value":"L8rm1JXJIE1b8YUDWq7h","password_details":{"strength":"EXCELLENT"}},{"id":"notesPlain","type":"STRING","purpose":"NOTES","label":"notesPlain"},{"id":"cqn7oda7wkcsar7rzcr52i2m3u","section":{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"},"type":"STRING","label":"exampleLabel","value":"exampleValue"}],"urls":[{"primary":true,"href":"https://www.example.com/"}]}
+) ELSE IF "%*" == "--session thisIsAFakeSessionToken item get --format json ExampleLogin --vault vault" (
+    echo.[ERROR] cannot use session tokens with OP_CONNECT_HOST and OP_CONNECT_TOKEN set 1>&2
+    exit /b 1
+) ELSE IF "%*" == "--session thisIsAFakeSessionToken item get --format json ExampleLogin" (
+    echo.[ERROR] cannot use session tokens with OP_CONNECT_HOST and OP_CONNECT_TOKEN set 1>&2
+    exit /b 1
+) ELSE IF "%*" == "account list --format=json" (
+    echo.[ERROR] cannot use accounts with OP_CONNECT_HOST and OP_CONNECT_TOKEN set 1>&2
+    exit /b 1
+) ELSE IF "%*" == "signin --account account_uuid --raw" (
+    echo.[ERROR] cannot sign in with OP_CONNECT_HOST and OP_CONNECT_TOKEN set 1>&2
+    exit /b 1
+) ELSE IF "%*" == "signin --raw" (
+    echo.[ERROR] cannot sign in with OP_CONNECT_HOST and OP_CONNECT_TOKEN set 1>&2
+) ELSE IF "%*" == "document get exampleDocument" (
+    echo.[ERROR] cannot use document get with OP_CONNECT_HOST and OP_CONNECT_TOKEN set 1>&2
+    exit /b 1
+) ELSE IF "%*" == "--session thisIsAFakeSessionToken document get exampleDocument" (
+    echo.[ERROR] cannot use document get with OP_CONNECT_HOST and OP_CONNECT_TOKEN set 1>&2
+    exit /b 1
+) ELSE IF "%*" == "--session thisIsAFakeSessionToken document get exampleDocument --vault vault" (
+    echo.[ERROR] cannot use document get with OP_CONNECT_HOST and OP_CONNECT_TOKEN set 1>&2
+    exit /b 1
+) ELSE IF "%*" == "--session thisIsAFakeSessionToken document get exampleDocument --account account_uuid" (
+    echo.[ERROR] cannot use document get with OP_CONNECT_HOST and OP_CONNECT_TOKEN set 1>&2
+    exit /b 1
+) ELSE IF "%*" == "--session thisIsAFakeSessionToken document get exampleDocument --vault vault --account account_uuid" (
+    echo.[ERROR] cannot use document get with OP_CONNECT_HOST and OP_CONNECT_TOKEN set 1>&2
+    exit /b 1
+) ELSE IF "%*" == "read --no-newline op://vault/item/field" (
+    echo.exampleField
+) ELSE IF "%*" == "--session thisIsAFakeSessionToken read --no-newline op://vault/item/field" (
+    echo.[ERROR] cannot use session tokens with OP_CONNECT_HOST and OP_CONNECT_TOKEN set 1>&2
+    exit /b 1
+) ELSE IF "%*" == "--session thisIsAFakeSessionToken read --no-newline op://vault/item/field --account account_uuid" (
+    echo.[ERROR] cannot use session tokens or accounts with OP_CONNECT_HOST and OP_CONNECT_TOKEN set 1>&2
+    exit /b 1
+) ELSE (
+    echo "[ERROR] 2020/01/01 00:00:00 unknown command \"%*\" for \"op\"" 1>&2
+    exit /b 1
+)
+-- home/user/.config/chezmoi/chezmoi.toml --
+[onepassword]
+mode = "connect"

--- a/internal/cmd/testdata/scripts/onepassword2service.txtar
+++ b/internal/cmd/testdata/scripts/onepassword2service.txtar
@@ -1,0 +1,198 @@
+[unix] chmod 755 bin/op
+[windows] unix2dos bin/op.cmd
+
+mkhomedir
+
+# test that mode is properly set and reported
+exec chezmoi execute-template '{{ .chezmoi.config.onepassword.mode }}'
+stdout '^service$'
+
+# test failure without OP_SERVICE_ACCOUNT_TOKEN set
+! exec chezmoi execute-template '{{ (onepassword "ExampleLogin").id }}'
+stderr 'OP_SERVICE_ACCOUNT_TOKEN is not set'
+
+env OP_SERVICE_ACCOUNT_TOKEN=x
+
+# test onepassword template function
+exec chezmoi execute-template '{{ (onepassword "ExampleLogin").id }}'
+stdout '^wxcplh5udshnonkzg2n4qx262y$'
+
+# test onepassword template function with vault
+exec chezmoi execute-template '{{ (onepassword "ExampleLogin" "vault").id }}'
+stdout '^wxcplh5udshnonkzg2n4qx262y$'
+
+# test failure onepassword template function with vault and account
+! exec chezmoi execute-template '{{ (onepassword "ExampleLogin" "vault" "account").id }}'
+stderr '1Password account parameters cannot be used in service mode'
+
+# test onepassword template function with empty vault
+exec chezmoi execute-template '{{ (onepassword "ExampleLogin" "").id }}'
+stdout '^wxcplh5udshnonkzg2n4qx262y$'
+
+# test onepasswordDetailsFields template function
+exec chezmoi execute-template '{{ (onepasswordDetailsFields "ExampleLogin").password.value }}'
+stdout '^L8rm1JXJIE1b8YUDWq7h$'
+
+# test onepasswordItemFields template function
+exec chezmoi execute-template '{{ (onepasswordItemFields "ExampleLogin").exampleLabel.value }}'
+stdout exampleValue
+
+# test onepasswordRead template function
+exec chezmoi execute-template '{{ onepasswordRead "op://vault/item/field" }}'
+stdout exampleField
+
+# test failure onepasswordRead template function with account
+! exec chezmoi execute-template '{{ onepasswordRead "op://vault/item/field" "account" }}'
+stderr '1Password account parameters cannot be used in service mode'
+
+# test onepasswordDocument template function
+exec chezmoi execute-template '{{ onepasswordDocument "exampleDocument" }}'
+stdout 'OK-COMPUTER'
+
+# test onepasswordDocument template function with vault
+exec chezmoi execute-template '{{ onepasswordDocument "exampleDocument" "vault" }}'
+stdout 'OK-VAULT'
+
+# test onepasswordDocument template function with vault and account
+! exec chezmoi execute-template '{{ onepasswordDocument "exampleDocument" "vault" "account" }}'
+stderr '1Password account parameters cannot be used in service mode'
+
+# test onepasswordDocument template function with account
+! exec chezmoi execute-template '{{ onepasswordDocument "exampleDocument" "" "account" }}'
+stderr '1Password account parameters cannot be used in service mode'
+
+# test failure with OP_CONNECT_HOST and OP_CONNECT_TOKEN set
+env OP_CONNECT_HOST=x
+env OP_CONNECT_TOKEN=y
+! exec chezmoi execute-template '{{ (onepassword "ExampleLogin").id }}'
+stderr 'OP_CONNECT_HOST and OP_CONNECT_TOKEN'
+
+-- bin/op --
+#!/bin/sh
+
+if [ "$*" = "--version" ]; then
+    echo 2.0.0
+elif [ "$*" = "item get --format json ExampleLogin --vault vault --account account_uuid" ]; then
+    echo "[ERROR] cannot use accounts with OP_SERVICE_TOKEN set" 1>&2
+    exit 1
+elif [ "$*" = "item get --format json ExampleLogin --account account_uuid" ]; then
+    echo "[ERROR] cannot use accounts with OP_SERVICE_TOKEN set" 1>&2
+    exit 1
+elif [ "$*" = "--session thisIsAFakeSessionToken item get --format json ExampleLogin --vault vault --account account_uuid" ]; then
+    echo "[ERROR] cannot use accounts with OP_SERVICE_TOKEN set" 1>&2
+    exit 1
+elif [ "$*" = "--session thisIsAFakeSessionToken item get --format json ExampleLogin --account account_uuid" ]; then
+    echo "[ERROR] cannot use accounts with OP_SERVICE_TOKEN set" 1>&2
+    exit 1
+elif [ "$*" = "item get --format json ExampleLogin" ]; then
+    echo '{"id":"wxcplh5udshnonkzg2n4qx262y","title":"ExampleLogin","version":1,"vault":{"id":"tscpxgi6s7c662jtqn3vmw4n5a"},"category":"LOGIN","last_edited_by":"YO4UTYPAD3ZFBNZG5DVAZFBNZM","created_at":"2022-01-17T01:53:50Z","updated_at":"2022-01-17T01:55:35Z","sections":[{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"}],"fields":[{"id":"username","type":"STRING","purpose":"USERNAME","label":"username","value":"exampleuser "},{"id":"password","type":"CONCEALED","purpose":"PASSWORD","label":"password","value":"L8rm1JXJIE1b8YUDWq7h","password_details":{"strength":"EXCELLENT"}},{"id":"notesPlain","type":"STRING","purpose":"NOTES","label":"notesPlain"},{"id":"cqn7oda7wkcsar7rzcr52i2m3u","section":{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"},"type":"STRING","label":"exampleLabel","value":"exampleValue"}],"urls":[{"primary":true,"href":"https://www.example.com/"}]}'
+elif [ "$*" = "item get --format json ExampleLogin --vault vault" ]; then
+    echo '{"id":"wxcplh5udshnonkzg2n4qx262y","title":"ExampleLogin","version":1,"vault":{"id":"tscpxgi6s7c662jtqn3vmw4n5a"},"category":"LOGIN","last_edited_by":"YO4UTYPAD3ZFBNZG5DVAZFBNZM","created_at":"2022-01-17T01:53:50Z","updated_at":"2022-01-17T01:55:35Z","sections":[{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"}],"fields":[{"id":"username","type":"STRING","purpose":"USERNAME","label":"username","value":"exampleuser "},{"id":"password","type":"CONCEALED","purpose":"PASSWORD","label":"password","value":"L8rm1JXJIE1b8YUDWq7h","password_details":{"strength":"EXCELLENT"}},{"id":"notesPlain","type":"STRING","purpose":"NOTES","label":"notesPlain"},{"id":"cqn7oda7wkcsar7rzcr52i2m3u","section":{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"},"type":"STRING","label":"exampleLabel","value":"exampleValue"}],"urls":[{"primary":true,"href":"https://www.example.com/"}]}'
+elif [ "$*" = "--session thisIsAFakeSessionToken item get --format json ExampleLogin --vault vault" ]; then
+    echo "[ERROR] cannot use session tokens with OP_SERVICE_TOKEN set" 1>&2
+    exit 1
+elif [ "$*" = "--session thisIsAFakeSessionToken item get --format json ExampleLogin" ]; then
+    echo "[ERROR] cannot use session tokens with OP_SERVICE_TOKEN set" 1>&2
+    exit 1
+elif [ "$*" = "account list --format=json" ]; then
+    echo "[ERROR] cannot use accounts with OP_SERVICE_TOKEN set" 1>&2
+    exit 1
+elif [ "$*" = "signin --account account_uuid --raw" ]; then
+    echo "[ERROR] cannot sign in with OP_SERVICE_TOKEN set" 1>&2
+    exit 1
+elif [ "$*" = "signin --raw" ]; then
+    echo "[ERROR] cannot sign in with OP_SERVICE_TOKEN set" 1>&2
+    exit 1
+elif [ "$*" = "document get exampleDocument" ]; then
+    echo 'OK-COMPUTER'
+elif [ "$*" = "document get exampleDocument --vault vault" ]; then
+    echo 'OK-VAULT'
+elif [ "$*" = "--session thisIsAFakeSessionToken document get exampleDocument" ]; then
+    echo "[ERROR] cannot use session tokens with OP_SERVICE_TOKEN set" 1>&2
+    exit 1
+elif [ "$*" = "--session thisIsAFakeSessionToken document get exampleDocument --vault vault" ]; then
+    echo 'OK-VAULT'
+elif [ "$*" = "--session thisIsAFakeSessionToken document get exampleDocument --account account_uuid" ]; then
+    echo "[ERROR] cannot use accounts or session tokens with OP_SERVICE_TOKEN set" 1>&2
+    exit 1
+elif [ "$*" = "--session thisIsAFakeSessionToken document get exampleDocument --vault vault --account account_uuid" ]; then
+    echo "[ERROR] cannot use accounts or session tokens with OP_SERVICE_TOKEN set" 1>&2
+    exit 1
+elif [ "$*" = "read --no-newline op://vault/item/field" ]; then
+    echo 'exampleField'
+elif [ "$*" = "--session thisIsAFakeSessionToken read --no-newline op://vault/item/field" ]; then
+    echo "[ERROR] cannot use session tokens with OP_SERVICE_TOKEN set" 1>&2
+    exit 1
+elif [ "$*" = "--session thisIsAFakeSessionToken read --no-newline op://vault/item/field --account account_uuid" ]; then
+    echo "[ERROR] cannot use session tokens or accounts with OP_SERVICE_TOKEN set" 1>&2
+    exit 1
+else
+    echo "[ERROR] 2020/01/01 00:00:00 unknown command \"$*\" for \"op\"" 1>&2
+    exit 1
+fi
+-- bin/op.cmd --
+@echo off
+IF "%*" == "--version" (
+    echo 2.0.0
+) ELSE IF "%*" == "item get --format json ExampleLogin --vault vault --account account_uuid" (
+    echo.[ERROR] cannot use accounts with OP_SERVICE_TOKEN set 1>&2
+    exit /b 1
+) ELSE IF "%*" == "item get --format json ExampleLogin --account account_uuid" (
+    echo.[ERROR] cannot use accounts with OP_SERVICE_TOKEN set 1>&2
+    exit /b 1
+) ELSE IF "%*" == "--session thisIsAFakeSessionToken item get --format json ExampleLogin --vault vault --account account_uuid" (
+    echo.[ERROR] cannot use accounts with OP_SERVICE_TOKEN set 1>&2
+    exit /b 1
+) ELSE IF "%*" == "--session thisIsAFakeSessionToken item get --format json ExampleLogin --account account_uuid" (
+    echo.[ERROR] cannot use accounts with OP_SERVICE_TOKEN set 1>&2
+    exit /b 1
+) ELSE IF "%*" == "item get --format json ExampleLogin" (
+    echo.{"id":"wxcplh5udshnonkzg2n4qx262y","title":"ExampleLogin","version":1,"vault":{"id":"tscpxgi6s7c662jtqn3vmw4n5a"},"category":"LOGIN","last_edited_by":"YO4UTYPAD3ZFBNZG5DVAZFBNZM","created_at":"2022-01-17T01:53:50Z","updated_at":"2022-01-17T01:55:35Z","sections":[{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"}],"fields":[{"id":"username","type":"STRING","purpose":"USERNAME","label":"username","value":"exampleuser "},{"id":"password","type":"CONCEALED","purpose":"PASSWORD","label":"password","value":"L8rm1JXJIE1b8YUDWq7h","password_details":{"strength":"EXCELLENT"}},{"id":"notesPlain","type":"STRING","purpose":"NOTES","label":"notesPlain"},{"id":"cqn7oda7wkcsar7rzcr52i2m3u","section":{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"},"type":"STRING","label":"exampleLabel","value":"exampleValue"}],"urls":[{"primary":true,"href":"https://www.example.com/"}]}
+) ELSE IF "%*" == "item get --format json ExampleLogin --vault vault" (
+    echo.{"id":"wxcplh5udshnonkzg2n4qx262y","title":"ExampleLogin","version":1,"vault":{"id":"tscpxgi6s7c662jtqn3vmw4n5a"},"category":"LOGIN","last_edited_by":"YO4UTYPAD3ZFBNZG5DVAZFBNZM","created_at":"2022-01-17T01:53:50Z","updated_at":"2022-01-17T01:55:35Z","sections":[{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"}],"fields":[{"id":"username","type":"STRING","purpose":"USERNAME","label":"username","value":"exampleuser "},{"id":"password","type":"CONCEALED","purpose":"PASSWORD","label":"password","value":"L8rm1JXJIE1b8YUDWq7h","password_details":{"strength":"EXCELLENT"}},{"id":"notesPlain","type":"STRING","purpose":"NOTES","label":"notesPlain"},{"id":"cqn7oda7wkcsar7rzcr52i2m3u","section":{"id":"Section_cdzjhg2jo7jylpyin2f5mbfnhm","label":"Related Items"},"type":"STRING","label":"exampleLabel","value":"exampleValue"}],"urls":[{"primary":true,"href":"https://www.example.com/"}]}
+) ELSE IF "%*" == "--session thisIsAFakeSessionToken item get --format json ExampleLogin --vault vault" (
+    echo.[ERROR] cannot use session tokens with OP_SERVICE_TOKEN set 1>&2
+    exit /b 1
+) ELSE IF "%*" == "--session thisIsAFakeSessionToken item get --format json ExampleLogin" (
+    echo.[ERROR] cannot use session tokens with OP_SERVICE_TOKEN set 1>&2
+    exit /b 1
+) ELSE IF "%*" == "account list --format=json" (
+    echo.[ERROR] cannot use accounts with OP_SERVICE_TOKEN set 1>&2
+    exit /b 1
+) ELSE IF "%*" == "signin --account account_uuid --raw" (
+    echo.[ERROR] cannot sign in with OP_SERVICE_TOKEN set 1>&2
+    exit /b 1
+) ELSE IF "%*" == "signin --raw" (
+    echo.[ERROR] cannot sign in with OP_SERVICE_TOKEN set 1>&2
+    exit /b 1
+) ELSE IF "%*" == "document get exampleDocument" (
+    echo.OK-COMPUTER
+) ELSE IF "%*" == "document get exampleDocument --vault vault" (
+    echo.OK-VAULT
+) ELSE IF "%*" == "--session thisIsAFakeSessionToken document get exampleDocument" (
+    echo.[ERROR] cannot use session tokens with OP_SERVICE_TOKEN set 1>&2
+    exit /b 1
+) ELSE IF "%*" == "--session thisIsAFakeSessionToken document get exampleDocument --vault vault" (
+    echo.[ERROR] cannot use session tokens with OP_SERVICE_TOKEN set 1>&2
+    exit /b 1
+) ELSE IF "%*" == "--session thisIsAFakeSessionToken document get exampleDocument --account account_uuid" (
+    echo.[ERROR] cannot use accounts or session tokens with OP_SERVICE_TOKEN set 1>&2
+    exit 1
+) ELSE IF "%*" == "--session thisIsAFakeSessionToken document get exampleDocument --vault vault --account account_uuid" (
+    echo.[ERROR] cannot use accounts or session tokens with OP_SERVICE_TOKEN set 1>&2
+    exit 1
+) ELSE IF "%*" == "read --no-newline op://vault/item/field" (
+    echo.exampleField
+) ELSE IF "%*" == "--session thisIsAFakeSessionToken read --no-newline op://vault/item/field" (
+    echo.[ERROR] cannot use session tokens with OP_SERVICE_TOKEN set 1>&2
+    exit /b 1
+) ELSE IF "%*" == "--session thisIsAFakeSessionToken read --no-newline op://vault/item/field --account account_uuid" (
+    echo.[ERROR] cannot use session tokens or accounts with OP_SERVICE_TOKEN set 1>&2
+    exit /b 1
+) ELSE (
+    echo "[ERROR] 2020/01/01 00:00:00 unknown command \"%*\" for \"op\"" 1>&2
+    exit /b 1
+)
+-- home/user/.config/chezmoi/chezmoi.toml --
+[onepassword]
+mode = "service"


### PR DESCRIPTION
Added a new configuration option, `onepassword.mode`, that can be set to
`account` (the default value), `connect` (for 1Password Connect), or
`service` (for 1Password Service Accounts).

When in `onepassword.mode` is:

- `account`: the presence of `OP_SERVICE_ACCOUNT_TOKEN`,
  `OP_CONNECT_HOST`, and/or `OP_CONNECT_TOKEN` will cause chezmoi to
  immediately exit; their presence changes the behaviour of the
  1Password CLI.

- `connect`: the presence of `OP_SERVICE_ACCOUNT_TOKEN` or absences of
  `OP_CONNECT_HOST` and/or `OP_CONNECT_TOKEN` will cause chezmoi to
  immediately exit.

  Additionally, the use of `onepasswordDocument` or passing an `account`
  parameter will cause immediate exits.

- `service`: the absence of `OP_SERVICE_ACCOUNT_TOKEN` or presence of
  `OP_CONNECT_HOST` and/or `OP_CONNECT_TOKEN` will cause chezmoi to
  immediately exit.

  Additionally, passing an `account` parameter will cause immediate
  exits.

In all other ways, the 1Password template functions have not changed.

I changed the format of the scripts in the `onepassword*.txtar` files so
that there is better parity between the three sets of tests _and_ so
that there is better / easier to read parity between the Unix and
Windows test scripts.

Closes: #3498
