### PR TITLE
chore: Remove owner/repo abstraction

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -21,13 +21,7 @@ import (
 	"github.com/twpayne/chezmoi/v2/internal/chezmoierrors"
 )
 
-// GitHub owner and repo for chezmoi itself.
-const (
-	gitHubOwner = "twpayne"
-	gitHubRepo  = "chezmoi"
-
-	readSourceStateHookName = "read-source-state"
-)
+const readSourceStateHookName = "read-source-state"
 
 var (
 	noArgs = []string(nil)

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -379,10 +379,6 @@ func newConfig(options ...configOption) (*Config, error) {
 		unmanaged: unmanagedCmdConfig{
 			pathStyle: chezmoi.PathStyleRelative,
 		},
-		upgrade: upgradeCmdConfig{
-			owner: gitHubOwner,
-			repo:  gitHubRepo,
-		},
 
 		// Configuration.
 		fileSystem: vfs.OSFS,

--- a/internal/cmd/doctorcmd.go
+++ b/internal/cmd/doctorcmd.go
@@ -118,8 +118,6 @@ type goVersionCheck struct{}
 type latestVersionCheck struct {
 	httpClient    *http.Client
 	httpClientErr error
-	owner         string
-	repo          string
 	version       semver.Version
 }
 
@@ -179,8 +177,6 @@ func (c *Config) runDoctorCmd(cmd *cobra.Command, args []string) error {
 		&latestVersionCheck{
 			httpClient:    httpClient,
 			httpClientErr: httpClientErr,
-			owner:         gitHubOwner,
-			repo:          gitHubRepo,
 			version:       c.version,
 		},
 		osArchCheck{},
@@ -663,7 +659,7 @@ func (c *latestVersionCheck) Run(system chezmoi.System, homeDirAbsPath chezmoi.A
 	ctx := context.Background()
 
 	gitHubClient := chezmoi.NewGitHubClient(ctx, c.httpClient)
-	rr, _, err := gitHubClient.Repositories.GetLatestRelease(ctx, c.owner, c.repo)
+	rr, _, err := gitHubClient.Repositories.GetLatestRelease(ctx, "twpayne", "chezmoi")
 	var rateLimitErr *github.RateLimitError
 	var abuseRateLimitErr *github.AbuseRateLimitError
 	switch {

--- a/internal/cmd/upgradecmd_unix.go
+++ b/internal/cmd/upgradecmd_unix.go
@@ -65,7 +65,7 @@ var (
 )
 
 func (c *Config) brewUpgrade() error {
-	return c.run(chezmoi.EmptyAbsPath, "brew", []string{"upgrade", c.upgrade.repo})
+	return c.run(chezmoi.EmptyAbsPath, "brew", []string{"upgrade", "chezmoi"})
 }
 
 func (c *Config) getPackageFilename(packageType string, version *semver.Version, os, arch string) (string, error) {
@@ -74,18 +74,18 @@ func (c *Config) getPackageFilename(packageType string, version *semver.Version,
 	}
 	switch packageType {
 	case packageTypeAPK:
-		return fmt.Sprintf("%s_%s_%s_%s.apk", c.upgrade.repo, version, os, arch), nil
+		return fmt.Sprintf("chezmoi_%s_%s_%s.apk", version, os, arch), nil
 	case packageTypeDEB:
-		return fmt.Sprintf("%s_%s_%s_%s.deb", c.upgrade.repo, version, os, arch), nil
+		return fmt.Sprintf("chezmoi_%s_%s_%s.deb", version, os, arch), nil
 	case packageTypeRPM:
-		return fmt.Sprintf("%s-%s-%s.rpm", c.upgrade.repo, version, arch), nil
+		return fmt.Sprintf("chezmoi-%s-%s.rpm", version, arch), nil
 	default:
 		return "", fmt.Errorf("%s: unsupported package type", packageType)
 	}
 }
 
 func (c *Config) snapRefresh() error {
-	return c.run(chezmoi.EmptyAbsPath, "snap", []string{"refresh", c.upgrade.repo})
+	return c.run(chezmoi.EmptyAbsPath, "snap", []string{"refresh", "chezmoi"})
 }
 
 func (c *Config) upgradeUNIXPackage(
@@ -109,7 +109,7 @@ func (c *Config) upgradeUNIXPackage(
 			if useSudo {
 				args = append(args, "sudo")
 			}
-			args = append(args, "pacman", "-S", c.upgrade.repo)
+			args = append(args, "pacman", "-S", "chezmoi")
 			return c.run(chezmoi.EmptyAbsPath, args[0], args[1:])
 		}
 

--- a/internal/cmd/upgradecmd_windows.go
+++ b/internal/cmd/upgradecmd_windows.go
@@ -5,7 +5,6 @@ package cmd
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -96,8 +95,9 @@ func (c *Config) upgradeUNIXPackage(
 }
 
 func (c *Config) winGetUpgrade() error {
-	format := "upgrade command is not currently supported for WinGet installations. chezmoi can still be upgraded via WinGet by running `winget upgrade --id %s.%s --source winget`"
-	return fmt.Errorf(format, c.upgrade.owner, c.upgrade.repo)
+	return errors.New(
+		"upgrade command is not currently supported for WinGet installations. chezmoi can still be upgraded via WinGet by running `winget upgrade --id twpayne.chezmoi --source winget`",
+	)
 }
 
 // getLibc attempts to determine the system's libc.


### PR DESCRIPTION
This abstraction was not used.

Realistically, the project will always be called chezmoi, so removing the `gitHubRepo` constant makes sense.

The project owner abstraction in `gitHubOwner` is not consistently used. When chezmoi moves from twpayne/chezmoi to chezmoi/chezmoi this can easily be done with a string replacement.