### PR TITLE
chore: Fix broken relative links

### DIFF
--- a/assets/chezmoi.io/docs/hooks.py
+++ b/assets/chezmoi.io/docs/hooks.py
@@ -32,7 +32,11 @@ def on_pre_build(config: MkDocsConfig, **kwargs) -> None:
         output_path = docs_dir.joinpath(src_path)
         template_path = output_path.parent / (output_path.name + '.tmpl')
         data_path = output_path.parent / (output_path.name + '.yaml')
-        args = ['go', 'run', Path(config_dir, '../../internal/cmds/execute-template')]
+        args = [
+            'go',
+            'run',
+            Path(config_dir, '../../internal/cmds/execute-template/main.go'),
+        ]
         if Path(data_path).exists():
             args.extend(['-data', data_path])
         args.extend(['-output', output_path, template_path])

--- a/assets/chezmoi.io/docs/reference/configuration-file/variables.md.yaml
+++ b/assets/chezmoi.io/docs/reference/configuration-file/variables.md.yaml
@@ -294,7 +294,7 @@ sections:
       description: KeePassXC database
     mode:
       default: '`cache-password`'
-      description: See [KeePassXC functions](../../templates/keepassxc-functions/)
+      description: See [KeePassXC functions](../templates/keepassxc-functions/index.md)
     prompt:
       type: bool
       default: '`true`'

--- a/assets/chezmoi.io/docs/reference/templates/1password-functions/index.md
+++ b/assets/chezmoi.io/docs/reference/templates/1password-functions/index.md
@@ -46,7 +46,7 @@ CLI](https://developer.1password.com/docs/cli) (`op`).
 !!! warning
 
     Chezmoi has experimental support for [1Password secrets
-    automation](../../user-guide/password-managers/1password.md#secrets-automation)
+    automation](../../../user-guide/password-managers/1password.md#secrets-automation)
     modes. These modes change how the 1Password CLI works and affect all
     functions. Most notably, `account` parameters are not allowed on all
     1Password template functions.

--- a/assets/chezmoi.io/docs/reference/templates/1password-functions/onepassword.md
+++ b/assets/chezmoi.io/docs/reference/templates/1password-functions/onepassword.md
@@ -41,5 +41,5 @@ config variable.
 !!! warning
 
     When using [1Password secrets
-    automation](../../user-guide/password-managers/1password.md#secrets-automation),
+    automation](../../../user-guide/password-managers/1password.md#secrets-automation),
     the *account* parameter is not allowed.

--- a/assets/chezmoi.io/docs/reference/templates/1password-functions/onepasswordDetailsFields.md
+++ b/assets/chezmoi.io/docs/reference/templates/1password-functions/onepasswordDetailsFields.md
@@ -13,7 +13,7 @@ interactively prompted to sign in.
 The output from `op` is cached so calling `onepasswordDetailsFields` multiple
 times with the same *uuid* will only invoke `op` once. If the optional
 *vault* is supplied, it will be passed along to the `op get` call, which
-can significantly improve performance. If the optional _account_ is
+can significantly improve performance. If the optional *account* is
 supplied, it will be passed along to the `op get` call, which will help it look
 in the right account, in case you have multiple accounts (e.g. personal and work
 accounts).
@@ -72,9 +72,8 @@ accounts).
     }
     ```
 
-
 !!! warning
 
     When using [1Password secrets
-    automation](../../user-guide/password-managers/1password.md#secrets-automation),
+    automation](../../../user-guide/password-managers/1password.md#secrets-automation),
     the *account* parameter is not allowed.

--- a/assets/chezmoi.io/docs/reference/templates/1password-functions/onepasswordDocument.md
+++ b/assets/chezmoi.io/docs/reference/templates/1password-functions/onepasswordDocument.md
@@ -7,7 +7,7 @@ get document $UUID` and the output from `op` is returned. The output from `op`
 is cached so calling `onepasswordDocument` multiple times with the same *uuid*
 will only invoke `op` once. If the optional *vault* is supplied, it will be
 passed along to the `op get` call, which can significantly improve performance.
-If the optional _account_ is supplied, it will be passed along to the `op
+If the optional *account* is supplied, it will be passed along to the `op
 get` call, which will help it look in the right account, in case you have
 multiple accounts (e.g., personal and work accounts).
 
@@ -25,10 +25,10 @@ interactively prompted to sign in.
 
 !!! warning
 
-    When using [1Password Connect](../../user-guide/password-managers/1password.md#1password-connect), `onepasswordDocument` is not available.
+    When using [1Password Connect](../../../user-guide/password-managers/1password.md#1password-connect), `onepasswordDocument` is not available.
 
 !!! warning
 
     When using [1Password Service
-    Accounts](../../user-guide/password-managers/1password.md#1password-service-accounts),
+    Accounts](../../../user-guide/password-managers/1password.md#1password-service-accounts),
     the *account* parameter is not allowed.

--- a/assets/chezmoi.io/docs/reference/templates/1password-functions/onepasswordItemFields.md
+++ b/assets/chezmoi.io/docs/reference/templates/1password-functions/onepasswordItemFields.md
@@ -75,5 +75,5 @@ interactively prompted to sign in.
 !!! warning
 
     When using [1Password secrets
-    automation](../../user-guide/password-managers/1password.md#secrets-automation),
+    automation](../../../user-guide/password-managers/1password.md#secrets-automation),
     the *account* parameter is not allowed.

--- a/assets/chezmoi.io/docs/reference/templates/1password-functions/onepasswordRead.md
+++ b/assets/chezmoi.io/docs/reference/templates/1password-functions/onepasswordRead.md
@@ -25,5 +25,5 @@ interactively prompted to sign in.
 !!! warning
 
     When using [1Password secrets
-    automation](../../user-guide/password-managers/1password.md#secrets-automation),
+    automation](../../../user-guide/password-managers/1password.md#secrets-automation),
     the *account* parameter is not allowed.


### PR DESCRIPTION
Fixes https://github.com/twpayne/chezmoi/issues/3598.

Without these changes, I can reproduce the warnings mentioned in https://github.com/twpayne/chezmoi/issues/3598.

The warnings mentioned in https://github.com/twpayne/chezmoi/actions/runs/8043964297/job/21966863415#step:5:30 appear to be mainly concerning the templated pages.

The `hooks.py` change should resolve the `package internal/cmds/execute-template is not in std (/opt/hostedtoolcache/go/1.22.0/x64/src/internal/cmds/execute-template)` output.