### PR TITLE
feat: Make DNS server configurable

### DIFF
--- a/assets/chezmoi.io/docs/reference/configuration-file/variables.md.yaml
+++ b/assets/chezmoi.io/docs/reference/configuration-file/variables.md.yaml
@@ -17,6 +17,11 @@ sections:
         `$HOME` <br/>
         `%USERPROFILE%`
       description: Destination directory
+    dns:
+      address:
+        description: DNS server address
+      network:
+        description: DNS server network (`tcp` or `udp`)
     encryption:
       description: Encryption type, either `age` or `gpg`
     env:


### PR DESCRIPTION
Fixes #3605.

@ErrrorMaxx with this you should be able to set the DNS server in your config file with, for example:

```toml
[dns]
    network = "udp"
    address = "1.1.1.1:53"
```

Note that this only applies once chezmoi has read its config file. Specifically, when you call `chezmoi init --use-builtin-git github.com/ErrrorMax/dotfiles` the lookup of `github.com` with **not** use the configured DNS as chezmoi will not have read its config file yet.

Would you be able to test this?