### PR TITLE
feat: Add darwinVersion to template data

### DIFF
--- a/assets/chezmoi.io/docs/reference/templates/variables.md
+++ b/assets/chezmoi.io/docs/reference/templates/variables.md
@@ -9,6 +9,7 @@ chezmoi provides the following automatically-populated variables:
 | `.chezmoi.cacheDir`           | string   | The cache directory                                                                                                                                   |
 | `.chezmoi.config`             | object   | The configuration, as read from the config file                                                                                                       |
 | `.chezmoi.configFile`         | string   | The path to the configuration file used by chezmoi                                                                                                    |
+| `.chezmoi.darwinVersion`      | object   | macOS version information, if running on macOS                                                                                                        |
 | `.chezmoi.executable`         | string   | The path to the `chezmoi` executable, if available                                                                                                    |
 | `.chezmoi.fqdnHostname`       | string   | The fully-qualified domain name hostname of the machine chezmoi is running on                                                                         |
 | `.chezmoi.gid`                | string   | The primary group ID                                                                                                                                  |
@@ -31,6 +32,19 @@ chezmoi provides the following automatically-populated variables:
 | `.chezmoi.version.version`    | string   | The version of chezmoi                                                                                                                                |
 | `.chezmoi.windowsVersion`     | object   | Windows version information, if running on Windows                                                                                                    |
 | `.chezmoi.workingTree`        | string   | The working tree of the source directory                                                                                                              |
