### PR TITLE
fix: Don't leak internal default sentinel values in template data

### DIFF
--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -2775,8 +2775,15 @@ func newConfigFile(bds *xdg.BaseDirectorySpecification) ConfigFile {
 }
 
 func (f *ConfigFile) toMap() map[string]any {
+	// Make a copy of f and replace any default sentinels with the empty string
+	// to ensure that there are no default sentinels in the result.
+	configFile := *f
+	if configFile.Diff.Pager == defaultSentinel {
+		configFile.Diff.Pager = ""
+	}
+
 	var result map[string]any
-	if err := mapstructure.Decode(f, &result); err != nil {
+	if err := mapstructure.Decode(configFile, &result); err != nil {
 		panic(err)
 	}
 	return result

--- a/internal/cmd/testdata/scripts/issue3590.txtar
+++ b/internal/cmd/testdata/scripts/issue3590.txtar
@@ -1,0 +1,3 @@
+# test that chezmoi data does not include default sentinels
+exec chezmoi data
+! stdout '"\\u0000"'


### PR DESCRIPTION
Fixes #3590.