### PR TITLE
chore: Refactor install.ps1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -135,6 +135,18 @@ jobs:
       run: |
         sh assets/scripts/install.sh
         bin/chezmoi --version
+    - name: test-install.ps1
+      shell: pwsh
+      run: |
+        if (Test-Path -Path bin/chezmoi) { Remove-Item -Force bin/chezmoi }
+        assets/scripts/install.ps1 -d
+        bin/chezmoi --version
+    - name: test-install.ps1-irm
+      shell: pwsh
+      run: |
+        if (Test-Path -Path bin/chezmoi) { Remove-Item -Force bin/chezmoi }
+        iex "&{$(irm 'https://raw.githubusercontent.com/twpayne/chezmoi/${{ github.event.pull_request.head.sha }}/assets/scripts/install.ps1')} -d"
+        bin/chezmoi --version
   test-oldstable-go:
     needs: changes
     if: github.event_name == 'push' || needs.changes.outputs.code == 'true'
@@ -283,6 +295,18 @@ jobs:
         rm -f bin/chezmoi
         sh assets/scripts/install.sh
         bin/chezmoi --version
+    - name: test-install.ps1
+      shell: pwsh
+      run: |
+        if (Test-Path -Path bin/chezmoi) { Remove-Item -Force bin/chezmoi }
+        assets/scripts/install.ps1 -d
+        bin/chezmoi --version
+    - name: test-install.ps1-irm
+      shell: pwsh
+      run: |
+        if (Test-Path -Path bin/chezmoi) { Remove-Item -Force bin/chezmoi }
+        iex "&{$(irm 'https://raw.githubusercontent.com/twpayne/chezmoi/${{ github.event.pull_request.head.sha }}/assets/scripts/install.ps1')} -d"
+        bin/chezmoi --version
   test-website:
     runs-on: ubuntu-22.04
     permissions:
@@ -330,17 +354,17 @@ jobs:
     - name: test-install.ps1
       run: |
         if (Test-Path -Path bin/chezmoi.exe) { Remove-Item -Force bin/chezmoi.exe }
-        powershell -c assets/scripts/install.ps1
+        assets/scripts/install.ps1 -d
         bin/chezmoi.exe --version
-    - name: test-install-irm
+    - name: test-install.ps1-irm
       run: |
         if (Test-Path -Path bin/chezmoi.exe) { Remove-Item -Force bin/chezmoi.exe }
-        (irm -useb https://get.chezmoi.io/ps1) | powershell -c -
+        iex "&{$(irm 'https://raw.githubusercontent.com/twpayne/chezmoi/${{ github.event.pull_request.head.sha }}/assets/scripts/install.ps1')} -d"
         bin/chezmoi.exe --version
-    - name: test-install-iwr
+    - name: test-install.ps1-iwr
       run: |
         if (Test-Path -Path bin/chezmoi.exe) { Remove-Item -Force bin/chezmoi.exe }
-        (iwr -useb https://get.chezmoi.io/ps1).ToString() | powershell -c -
+        iex "&{$(iwr 'https://raw.githubusercontent.com/twpayne/chezmoi/${{ github.event.pull_request.head.sha }}/assets/scripts/install.ps1')} -d"
         bin/chezmoi.exe --version
   check:
     runs-on: ubuntu-22.04

--- a/assets/chezmoi.io/docs/install.md.tmpl
+++ b/assets/chezmoi.io/docs/install.md.tmpl
@@ -148,7 +148,13 @@ with a single command:
 === "PowerShell"
 
     ```powershell
-    (irm -useb https://get.chezmoi.io/ps1) | powershell -c -
+    iex "&{$(irm 'https://get.chezmoi.io/ps1')}"
+    ```
+
+    To provide the script with arguments, place them at the end of the quote:
+
+    ```powershell
+    iex "&{$(irm 'https://get.chezmoi.io/ps1')} -b '~/bin'"
     ```
 
 !!! hint


### PR DESCRIPTION
I've been wanting to do this for a long time but always seemed to find something else to do instead.

Changes:

- Use PowerShell's [Approved Verbs](https://learn.microsoft.com/en-us/powershell/scripting/developer/cmdlet/approved-verbs-for-windows-powershell-commands?view=powershell-5.1)
- Use PowerShell's built-in output streams
- Remove unused functions
- General style changes to align more with the [unofficial style guide](https://poshcode.gitbooks.io/powershell-practice-and-style)
- ~Use GitHub's REST API (I am concerned this may cause issues with actions but I'm not sure. If this is preferred I can also make this change in `install.sh.tmpl`)~
- Removed almost 100 lines

`get_goos` handled FreeBSD, but I'm struggling to even find any information about PowerShell being installable on FreeBSD. https://github.com/PowerShell/PowerShell?tab=readme-ov-file#get-powershell makes no mention of FreeBSD, nor does https://github.com/dotnet/core/blob/main/release-notes/8.0/supported-os.md.

```console
PowerShell 7.4.1

~
❯ [System.Runtime.InteropServices.RuntimeInformation]::FrameworkDescription
.NET 8.0.1
```

https://ports.freebsd.org/cgi/ports.cgi?query=powershell&stype=all&sektion=all
https://ports.freebsd.org/cgi/ports.cgi?query=pwsh&stype=all&sektion=all

TODO:

- [X] Verify that the invocation remains the same when downloading and executing the script over the network
- [X] Test on Linux and macOS

There's no rush for this. I want to be absolutely sure there are no regressions before merging.