### PR TITLE
docs: Add example for running script on macOS update

### DIFF
--- a/assets/chezmoi.io/docs/user-guide/machines/macos.md
+++ b/assets/chezmoi.io/docs/user-guide/machines/macos.md
@@ -34,3 +34,12 @@ machine is connected to. For a stable result, use the `scutil` command:
 ```
 {{ $computerName := output "scutil" "--get" "ComputerName" | trim }}
 ```
+
+## Run script after every macOS update
+
+You can automate a script to run after each macOS update by creating
+a `run_onchange_` script and using the `output` template function to run `sw_vers`:
+
+```
+# MacOS build version: {{ output "sw_vers" "--buildVersion" }}
+```


### PR DESCRIPTION
Somehow I overlooked existense of `output` for executing arbitrary commands. I guess its name doesn't give a hint that it runs something.

Add an example in user guide section from #3983 to show one more case how it can be used.