+
+`.chezmoi.darwinVersion` contains the following keys populated from the
+`sw_vers` tool.
+
+| Key                         | Type    |
+| --------------------------- | ------- |
+| `buildVersion`              | string  |
+| `productName`               | string  |
+| `productVersion`            | string  |
+| `productVersionExtra`       | string  |
+| `productMajorVersion`       | integer |
+| `productMinorVersion`       | integer |
+| `productPatchVersion`       | integer |
 
 `.chezmoi.windowsVersion` contains the following keys populated from the
 registry key `Computer\HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows

--- a/assets/chezmoi.io/docs/user-guide/machines/macos.md
+++ b/assets/chezmoi.io/docs/user-guide/machines/macos.md
@@ -34,3 +34,12 @@ machine is connected to. For a stable result, use the `scutil` command:
 ```
 {{ $computerName := output "scutil" "--get" "ComputerName" | trim }}
 ```
+
+## Run script after every macOS update
+
+You can automate a script to run after each macOS update by creating
+a `run_onchange_` script using the `.chezmoi.darwinVersion` template:
+
+```
+# MacOS build version: {{ .chezmoi.darwinVersion.buildVersion }}
+```

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -267,6 +267,7 @@ type templateData struct {
 	commandDir        chezmoi.AbsPath
 	config            map[string]any
 	configFile        chezmoi.AbsPath
+	darwinVersion     map[string]any
 	executable        chezmoi.AbsPath
 	fqdnHostname      string
 	gid               string
@@ -1496,6 +1497,7 @@ func (c *Config) getTemplateDataMap(cmd *cobra.Command) map[string]any {
 			"commandDir":        templateData.commandDir.String(),
 			"config":            templateData.config,
 			"configFile":        templateData.configFile.String(),
+			"darwinVersion":     templateData.darwinVersion,
 			"executable":        templateData.executable.String(),
 			"fqdnHostname":      templateData.fqdnHostname,
 			"gid":               templateData.gid,
@@ -2217,6 +2219,7 @@ func (c *Config) persistentPreRunRootE(cmd *cobra.Command, args []string) error 
 		os.Setenv("CHEZMOI_VERBOSE", "1")
 	}
 	for groupKey, group := range map[string]map[string]any{
+		"DARWIN_VERSION":  templateData.darwinVersion,
 		"KERNEL":          templateData.kernel,
 		"OS_RELEASE":      templateData.osRelease,
 		"VERSION":         templateData.version,
@@ -2354,6 +2357,7 @@ func (c *Config) newTemplateData(cmd *cobra.Command) *templateData {
 	}
 
 	executable, _ := os.Executable()
+	darwinVersion, _ := darwinVersion()
 	windowsVersion, _ := windowsVersion()
 	sourceDirAbsPath, _ := c.getSourceDirAbsPath(nil)
 
@@ -2365,6 +2369,7 @@ func (c *Config) newTemplateData(cmd *cobra.Command) *templateData {
 		commandDir:        c.commandDirAbsPath,
 		config:            c.ConfigFile.toMap(),
 		configFile:        c.getConfigFileAbsPath(),
+		darwinVersion:     darwinVersion,
 		executable:        chezmoi.NewAbsPath(executable),
 		fqdnHostname:      fqdnHostname,
 		gid:               gid,

--- a/internal/cmd/testdata/scripts/templatevars.txtar
+++ b/internal/cmd/testdata/scripts/templatevars.txtar
@@ -24,3 +24,22 @@ exec chezmoi execute-template '{{ .chezmoi.os }}'
 
 exec chezmoi execute-template '{{ .chezmoi.sourceDir }}'
 stdout ${CHEZMOISOURCEDIR@R}
+
+exec chezmoi execute-template '{{ get .chezmoi.darwinVersion "productName" }}'
+[darwin] stdout macOS
+[!darwin] stdout ^$
+
+[darwin] exec chezmoi execute-template '{{ .chezmoi.darwinVersion.productVersion }}'
+[darwin] stdout ^\d+.\d+(.\d+)?$
+
+[darwin] exec chezmoi execute-template '{{ .chezmoi.darwinVersion.productMajorVersion }}'
+[darwin] stdout ^\d+$
+
+[darwin] exec chezmoi execute-template '{{ .chezmoi.darwinVersion.productMinorVersion }}'
+[darwin] stdout ^\d+$
+
+[darwin] exec chezmoi execute-template '{{ .chezmoi.darwinVersion.productPatchVersion }}'
+[darwin] stdout ^\d+$
+
+[darwin] exec chezmoi execute-template '{{ .chezmoi.darwinVersion.buildVersion }}'
+[darwin] stdout ^[0-9A-Z]+$

--- a/internal/cmd/util_unix.go
+++ b/internal/cmd/util_unix.go
@@ -4,6 +4,10 @@ package cmd
 
 import (
 	"io/fs"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
 	"syscall"
 
 	"github.com/twpayne/chezmoi/v2/internal/chezmoi"
@@ -15,6 +19,54 @@ var defaultInterpreters = make(map[string]chezmoi.Interpreter)
 
 func fileInfoUID(info fs.FileInfo) int {
 	return int(info.Sys().(*syscall.Stat_t).Uid) //nolint:forcetypeassert
+}
+
+func darwinVersion() (map[string]any, error) {
+	if runtime.GOOS != "darwin" {
+		return nil, nil
+	}
+	darwinVersion := make(map[string]any)
+	for _, name := range []string{
+		"buildVersion",
+		"productName",
+		"productVersion",
+		"productVersionExtra",
+	} {
+		output, err := exec.Command("sw_vers", "--"+name).Output()
+		if err != nil {
+			return nil, err
+		}
+		darwinVersion[name] = strings.TrimSpace(string(output))
+	}
+
+	productVersion, ok := darwinVersion["productVersion"].(string)
+	if ok {
+		versionParts := strings.Split(productVersion, ".")
+		var err error
+		major, minor, patch := 0, 0, 0
+		if len(versionParts) > 0 {
+			major, err = strconv.Atoi(versionParts[0])
+			if err != nil {
+				return nil, err
+			}
+		}
+		if len(versionParts) > 1 {
+			minor, err = strconv.Atoi(versionParts[1])
+			if err != nil {
+				return nil, err
+			}
+		}
+		if len(versionParts) > 2 {
+			patch, err = strconv.Atoi(versionParts[2])
+			if err != nil {
+				return nil, err
+			}
+		}
+		darwinVersion["productMajorVersion"] = major
+		darwinVersion["productMinorVersion"] = minor
+		darwinVersion["productPatchVersion"] = patch
+	}
+	return darwinVersion, nil
 }
 
 func windowsVersion() (map[string]any, error) {

--- a/internal/cmd/util_windows.go
+++ b/internal/cmd/util_windows.go
@@ -34,6 +34,10 @@ var defaultInterpreters = map[string]chezmoi.Interpreter{
 	},
 }
 
+func darwinVersion() (map[string]any, error) {
+	return nil, nil
+}
+
 func windowsVersion() (map[string]any, error) {
 	registryKey, err := registry.OpenKey(
 		registry.LOCAL_MACHINE,


### PR DESCRIPTION
There is `windowsVersion` for Windows and `osRelease` for Linux but nothing for MacOS. Add similar `darwinVersion` section for MacOS.

## Implementation

Here I added a new dependency to read .plist file. It's possible to do it without new dependencies by running `sw_vers` tool and parsing its output. I have such version here: https://github.com/KapJI/chezmoi/commit/38b949aebd38d0fef33e029a2cafb3b1937ab4de . Reading plist should be more lightweight and closer to Windows version which reads registry. Let me know which one you prefer.

## Use case

I want to have run_onchange script which runs after software update which resets some settings. Currently I can think of some hacky solutions using script which writes `sw_vers` output to file on each `chezmoi apply` and then reading it using `include` template function. This will make it more straightfordard and simpler.

If you agree this is useful, I can add some tests.

