### PR TITLE
feat: Support YubiKeys in KeePassXC open mode

### DIFF
--- a/assets/chezmoi.io/docs/reference/templates/keepassxc-functions/index.md
+++ b/assets/chezmoi.io/docs/reference/templates/keepassxc-functions/index.md
@@ -16,4 +16,5 @@ password prompt can be disabled by setting `keepassxc.prompt` to `false`.
 By default, chezmoi will prompt for the KeePassXC password when required and
 cache it for the duration of chezmoi's execution. Setting `keepassxc.mode` to
 `open` will tell chezmoi to instead open KeePassXC's console with `keepassxc-cli
-open`. chezmoi will use this console to request values from KeePassXC.
+open` followed by `keepassxc.args`. chezmoi will use this console to request
+values from KeePassXC.

--- a/assets/chezmoi.io/docs/user-guide/password-managers/keepassxc.md
+++ b/assets/chezmoi.io/docs/user-guide/password-managers/keepassxc.md
@@ -33,6 +33,7 @@ If your database is not password protected, add `--no-password` to
 
 ```toml title="~/.config/chezmoi/chezmoi.toml"
 [keepassxc]
+    database = "/home/user/Passwords.kdbx"
     args = ["--no-password"]
     prompt = false
 ```
@@ -45,6 +46,7 @@ set your YubiKey, for example:
 
 ```toml title="~/.config/chezmoi/chezmoi.toml"
 [keepassxc]
-    args = ["--yubikey", "1:7370001"]
+    database = "/home/user/Passwords.kdbx"
+    args = ["--no-password", "--yubikey", "2:7370001"]
     mode = "open"
 ```


### PR DESCRIPTION
Fixes #3910.

@mihakrumpestar would you be able to test this? tl;dr replace `keepassxc.args` with `keepassxc.openArgs` in your config file and it should work.

It's not easy for me to write a test for it because I don't use KeePassXC, don't have a YubiKey, and the "open" mode has two processes communicating with each other through a terminal.