### PR TITLE
docs: Split docs into sections for age, secret and state

### DIFF
--- a/assets/chezmoi.io/docs/reference/commands/age.md
+++ b/assets/chezmoi.io/docs/reference/commands/age.md
@@ -2,17 +2,25 @@
 
 Interact with age's passphrase-based encryption.
 
-# `age encrypt` [*file*...]
+## Subcommands
 
-## `-p`, `--passphrase`
+### `age encrypt` [*file*...]
 
-Encrypt with a passphrase.
+Encrypt file or standard input.
 
-# `age decrypt` [*file*...]
-
-## `-p`, `--passphrase`
+#### `-p`, `--passphrase`
 
 Decrypt with a passphrase.
+
+### `age decrypt` [*file*...]
+
+Decrypt file or standard input.
+
+#### `-p`, `--passphrase`
+
+Decrypt with a passphrase.
+
+## Example
 
 !!! example
 

--- a/assets/chezmoi.io/docs/reference/commands/secret.md
+++ b/assets/chezmoi.io/docs/reference/commands/secret.md
@@ -9,39 +9,43 @@ manager. Normally you would use chezmoi's existing template functions to retriev
     If you need to pass flags to the secret manager's CLI you must separate
     them with `--` to prevent chezmoi from interpreting them.
 
-# `secret keyring delete`
+## Subcommands
 
-## `--service` *string*
+### `secret keyring delete`
 
-Name of the service.
-
-## `--user` *string*
-
-Name of the user.
-
-# `secret keyring get`
-
-## `--service` *string*
+#### `--service` *string*
 
 Name of the service.
 
-## `--user` *string*
+#### `--user` *string*
 
 Name of the user.
 
-# `secret keyring set`
+### `secret keyring get`
 
-## `--service` *string*
+#### `--service` *string*
 
 Name of the service.
 
-## `--user` *string*
+#### `--user` *string*
 
 Name of the user.
 
-## `--value` *string*
+### `secret keyring set`
+
+#### `--service` *string*
+
+Name of the service.
+
+#### `--user` *string*
+
+Name of the user.
+
+#### `--value` *string*
 
 New value.
+
+## Example
 
 !!! example
 
@@ -50,6 +54,8 @@ New value.
     $ chezmoi secret keyring get --service=service --user=user
     $ chezmoi secret keyring delete --service=service --user=user
     ```
+
+## Warning
 
 !!! warning
 

--- a/assets/chezmoi.io/docs/reference/commands/state.md
+++ b/assets/chezmoi.io/docs/reference/commands/state.md
@@ -10,39 +10,41 @@ Manipulate the persistent state.
     $ chezmoi state help
     ```
 
-# Available subcommands
+## Subcommands
 
-## `data`
+### `data`
 
 Print the raw data in the persistent state.
 
-## `delete`
+### `delete`
 
 Delete a value from the persistent state.
 
-## `delete-bucket`
+### `delete-bucket`
 
 Delete a bucket from the persistent state.
 
-## `dump`
+### `dump`
 
 Generate a dump of the persistent state.
 
-## `get`
+### `get`
 
 Get a value from the persistent state.
 
-## `get-bucket`
+### `get-bucket`
 
 Get a bucket from the persistent state.
 
-## `reset`
+### `reset`
 
 Reset the persistent state.
 
-## `set`
+### `set`
 
 Set a value from the persistent state
+
+## Example
 
 !!! example
 


### PR DESCRIPTION
Addressing feedback from #3997 

Downgrade `h1` headings to keep only one `h1` on each page.

This is how it looks like now. Structured and table of contents looks good.

## age
![Screenshot 2024-10-17 at 21 50 01](https://github.com/user-attachments/assets/e669d79a-33d8-44a9-b864-fa65d487c90b)

## secret
![Screenshot 2024-10-17 at 21 50 27](https://github.com/user-attachments/assets/0911e968-bfe3-4396-8cc3-52a2cf4545a3)

If we agree on that, I can update docs for other commands to follow similar style. Add sections like "Flags", "Common flags", "Example", "Notes".