### PR TITLE
feat: Add tempDir configuration variable

### DIFF
--- a/assets/chezmoi.io/docs/reference/configuration-file/variables.md.yaml
+++ b/assets/chezmoi.io/docs/reference/configuration-file/variables.md.yaml
@@ -51,6 +51,9 @@ sections:
         `$HOME/.local/share/chezmoi` <br/>
         `%USERPROFILE%/.local/share/chezmoi`
       description: Source directory
+    tempDir:
+      default: '*from system*'
+      description: Temporary directory
     umask:
       type: int
       default: '*from system*'

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -115,6 +115,7 @@ type ConfigFile struct {
 	ScriptEnv              map[string]string              `json:"scriptEnv"       mapstructure:"scriptEnv"       yaml:"scriptEnv"`
 	ScriptTempDir          chezmoi.AbsPath                `json:"scriptTempDir"   mapstructure:"scriptTempDir"   yaml:"scriptTempDir"`
 	SourceDirAbsPath       chezmoi.AbsPath                `json:"sourceDir"       mapstructure:"sourceDir"       yaml:"sourceDir"`
+	TempDir                chezmoi.AbsPath                `json:"tempDir"         mapstructure:"tempDir"         yaml:"tempDir"`
 	Template               templateConfig                 `json:"template"        mapstructure:"template"        yaml:"template"`
 	TextConv               textConv                       `json:"textConv"        mapstructure:"textConv"        yaml:"textConv"`
 	Umask                  fs.FileMode                    `json:"umask"           mapstructure:"umask"           yaml:"umask"`
@@ -2631,7 +2632,7 @@ func (c *Config) tempDir(key string) (chezmoi.AbsPath, error) {
 	if tempDirAbsPath, ok := c.tempDirs[key]; ok {
 		return tempDirAbsPath, nil
 	}
-	tempDir, err := os.MkdirTemp("", key)
+	tempDir, err := os.MkdirTemp(c.TempDir.String(), key)
 	chezmoilog.InfoOrError(c.logger, "MkdirTemp", err, slog.String("tempDir", tempDir))
 	if err != nil {
 		return chezmoi.EmptyAbsPath, err
@@ -2709,7 +2710,8 @@ func newConfigFile(bds *xdg.BaseDirectorySpecification) ConfigFile {
 		PINEntry: pinEntryConfig{
 			Options: pinEntryDefaultOptions,
 		},
-		Safe: true,
+		Safe:    true,
+		TempDir: chezmoi.NewAbsPath(os.TempDir()),
 		Template: templateConfig{
 			Options: chezmoi.DefaultTemplateOptions,
 		},

--- a/internal/cmd/editcmd.go
+++ b/internal/cmd/editcmd.go
@@ -144,10 +144,8 @@ TARGET_REL_PATH:
 			// Attempt to create the hard link. If this succeeds, continue to
 			// the next target. Hardlinking will fail if the temporary directory
 			// is on a different filesystem to the source directory, which is
-			// not the case for most users.
-			//
-			// FIXME create a temporary directory on the same filesystem as the
-			// source directory if needed.
+			// not the case for most users. The user can set the tempDir
+			// configuration variable if needed.
 			if err := os.MkdirAll(hardlinkAbsPath.Dir().String(), 0o700); err != nil {
 				return err
 			}


### PR DESCRIPTION
Fixes #3846.

@kjkent would you be able to test this?

tl;dr set the `tempDir` configuration variable in your config file to be a directory in the same btrfs subvolume as your source directory. If it's in your source directory then be sure to add it to your `.gitignore` as well.