### PR TITLE
docs: Add notes where to place 'encryption' setting

### DIFF
--- a/assets/chezmoi.io/docs/user-guide/encryption/age.md
+++ b/assets/chezmoi.io/docs/user-guide/encryption/age.md
@@ -22,6 +22,11 @@ encryption = "age"
 chezmoi supports multiple recipients and recipient files, and multiple
 identities.
 
+!!! note
+
+    Make sure `encryption` is added to the top level section at the beginning of
+    the config, before any other sections.
+
 ## Symmetric encryption
 
 To use age's symmetric encryption, specify a single identity and enable

--- a/assets/chezmoi.io/docs/user-guide/encryption/gpg.md
+++ b/assets/chezmoi.io/docs/user-guide/encryption/gpg.md
@@ -24,6 +24,11 @@ gpg --armor --recipient $RECIPIENT --encrypt
 and store the encrypted file in the source state. The file will automatically
 be decrypted when generating the target state.
 
+!!! note
+
+    Make sure `encryption` is added to the top level section at the beginning of
+    the config, before any other sections.
+
 ## Symmetric encryption
 
 Specify symmetric encryption in your configuration file:

--- a/assets/chezmoi.io/docs/user-guide/encryption/rage.md
+++ b/assets/chezmoi.io/docs/user-guide/encryption/rage.md
@@ -10,4 +10,9 @@ encryption = "age"
     command = "rage"
 ```
 
+!!! note
+
+    Make sure `encryption` is added to the top level section at the beginning of
+    the config, before any other sections.
+
 Then, configure chezmoi as you would for [age](age.md).

--- a/assets/chezmoi.io/docs/user-guide/frequently-asked-questions/encryption.md
+++ b/assets/chezmoi.io/docs/user-guide/frequently-asked-questions/encryption.md
@@ -51,18 +51,16 @@ fi
 EOF
 ```
 
-Configure chezmoi to use the public and private key for encryption:
+Specify the public and private keys for encryption.
+`age.recipient` must be your public key from above.
+Make sure `encryption` is added at the beginning, before any other sections.
 
-```console
-$ cat >> .chezmoi.toml.tmpl <<EOF
+```toml title="~/.config/chezmoi/chezmoi.toml"
 encryption = "age"
 [age]
     identity = "~/.config/chezmoi/key.txt"
     recipient = "age193wd0hfuhtjfsunlq3c83s8m93pde442dkcn7lmj3lspeekm9g7stwutrl"
-EOF
 ```
-
-`age.recipient` must be your public key from above.
 
 Run `chezmoi init --apply` to generate the chezmoi's config file and decrypt the
 private key:


### PR DESCRIPTION
Follow up to #3980 

* Advice to append content to the config in `encryption.md` very likely will cause `encryption` set incorrectly if config is not empty. Replace it with instructions what to do because command to prepend file in bash is a bit cumbersome and may also lead to incorrect config if other global settings are specified already.
* Add notes to articles about each encryption method to be careful with placement of `encryption` setting.

