### PR TITLE
chore: Re-enable snapcraft builds

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -271,6 +271,21 @@ signs:
   - ${artifact}
   artifacts: checksum
 
+snapcrafts:
+- builds:
+  - chezmoi-cgo-glibc
+  - chezmoi-nocgo
+  summary: Manage your dotfiles across multiple diverse machines, securely.
+  description: Manage your dotfiles across multiple diverse machines, securely.
+  publish: true
+  grade: stable
+  confinement: classic
+  license: MIT
+  apps:
+    chezmoi:
+      command: chezmoi
+      completer: completions/chezmoi-completion.bash
+
 source:
   enabled: true
   prefix_template: '{{ .ProjectName }}-{{ .Version }}/'


### PR DESCRIPTION
This reverts commit 9b57763a79e2e744d53eafb6483972e32afbd3b8.

Refs https://github.com/canonical/snapcraft/issues/4769.