### PR TITLE
chore: Work around ruamel.yaml errors when formatting YAML

### DIFF
--- a/assets/chezmoi.io/docs/reference/configuration-file/variables.md.yaml
+++ b/assets/chezmoi.io/docs/reference/configuration-file/variables.md.yaml
@@ -390,7 +390,7 @@ sections:
       description: Vault CLI command
   update:
     apply:
-      type: 'bool'
+      type: bool
       default: '`true`'
       description: Apply after pulling
     args:

--- a/assets/requirements.txt
+++ b/assets/requirements.txt
@@ -1,1 +1,1 @@
-ruamel.yaml==0.18.5
+ruamel.yaml==0.18.6

--- a/assets/scripts/format-yaml.py
+++ b/assets/scripts/format-yaml.py
@@ -10,10 +10,17 @@ from ruamel.yaml import YAML
 
 def main() -> int:
     yaml = YAML()
+    # ruamel.yaml.YAML will by default use the native line ending, which leads
+    # to differences between Windows and UNIX. Force the output to use UNIX line
+    # endings.
+    yaml.line_break = '\n'
+    # ruamel.yaml.YAML will by default break long lines and introduce trailing
+    # whitespace errors. Disable this behavior by setting a long line width.
+    yaml.width = 1024
     for filename in sys.argv[1:]:
         with Path(filename).open('r') as file:
             data = yaml.load(file)
-        with Path(filename).open('w') as file:
+        with Path(filename).open('w', newline='\n') as file:
             yaml.dump(data, file)
     return 0
 


### PR DESCRIPTION
This is an alternative to #3575.