### PR TITLE
docs: Improve description for command arguments

### DIFF
--- a/assets/chezmoi.io/docs/reference/command-line-flags/common.md
+++ b/assets/chezmoi.io/docs/reference/command-line-flags/common.md
@@ -6,10 +6,21 @@ The following flags apply to multiple commands where they are relevant.
 
 Set the output format.
 
+## `-h`, `--help`
+
+Print help.
+
 ## `-i`, `--include` *types*
 
-Include target state entries of type *types*. *types* is a comma-separated list
-of types:
+Include target state entries of type *types*.
+
+!!! example
+
+    `--include=files` specifies all files.
+
+### Available types
+
+*types* is a comma-separated list of types:
 
 | Type        | Description                 |
 | ----------- | --------------------------- |
@@ -29,18 +40,10 @@ Types can be preceded with `no` to remove them.
 
 Types can be explicitly excluded with the `--exclude` flag.
 
-!!! example
-
-    `--include=files` specifies all files.
-
 ## `--init`
 
 Regenerate and reread the config file from the config file template before
 computing the target state.
-
-## `--interactive`
-
-Prompt before applying each target.
 
 ## `-o`, `--output` *filename*
 
@@ -54,11 +57,6 @@ Also perform command on all parent directories of *target*.
 
 Recurse into subdirectories, `true` by default.
 
-## `--source-path`
-
-Interpret *targets* passed to the command as paths in the source directory
-rather than the destination directory.
-
 ## `--tree`
 
 Print paths as a tree instead of a list.
@@ -70,8 +68,7 @@ is set.
 
 ## `-x`, `--exclude` *types*
 
