### PR TITLE
chore: Show curl download errors in install script

### DIFF
--- a/assets/scripts/install-local-bin.sh
+++ b/assets/scripts/install-local-bin.sh
@@ -239,9 +239,9 @@ http_download_curl() {
 	source_url="${2}"
 	header="${3}"
 	if [ -z "${header}" ]; then
-		code="$(curl -w '%{http_code}' -sL -o "${local_file}" "${source_url}")"
+		code="$(curl -w '%{http_code}' -fsSL -o "${local_file}" "${source_url}")"
 	else
-		code="$(curl -w '%{http_code}' -sL -H "${header}" -o "${local_file}" "${source_url}")"
+		code="$(curl -w '%{http_code}' -fsSL -H "${header}" -o "${local_file}" "${source_url}")"
 	fi
 	if [ "${code}" != "200" ]; then
 		log_debug "http_download_curl received HTTP status ${code}"

--- a/assets/scripts/install.sh
+++ b/assets/scripts/install.sh
@@ -239,9 +239,9 @@ http_download_curl() {
 	source_url="${2}"
 	header="${3}"
 	if [ -z "${header}" ]; then
-		code="$(curl -w '%{http_code}' -sL -o "${local_file}" "${source_url}")"
+		code="$(curl -w '%{http_code}' -fsSL -o "${local_file}" "${source_url}")"
 	else
-		code="$(curl -w '%{http_code}' -sL -H "${header}" -o "${local_file}" "${source_url}")"
+		code="$(curl -w '%{http_code}' -fsSL -H "${header}" -o "${local_file}" "${source_url}")"
 	fi
 	if [ "${code}" != "200" ]; then
 		log_debug "http_download_curl received HTTP status ${code}"

--- a/internal/cmds/generate-install.sh/install.sh.tmpl
+++ b/internal/cmds/generate-install.sh/install.sh.tmpl
@@ -214,9 +214,9 @@ http_download_curl() {
 	source_url="${2}"
 	header="${3}"
 	if [ -z "${header}" ]; then
-		code="$(curl -w '%{http_code}' -sL -o "${local_file}" "${source_url}")"
+		code="$(curl -w '%{http_code}' -fsSL -o "${local_file}" "${source_url}")"
 	else
-		code="$(curl -w '%{http_code}' -sL -H "${header}" -o "${local_file}" "${source_url}")"
+		code="$(curl -w '%{http_code}' -fsSL -H "${header}" -o "${local_file}" "${source_url}")"
 	fi
 	if [ "${code}" != "200" ]; then
 		log_debug "http_download_curl received HTTP status ${code}"


### PR DESCRIPTION
This adds two options to curl downloads in the install script:

* `-f` (long version `--fail`), which tells curl to fail fast on server errors.

* `-S` (long version `--show-error`) which tells curl to show an error when it fails.

Fixes #3756 (I hope). I could not find equivalent options for downloading with `wget`.