### PR TITLE
chore: Build with Go 1.23

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,9 +16,9 @@ env:
   CHOCOLATEY_VERSION: 2.2.2 # https://github.com/chocolatey/choco/releases
   EDITORCONFIG_CHECKER_VERSION: 3.0.3 # https://github.com/editorconfig-checker/editorconfig-checker/releases
   FIND_TYPOS_VERSION: 0.0.3 # https://github.com/twpayne/find-typos/tags
-  GO_VERSION: 1.22.6 # https://go.dev/doc/devel/release
+  GO_VERSION: 1.23.0 # https://go.dev/doc/devel/release
   GOFUMPT_VERSION: 0.6.0 # https://github.com/mvdan/gofumpt/releases
-  GOLANGCI_LINT_VERSION: 1.59.1 # https://github.com/golangci/golangci-lint/releases
+  GOLANGCI_LINT_VERSION: 1.60.1 # https://github.com/golangci/golangci-lint/releases
   GOLINES_VERSION: 0.12.2 # https://github.com/segmentio/golines/releases
   GORELEASER_VERSION: 2.1.0 # https://github.com/goreleaser/goreleaser/releases
   GOVERSIONINFO_VERSION: 1.4.0 # https://github.com/josephspurrier/goversioninfo/releases

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  go: '1.21'
+  go: '1.23'
 
 linters:
   enable:
@@ -8,6 +8,7 @@ linters:
   - bodyclose
   - canonicalheader
   - containedctx
+  - copyloopvar
   - decorder
   - dogsled
   - dupword
@@ -17,7 +18,6 @@ linters:
   - errchkjson
   - errname
   - errorlint
-  - exportloopref
   - fatcontext
   - forbidigo
   - forcetypeassert
@@ -40,6 +40,7 @@ linters:
   - inamedparam
   - ineffassign
   - interfacebloat
+  - intrange
   - loggercheck
   - makezero
   - mirror
@@ -78,12 +79,12 @@ linters:
   disable:
   - asasalint
   - contextcheck
-  - copyloopvar
   - cyclop
   - depguard
   - dupl
   - exhaustive
   - exhaustruct
+  - exportloopref
   - funlen
   - ginkgolinter
   - gochecknoglobals