-Exclude target state entries of type *types*. *types* is defined as in the
-`--include` flag and defaults to `none`.
+Exclude target state entries of type [*types*](#available-types). Defaults to `none`.
 
 !!! example
 

--- a/assets/chezmoi.io/docs/reference/command-line-flags/global.md
+++ b/assets/chezmoi.io/docs/reference/command-line-flags/global.md
@@ -40,13 +40,17 @@ changes that would be made without making them.
 
 Make changes without prompting.
 
-## `-h`, `--help`
+## `--interactive`
 
-Print help.
+Prompt before applying each target.
 
 ## `-k`, `--keep-going`
 
 Keep going as far as possible after a encountering an error.
+
+## `--mode` `file`|`symlink`
+
+Mode of operation. The default is `file`.
 
 ## `--no-pager`
 
@@ -89,6 +93,11 @@ if no cached external is available.
 > Configuration: `sourceDir`
 
 Use *directory* as the source directory.
+
+## `--source-path`
+
+Interpret *targets* passed to the command as paths in the source directory
+rather than the destination directory.
 
 ## `--use-builtin-age` *value*
 

--- a/assets/chezmoi.io/docs/reference/commands/add.md
+++ b/assets/chezmoi.io/docs/reference/commands/add.md
@@ -17,11 +17,23 @@ This implies the `--template` option.
     templates with unwanted variable substitutions. Carefully review any
     templates it generates.
 
+## `--create`
+
+Add files that should exist, irrespective of their contents.
+
 ## `--encrypt`
 
 > Configuration: `add.encrypt`
 
 Encrypt files using the defined encryption method.
+
+## `--exact`
+
+Set the `exact` attribute on added directories.
+
+## `-x`, `--exclude` *types*
+
+Exclude entries of type [*types*](../command-line-flags/common.md#available-types),  defaults to `none`.
 
 ## `-f`, `--force`
 
@@ -33,13 +45,9 @@ overwritten.
 If the last part of a target is a symlink, add the target of the symlink
 instead of the symlink itself.
 
-## `--exact`
-
-Set the `exact` attribute on added directories.
-
 ## `-i`, `--include` *types*
 
-Only add entries of type *types*.
+Only add entries of type [*types*](../command-line-flags/common.md#available-types), defaults to `all`.
 
 ## `-p`, `--prompt`
 
@@ -51,7 +59,7 @@ Suppress warnings about adding ignored entries.
 
 ## `-r`, `--recursive`
 
-Recursively add all files, directories, and symlinks.
+Recursively add all files, directories, and symlinks, `true` by default. Can be disabled with `--recursive=false`.
 
 ## `-s`, `--secrets` `ignore`|`warning`|`error`
 

--- a/assets/chezmoi.io/docs/reference/commands/age.md
+++ b/assets/chezmoi.io/docs/reference/commands/age.md
@@ -2,13 +2,17 @@
 
 Interact with age's passphrase-based encryption.
 
-!!! hint
+# `age encrypt` [*file*...]
 
-    To get a full list of subcommands run:
+## `-p`, `--passphrase`
 
-    ```console
-    $ chezmoi age help
-    ```
+Encrypt with a passphrase.
+
+# `age decrypt` [*file*...]
+
+## `-p`, `--passphrase`
+
+Decrypt with a passphrase.
 
 !!! example
 

--- a/assets/chezmoi.io/docs/reference/commands/apply.md
+++ b/assets/chezmoi.io/docs/reference/commands/apply.md
@@ -5,9 +5,21 @@ no targets are specified, the state of all targets are ensured. If a target has
 been modified since chezmoi last wrote it then the user will be prompted if
 they want to overwrite the file.
 
+## `-x`, `--exclude` *types*
+
+Exclude entries of type [*types*](../command-line-flags/common.md#available-types),  defaults to `none`.
+
 ## `-i`, `--include` *types*
 
-Only add entries of type *types*.
+Only add entries of type [*types*](../command-line-flags/common.md#available-types), defaults to `all`.
+
+## `--init`
+
+Recreate config file from template.
+
+## `-r`, `--recursive`
+
+Recurse into subdirectories, `true` by default. Can be disabled with `--recursive=false`.
 
 ## `--source-path`
 

--- a/assets/chezmoi.io/docs/reference/commands/archive.md
+++ b/assets/chezmoi.io/docs/reference/commands/archive.md
@@ -3,19 +3,43 @@
 Generate an archive of the target state, or only the targets specified. This
 can be piped into `tar` to inspect the target state.
 
-## `-f`, `--format` `tar`|`tar.gz`|`tgz`|`zip`
+## `-x`, `--exclude` *types*
+
+Exclude entries of type [*types*](../command-line-flags/common.md#-i-include-types),  defaults to `none`.
+
+## `-f`, `--format` *format*
 
 Write the archive in *format*. If `--output` is set the format is guessed from
 the extension, otherwise the default is `tar`.
 
+| Supported formats |
+| ----------------- |
+| `tar`             |
+| `tar.bz2`         |
+| `tar.gz`          |
+| `tar.xz`          |
+| `tar.zst`         |
+| `tbz2`            |
+| `tgz`             |
+| `txz`             |
+| `zip`             |
+
 ## `-i`, `--include` *types*
 
-Only include entries of type *types*.
+Only add entries of type [*types*](../command-line-flags/common.md#available-types), defaults to `all`.
+
+## `--init`
+
+Recreate config file from template.
 
 ## `-z`, `--gzip`
 
 Compress the archive with gzip. This is automatically set if the format is
 `tar.gz` or `tgz` and is ignored if the format is `zip`.
+
+## `-r`, `--recursive`
+
+Recurse into subdirectories, `true` by default. Can be disabled with `--recursive=false`.
 
 !!! example
 

--- a/assets/chezmoi.io/docs/reference/commands/chattr.md
+++ b/assets/chezmoi.io/docs/reference/commands/chattr.md
@@ -39,6 +39,10 @@ Multiple modifications may be specified by separating them with a comma (`,`).
 If you use the `-`*modifier* form then you must put *modifier* after a `--` to
 prevent chezmoi from interpreting `-`*modifier* as an option.
 
+## `-r`, `--recursive`
+
+Recurse into subdirectories.
+
 !!! example
 
     ```console

--- a/assets/chezmoi.io/docs/reference/commands/data.md
+++ b/assets/chezmoi.io/docs/reference/commands/data.md
@@ -4,7 +4,7 @@ Write the computed template data to stdout.
 
 ## `-f`, `--format` `json`|`yaml`
 
-Set the output format.
+Set the output format, `json` by default.
 
 !!! example
 

--- a/assets/chezmoi.io/docs/reference/commands/destroy.md
+++ b/assets/chezmoi.io/docs/reference/commands/destroy.md
@@ -15,3 +15,7 @@ Remove *target* from the source state, the destination directory, and the state.
 ## `-f`, `--force`
 
 Destroy without prompting.
+
+## `-r`, `--recursive`
+
+Recurse into subdirectories.

--- a/assets/chezmoi.io/docs/reference/commands/diff.md
+++ b/assets/chezmoi.io/docs/reference/commands/diff.md
@@ -15,6 +15,28 @@ respectively. The default value of `diff.args` is
 template arguments then `{{ .Destination }}` and `{{ .Target }}` will be
 appended automatically.
 
+## `-x`, `--exclude` *types*
+
+Exclude entries of type [*types*](../command-line-flags/common.md#available-types),  defaults to `none`.
+
+## `-i`, `--include` *types*
+
+Only add entries of type [*types*](../command-line-flags/common.md#available-types), defaults to `all`.
+
+## `--init`
+
+Recreate config file from template.
+
+## `--pager` *pager*
+
+> Configuration: `diff.pager`
+
+Pager to use for output.
+
+## `-r`, `--recursive`
+
+Recurse into subdirectories.
+
 ## `--reverse`
 
 > Configuration: `diff.reverse`
@@ -22,11 +44,9 @@ appended automatically.
 Reverse the direction of the diff, i.e. show the changes to the target required
 to match the destination.
 
-## `--pager` *pager*
+## `--script-contents`
 
-> Configuration: `diff.pager`
-
-Pager to use for output.
+Show script contents, defaults to `true`.
 
 !!! example
 

--- a/assets/chezmoi.io/docs/reference/commands/dump-config.md
+++ b/assets/chezmoi.io/docs/reference/commands/dump-config.md
@@ -2,6 +2,10 @@
 
 Dump the configuration.
 
+## `-f`, `--format` `json`|`yaml`
+
+Set the output format, `json` by default.
+
 !!! example
 
     ```console

--- a/assets/chezmoi.io/docs/reference/commands/dump.md
+++ b/assets/chezmoi.io/docs/reference/commands/dump.md
@@ -3,13 +3,25 @@
 Dump the target state of *target*s. If no targets are specified, then the
 entire target state.
 
+## `-x`, `--exclude` *types*
+
+Exclude entries of type [*types*](../command-line-flags/common.md#available-types),  defaults to `none`.
+
 ## `-f`, `--format` `json`|`yaml`
 
-Set the output format.
+Set the output format, default to `json`.
 
 ## `-i`, `--include` *types*
 
-Only include entries of type *types*.
+Only add entries of type [*types*](../command-line-flags/common.md#available-types), defaults to `all`.
+
+## `--init`
+
+Recreate config file from template.
+
+## `-r`, `--recursive`
+
+Recurse into subdirectories, `true` by default. Can be disabled with `--recursive=false`.
 
 !!! example
 

--- a/assets/chezmoi.io/docs/reference/commands/edit.md
+++ b/assets/chezmoi.io/docs/reference/commands/edit.md
@@ -18,6 +18,10 @@ editor with filenames which match the target filename, unless the
 
 Apply target immediately after editing. Ignored if there are no targets.
 
+## `-x`, `--exclude` *types*
+
+Exclude entries of type [*types*](../command-line-flags/common.md#available-types),  defaults to `none`.
+
 ## `--hardlink` *bool*
 
 > Configuration: `edit.hardlink`
@@ -25,6 +29,14 @@ Apply target immediately after editing. Ignored if there are no targets.
 Invoke the editor with a hard link to the source file with a name matching the
 target filename. This can help the editor determine the type of the file
 correctly. This is the default.
+
+## `-i`, `--include` *types*
+
+Only add entries of type [*types*](../command-line-flags/common.md#available-types), defaults to `all`.
+
+## `--init`
+
+Recreate config file from template.
 
 ## `--watch`
 

--- a/assets/chezmoi.io/docs/reference/commands/ignored.md
+++ b/assets/chezmoi.io/docs/reference/commands/ignored.md
@@ -2,6 +2,10 @@
 
 Print the list of entries ignored by chezmoi.
 
+## `-t`, `--tree`
+
+Print paths as a tree.
+
 !!! example
 
     ```console

--- a/assets/chezmoi.io/docs/reference/commands/import.md
+++ b/assets/chezmoi.io/docs/reference/commands/import.md
@@ -16,6 +16,14 @@ Set the destination (in the source state) where the archive will be imported.
 
 Set the `exact` attribute on all imported directories.
 
+## `-x`, `--exclude` *types*
+
+Exclude entries of type [*types*](../command-line-flags/common.md#available-types),  defaults to `none`.
+
+## `-i`, `--include` *types*
+
+Only add entries of type [*types*](../command-line-flags/common.md#available-types), defaults to `all`.
+
 ## `-r`, `--remove-destination`
 
 Remove destination (in the source state) before importing.

--- a/assets/chezmoi.io/docs/reference/commands/init.md
+++ b/assets/chezmoi.io/docs/reference/commands/init.md
@@ -55,6 +55,25 @@ existing template data.
 
 Clone the repo with depth *depth*.
 
+## `-x`, `--exclude` *types*
+
+Exclude entries of type [*types*](../command-line-flags/common.md#available-types),  defaults to `none`.
+
+## `--guess-repo-url` *bool*
+
+Guess the repo URL from the *repo* argument. This defaults to `true`.
+
+## `-i`, `--include` *types*
+
+Only add entries of type [*types*](../command-line-flags/common.md#available-types), defaults to `all`.
+
+## `--one-shot`
+
+`--one-shot` is the equivalent of `--apply`, `--depth=1`, `--force`, `--purge`,
+and `--purge-binary`. It attempts to install your dotfiles with chezmoi and
+then remove all traces of chezmoi from the system. This is useful for setting
+up temporary environments (e.g. Docker containers).
+
 ## `--prompt`
 
 Force the `prompt*Once` template functions to prompt.
@@ -91,17 +110,6 @@ Populate the `promptString` template function with values from *pairs*. *pairs* 
 a comma-separated list of *prompt*`=`*value* pairs. If `promptString` is called
 with a *prompt* that does not match any of *pairs*, then it prompts the user for
 a value.
-
-## `--guess-repo-url` *bool*
-
-Guess the repo URL from the *repo* argument. This defaults to `true`.
-
-## `--one-shot`
-
-`--one-shot` is the equivalent of `--apply`, `--depth=1`, `--force`, `--purge`,
-and `--purge-binary`. It attempts to install your dotfiles with chezmoi and
-then remove all traces of chezmoi from the system. This is useful for setting
-up temporary environments (e.g. Docker containers).
 
 ## `--purge`
 

--- a/assets/chezmoi.io/docs/reference/commands/managed.md
+++ b/assets/chezmoi.io/docs/reference/commands/managed.md
@@ -4,10 +4,22 @@ List all managed entries in the destination directory under all *path*s in
 alphabetical order. When no *path*s are supplied, list all managed entries in
 the destination directory in alphabetical order.
 
+## `-x`, `--exclude` *types*
+
+Exclude entries of type [*types*](../command-line-flags/common.md#available-types),  defaults to `none`.
+
+## `-i`, `--include` *types*
+
+Only add entries of type [*types*](../command-line-flags/common.md#available-types), defaults to `all`.
+
 ## `-p`, `--path-style` `absolute`|`relative`|`source-absolute`|`source-relative`
 
 Print paths in the given style. Relative paths are relative to the destination
 directory. The default is `relative`.
+
+## `-t`, `--tree`
+
+Print paths as a tree.
 
 !!! example
 

--- a/assets/chezmoi.io/docs/reference/commands/merge-all.md
+++ b/assets/chezmoi.io/docs/reference/commands/merge-all.md
@@ -3,6 +3,14 @@
 Perform a three-way merge for file whose actual state does not match its target
 state. The merge is performed with `chezmoi merge`.
 
+## `--init`
+
+Recreate config file from template.
+
+## `-r`, `--recursive`
+
+Recurse into subdirectories, `true` by default. Can be disabled with `--recursive=false`.
+
 !!! example
 
     ```console

--- a/assets/chezmoi.io/docs/reference/commands/purge.md
+++ b/assets/chezmoi.io/docs/reference/commands/purge.md
@@ -3,6 +3,10 @@
 Remove chezmoi's configuration, state, and source directory, but leave the
 target state intact.
 
+## `-P`, `--binary`
+
+Purge chezmoi binary.
+
 ## `-f`, `--force`
 
 Remove without prompting.

--- a/assets/chezmoi.io/docs/reference/commands/re-add.md
+++ b/assets/chezmoi.io/docs/reference/commands/re-add.md
@@ -7,9 +7,17 @@ files are ignored. Directories are recursed into by default.
 If no *target*s are specified then all modified files are re-added. If one or
 more *target*s are given then only those targets are re-added.
 
+## `-x`, `--exclude` *types*
+
+Exclude entries of type [*types*](../command-line-flags/common.md#available-types),  defaults to `none`.
+
+## `-i`, `--include` *types*
+
+Only add entries of type [*types*](../command-line-flags/common.md#available-types), defaults to `all`.
+
 ## `-r`, `--recursive`
 
-Recursively add files in subdirectories.
+Recursively add files in subdirectories, `true` by default. Can be disabled with `--recursive=false`.
 
 !!! hint
 

--- a/assets/chezmoi.io/docs/reference/commands/secret.md
+++ b/assets/chezmoi.io/docs/reference/commands/secret.md
@@ -9,13 +9,39 @@ manager. Normally you would use chezmoi's existing template functions to retriev
     If you need to pass flags to the secret manager's CLI you must separate
     them with `--` to prevent chezmoi from interpreting them.
 
-!!! hint
+# `secret keyring delete`
 
-    To get a full list of subcommands run:
+## `--service` *string*
 
-    ```console
-    $ chezmoi secret help
-    ```
+Name of the service.
+
+## `--user` *string*
+
+Name of the user.
+
+# `secret keyring get`
+
+## `--service` *string*
+
+Name of the service.
+
+## `--user` *string*
+
+Name of the user.
+
+# `secret keyring set`
+
+## `--service` *string*
+
+Name of the service.
+
+## `--user` *string*
+
+Name of the user.
+
+## `--value` *string*
+
+New value.
 
 !!! example
 

--- a/assets/chezmoi.io/docs/reference/commands/state.md
+++ b/assets/chezmoi.io/docs/reference/commands/state.md
@@ -10,6 +10,40 @@ Manipulate the persistent state.
     $ chezmoi state help
     ```
 
+# Available subcommands
+
+## `data`
+
+Print the raw data in the persistent state.
+
+## `delete`
+
+Delete a value from the persistent state.
+
+## `delete-bucket`
+
+Delete a bucket from the persistent state.
+
+## `dump`
+
+Generate a dump of the persistent state.
+
+## `get`
+
+Get a value from the persistent state.
+
+## `get-bucket`
+
+Get a bucket from the persistent state.
+
+## `reset`
+
+Reset the persistent state.
+
+## `set`
+
+Set a value from the persistent state
+
 !!! example
 
     ```console

--- a/assets/chezmoi.io/docs/reference/commands/status.md
+++ b/assets/chezmoi.io/docs/reference/commands/status.md
@@ -16,9 +16,26 @@ running [`chezmoi apply`](apply.md) will have.
 | `M`       | Modified  | Entry was modified | Entry will be modified |
 | `R`       | Run       | Not applicable     | Script will be run     |
 
+## `-x`, `--exclude` *types*
+
+Exclude entries of type [*types*](../command-line-flags/common.md#available-types),  defaults to `none`.
+
 ## `-i`, `--include` *types*
 
-Only include entries of type *types*.
+Only add entries of type [*types*](../command-line-flags/common.md#available-types), defaults to `all`.
+
+## `--init`
+
+Recreate config file from template.
+
+## `-p`, `--path-style` `absolute`|`relative`|`source-absolute`|`source-relative`
+
+Print paths in the given style. Relative paths are relative to the destination
+directory. The default is `relative`.
+
+## `-r`, `--recursive`
+
+Recurse into subdirectories, `true` by default. Can be disabled with `--recursive=false`.
 
 !!! example
 

--- a/assets/chezmoi.io/docs/reference/commands/unmanaged.md
+++ b/assets/chezmoi.io/docs/reference/commands/unmanaged.md
@@ -5,10 +5,14 @@ unmanaged files in the destination directory.
 
 It is an error to supply *path*s that are not found on the filesystem.
 
-## `-p`, `--path-style` `absolute`|`relative`
+## `-p`, `--path-style` `absolute`|`relative`|`source-absolute`|`source-relative`
 
 Print paths in the given style. Relative paths are relative to the destination
 directory. The default is `relative`.
+
+## `-t`, `--tree`
+
+Print paths as a tree.
 
 !!! example
 

--- a/assets/chezmoi.io/docs/reference/commands/update.md
+++ b/assets/chezmoi.io/docs/reference/commands/update.md
@@ -7,13 +7,29 @@ If `update.command` is set then chezmoi will run `update.command` with
 --autostash --rebase [--recurse-submodules]` , using chezmoi's builtin git if
 `useBuiltinGit` is `true` or if `git.command` cannot be found in `$PATH`.
 
+## `--apply`
+
+Apply changes after pulling, `true` by default. Can be disabled with `--apply=false`.
+
+## `-x`, `--exclude` *types*
+
+Exclude entries of type [*types*](../command-line-flags/common.md#available-types),  defaults to `none`.
+
 ## `-i`, `--include` *types*
 
-Only update entries of type *types*.
+Only add entries of type [*types*](../command-line-flags/common.md#available-types), defaults to `all`.
 
-## `--recurse-submodules` *bool*
+## `--init`
 
-Update submodules recursively. This defaults to `true`.
+Recreate config file from template.
+
+## `--recurse-submodules`
+
+Update submodules recursively. This defaults to `true`. Can be disabled with `--recurse-submodules=false`.
+
+## `-r`, `--recursive`
+
+Recurse into subdirectories, `true` by default. Can be disabled with `--recursive=false`.
 
 !!! example
 

--- a/assets/chezmoi.io/docs/reference/commands/upgrade.md
+++ b/assets/chezmoi.io/docs/reference/commands/upgrade.md
@@ -16,3 +16,19 @@ requests should be sufficient for most cases.
 
     If you installed chezmoi using a package manager, the `upgrade` command
     might have been removed by the package maintainer.
+
+## `--executable` *filename*
+
+Set name of executable to replace.
+
+## `--method` *method*
+
+Set upgrade method.
+
+| Methods                | Description                                                                        |
+| ---------------------- | ---------------------------------------------------------------------------------- |
+| `brew-upgrade`         | Run `brew upgrade chezmoi`.                                                        |
+| `replace-executable`   | Download the latest released executable from Github.                               |
+| `snap-refresh`         | Run `snap refresh chezmoi`.                                                        |
+| `sudo-upgrade-package` | Same as `upgrade-package` but use `sudo`.                                          |
+| `upgrade-package`      | Download and install `.apk`, `.deb` or `.rpm` package. Run `pacman` on Arch Linux. |

--- a/assets/chezmoi.io/docs/reference/commands/verify.md
+++ b/assets/chezmoi.io/docs/reference/commands/verify.md
@@ -4,9 +4,21 @@ Verify that all *target*s match their target state. chezmoi exits with code 0
 (success) if all targets match their target state, or 1 (failure) otherwise. If
 no targets are specified then all targets are checked.
 
+## `-x`, `--exclude` *types*
+
+Exclude entries of type [*types*](../command-line-flags/common.md#available-types),  defaults to `none`.
+
 ## `-i`, `--include` *types*
 
-Only include entries of type *types*.
+Only add entries of type [*types*](../command-line-flags/common.md#available-types), defaults to `all`.
+
+## `--init`
+
+Recreate config file from template.
+
+## `-r`, `--recursive`
+
+Recurse into subdirectories, `true` by default. Can be disabled with `--recursive=false`.
 
 !!! example
 

--- a/internal/chezmoi/mode.go
+++ b/internal/chezmoi/mode.go
@@ -43,5 +43,5 @@ func (m Mode) String() string {
 
 // Type implements github.com/spf13/flag.Value.Type.
 func (m Mode) Type() string {
-	return "mode"
+	return "file|symlink"
 }

--- a/internal/cmd/diffcmd.go
+++ b/internal/cmd/diffcmd.go
@@ -39,7 +39,8 @@ func (c *Config) newDiffCmd() *cobra.Command {
 	diffCmd.Flags().VarP(c.Diff.include, "include", "i", "Include entry types")
 	diffCmd.Flags().BoolVar(&c.Diff.init, "init", c.Diff.init, "Recreate config file from template")
 	diffCmd.Flags().StringVar(&c.Diff.Pager, "pager", c.Diff.Pager, "Set pager")
-	diffCmd.Flags().BoolVarP(&c.Diff.parentDirs, "parent-dirs", "P", c.apply.parentDirs, "Print the diff of all parent directories")
+	diffCmd.Flags().
+		BoolVarP(&c.Diff.parentDirs, "parent-dirs", "P", c.apply.parentDirs, "Print the diff of all parent directories")
 	diffCmd.Flags().BoolVarP(&c.Diff.recursive, "recursive", "r", c.Diff.recursive, "Recurse into subdirectories")
 	diffCmd.Flags().BoolVar(&c.Diff.Reverse, "reverse", c.Diff.Reverse, "Reverse the direction of the diff")
 	diffCmd.Flags().BoolVar(&c.Diff.ScriptContents, "script-contents", c.Diff.ScriptContents, "Show script contents")

--- a/internal/cmd/removecmd.go
+++ b/internal/cmd/removecmd.go
@@ -8,7 +8,7 @@ import (
 
 func (c *Config) newRemoveCmd() *cobra.Command {
 	removeCmd := &cobra.Command{
-		Deprecated: "remove has been removed, use forget or destroy instead",
+		Deprecated: "use forget or destroy instead",
 		Use:        "remove",
 		Aliases:    []string{"rm"},
 		RunE:       c.runRemoveCmd,

--- a/internal/cmd/statuscmd.go
+++ b/internal/cmd/statuscmd.go
@@ -41,7 +41,8 @@ func (c *Config) newStatusCmd() *cobra.Command {
 	statusCmd.Flags().VarP(c.Status.PathStyle, "path-style", "p", "Path style")
 	statusCmd.Flags().VarP(c.Status.include, "include", "i", "Include entry types")
 	statusCmd.Flags().BoolVar(&c.Status.init, "init", c.Status.init, "Recreate config file from template")
-	statusCmd.Flags().BoolVarP(&c.Status.parentDirs, "parent-dirs", "P", c.Status.parentDirs, "Show status of all parent directories")
+	statusCmd.Flags().
+		BoolVarP(&c.Status.parentDirs, "parent-dirs", "P", c.Status.parentDirs, "Show status of all parent directories")
 	statusCmd.Flags().BoolVarP(&c.Status.recursive, "recursive", "r", c.Status.recursive, "Recurse into subdirectories")
 
 	return statusCmd

--- a/internal/cmd/testdata/scripts/remove.txtar
+++ b/internal/cmd/testdata/scripts/remove.txtar
@@ -1,7 +1,7 @@
 # test that chezmoi remove produces an error
 ! exec chezmoi remove
-stderr 'remove has been removed, use forget or destroy instead'
+stderr 'Command "remove" is deprecated, use forget or destroy instead'
 
 # test that chezmoi rm produces an error
 ! exec chezmoi rm
-stderr 'remove has been removed, use forget or destroy instead'
+stderr 'Command "remove" is deprecated, use forget or destroy instead'


### PR DESCRIPTION
* Add missing arguments. They are synced with `chezmoi cmd --help`.
* Add links to list of supported types for `--include` and `--exclude`.
* Clarify how to disable flags which are enabled by default.
* Add supported values for some flags.
* Add list of supported upgrade methods.
* Move some common and global flags to the correct place.
* Better output for `chezmoi remove --help`.