### PR TITLE
chore: Limit commit hash length to seven characters in website

### DIFF
--- a/assets/chezmoi.io/docs/reference/release-history.md.tmpl
+++ b/assets/chezmoi.io/docs/reference/release-history.md.tmpl
@@ -20,7 +20,7 @@
    | replaceAllRegex "\\(#(\\d+)[)]" "(https://github.com/twpayne/chezmoi/pull/$1)"
    | replaceAllRegex "(https://github\\.com/twpayne/chezmoi/pull/(\\d+))" "[#$2]($1)"
    | replaceAllRegex "(?m)^([0-9a-f]{7,})" "* $1"
-   | replaceAllRegex "(?m)^\\* ([0-9a-f]{7,})" "* [`$1`](https://github.com/twpayne/chezmoi/commit/$1)"
+   | replaceAllRegex "(?m)^\\* (([0-9a-f]{7})[0-9a-f]*)" "* [`$2`](https://github.com/twpayne/chezmoi/commit/$1)"
    | replaceAllRegex "\\r\\n" "\\n"
    | trim
    | default "Internal changes only"


### PR DESCRIPTION
@bradenhilton spotted the long commit hashes in the 2.51.0 [release notes](https://www.chezmoi.io/reference/release-history/) in https://github.com/twpayne/chezmoi/pull/3867#issuecomment-2229751267. This should fix it.