--- a/assets/chezmoi.io/docs/developer-guide/index.md
+++ b/assets/chezmoi.io/docs/developer-guide/index.md
@@ -2,7 +2,7 @@
 
 chezmoi is written in [Go](https://golang.org) and development happens on
 [GitHub](https://github.com). chezmoi is a standard Go project, using standard
-Go tooling. chezmoi requires Go 1.21 or later.
+Go tooling. chezmoi requires Go 1.22 or later.
 
 Checkout chezmoi:
 
@@ -25,8 +25,9 @@ $ go test ./...
 
 chezmoi's tests include integration tests with other software. If the other
 software is not found in `$PATH` the tests will be skipped. Running the full set
-of tests requires `age`, `base64`, `bash`, `gpg`, `perl`, `python3`, `rage`,
-`ruby`, `sed`, `sha256sum`, `unzip`, `xz`, `zip`, and `zstd`.
+of tests requires `age`, `base64`, `bash`, `bzip2`, `git`, `gpg`, `gzip`,
+`perl`, `python3`, `rage`, `ruby`, `sed`, `sha256sum`, `tr`, `true`, `unzip`,
+`xz`, `zip`, and `zstd`.
 
 Run chezmoi:
 

--- a/assets/chezmoi.io/docs/install.md.tmpl
+++ b/assets/chezmoi.io/docs/install.md.tmpl
@@ -250,13 +250,13 @@ pre-built binary and shell completions.
 
 === "OpenBSD"
 
-{{ range $arch := list "amd64" "arm" "arm64" "i386" "ppc64" }}
+{{ range $arch := list "amd64" "arm" "arm64" "i386" "ppc64" "riscv64" }}
     [`{{ $arch }}`](https://github.com/twpayne/chezmoi/releases/download/v{{ $version }}/chezmoi_{{ $version }}_openbsd_{{ $arch }}.tar.gz)
 {{- end }}
 
 ## Install from source
 
-Download, build, and install chezmoi for your system with Go 1.21 or later:
+Download, build, and install chezmoi for your system with Go 1.22 or later:
 
 ```console
 $ git clone https://github.com/twpayne/chezmoi.git

--- a/assets/scripts/install-local-bin.sh
+++ b/assets/scripts/install-local-bin.sh
@@ -172,6 +172,7 @@ check_goos_goarch() {
 	openbsd/arm) return 0 ;;
 	openbsd/arm64) return 0 ;;
 	openbsd/ppc64) return 0 ;;
+	openbsd/riscv64) return 0 ;;
 	windows/386) return 0 ;;
 	windows/amd64) return 0 ;;
 	windows/arm) return 0 ;;

--- a/assets/scripts/install.sh
+++ b/assets/scripts/install.sh
@@ -172,6 +172,7 @@ check_goos_goarch() {
 	openbsd/arm) return 0 ;;
 	openbsd/arm64) return 0 ;;
 	openbsd/ppc64) return 0 ;;
+	openbsd/riscv64) return 0 ;;
 	windows/386) return 0 ;;
 	windows/amd64) return 0 ;;
 	windows/arm) return 0 ;;

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/twpayne/chezmoi/v2
 
-go 1.21.4
-
-toolchain go1.22.0
+go 1.22.0
 
 require (
 	filippo.io/age v1.2.0

--- a/internal/chezmoi/encryption_test.go
+++ b/internal/chezmoi/encryption_test.go
@@ -2,7 +2,7 @@ package chezmoi
 
 import (
 	"errors"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"os/exec"
 	"testing"
@@ -118,7 +118,7 @@ func testEncryptionEncryptFile(t *testing.T, encryption Encryption) {
 
 func TestXOREncryption(t *testing.T) {
 	testEncryption(t, &xorEncryption{
-		key: byte(rand.Intn(255) + 1),
+		key: byte(rand.N(255) + 1),
 	})
 }
 

--- a/internal/chezmoi/sourcestate.go
+++ b/internal/chezmoi/sourcestate.go
@@ -1341,7 +1341,6 @@ func (s *SourceState) addExternal(sourceAbsPath, parentAbsPath AbsPath) error {
 	s.Lock()
 	defer s.Unlock()
 	for path, external := range externals {
-		external := external
 		if strings.HasPrefix(path, "/") || filepath.IsAbs(path) {
 			return fmt.Errorf("%s: %s: path is not relative", sourceAbsPath, path)
 		}

--- a/internal/chezmoi/sourcestate_test.go
+++ b/internal/chezmoi/sourcestate_test.go
@@ -2028,7 +2028,7 @@ func withTemplates(templates map[string]*Template) SourceStateOption {
 
 func manyScripts(amount int) map[string]any {
 	scripts := map[string]any{}
-	for i := 0; i < amount; i++ {
+	for i := range amount {
 		scripts[fmt.Sprintf("run_onchange_before_%d.sh", i)] = ""
 	}
 	return scripts

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bufio"
 	"bytes"
+	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
@@ -1221,7 +1222,7 @@ func (c *Config) editor(args []string) (string, []string, error) {
 	}
 
 	// Prefer $VISUAL over $EDITOR and fallback to the OS's default editor.
-	editCommand = firstNonEmptyString(os.Getenv("VISUAL"), os.Getenv("EDITOR"), defaultEditor)
+	editCommand = cmp.Or(os.Getenv("VISUAL"), os.Getenv("EDITOR"), defaultEditor)
 
 	return parseCommand(editCommand, append(editArgs, args...))
 }
@@ -2270,7 +2271,7 @@ func (c *Config) newTemplateData(cmd *cobra.Command) *templateData {
 	// solutions.
 	var gid, group, uid, username string
 	if runtime.GOOS == "android" {
-		username = firstNonEmptyString(os.Getenv("LOGNAME"), os.Getenv("USER"))
+		username = cmp.Or(os.Getenv("LOGNAME"), os.Getenv("USER"))
 	} else if currentUser, err := user.Current(); err == nil {
 		gid = currentUser.Gid
 		uid = currentUser.Uid
@@ -2753,7 +2754,7 @@ func newConfigFile(bds *xdg.BaseDirectorySpecification) ConfigFile {
 			Command: "doppler",
 		},
 		Ejson: ejsonConfig{
-			KeyDir: firstNonEmptyString(os.Getenv("EJSON_KEYDIR"), "/opt/ejson/keys"),
+			KeyDir: cmp.Or(os.Getenv("EJSON_KEYDIR"), "/opt/ejson/keys"),
 		},
 		Gopass: gopassConfig{
 			Command: "gopass",

--- a/internal/cmd/doctorcmd_unix.go
+++ b/internal/cmd/doctorcmd_unix.go
@@ -8,7 +8,6 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
-	"runtime"
 
 	"golang.org/x/sys/unix"
 
@@ -41,9 +40,6 @@ func (unameCheck) Name() string {
 }
 
 func (unameCheck) Run(system chezmoi.System, homeDirAbsPath chezmoi.AbsPath) (checkResult, string) {
-	if runtime.GOOS == "windows" {
-		return checkResultOmitted, ""
-	}
 	cmd := exec.Command("uname", "-a")
 	cmd.Stderr = os.Stderr
 	data, err := chezmoilog.LogCmdOutput(slog.Default(), cmd)

--- a/internal/cmd/util.go
+++ b/internal/cmd/util.go
@@ -89,17 +89,6 @@ func englishListWithNoun(ss []string, singular, plural string) string {
 	}
 }
 
-// firstNonEmptyString returns its first non-empty argument, or "" if all
-// arguments are empty.
-func firstNonEmptyString(ss ...string) string {
-	for _, s := range ss {
-		if s != "" {
-			return s
-		}
-	}
-	return ""
-}
-
 // pluralize returns the English plural form of singular.
 func pluralize(singular string) string {
 	if strings.HasSuffix(singular, "y") {


### PR DESCRIPTION
This is a draft PR for when Go 1.23 is released (sometime in August).

The release of Go 1.23 means that Go 1.21 will no longer be supported so we can use Go 1.22 features.