### PR TITLE
fix: pass the `--needed` flag to pacman

### DIFF
--- a/internal/cmd/upgradecmd_unix.go
+++ b/internal/cmd/upgradecmd_unix.go
@@ -109,7 +109,7 @@ func (c *Config) upgradeUNIXPackage(
 			if useSudo {
 				args = append(args, "sudo")
 			}
-			args = append(args, "pacman", "-S", "chezmoi")
+			args = append(args, "pacman", "-S", "--needed", "chezmoi")
 			return c.run(chezmoi.EmptyAbsPath, args[0], args[1:])
 		}
 


### PR DESCRIPTION
This ensures that pacman doesn't re-install an already up-to-date package

<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer-guide/contributing-changes/

-->
