### PR TITLE
feat: Extend squote template func to handle more types

### DIFF
--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -406,6 +406,7 @@ func newConfig(options ...configOption) (*Config, error) {
 	delete(c.templateFuncs, "fromJson")
 	delete(c.templateFuncs, "quote")
 	delete(c.templateFuncs, "splitList")
+	delete(c.templateFuncs, "squote")
 	delete(c.templateFuncs, "toPrettyJson")
 
 	// The completion template function is added in persistentPreRunRootE as
@@ -492,6 +493,7 @@ func newConfig(options ...configOption) (*Config, error) {
 		"secretJSON":                   c.secretJSONTemplateFunc,
 		"setValueAtPath":               c.setValueAtPathTemplateFunc,
 		"splitList":                    c.splitListTemplateFunc,
+		"squote":                       c.squoteTemplateFunc,
 		"stat":                         c.statTemplateFunc,
 		"toIni":                        c.toIniTemplateFunc,
 		"toPrettyJson":                 c.toPrettyJsonTemplateFunc,

--- a/internal/cmd/templatefuncs.go
+++ b/internal/cmd/templatefuncs.go
@@ -413,6 +413,16 @@ func (c *Config) quoteTemplateFunc(list ...any) string {
 	return strings.Join(ss, " ")
 }
 
+func (c *Config) squoteTemplateFunc(list ...any) string {
+	ss := make([]string, 0, len(list))
+	for _, elem := range list {
+		if elem != nil {
+			ss = append(ss, "'"+anyToString(elem)+"'")
+		}
+	}
+	return strings.Join(ss, " ")
+}
+
 func (c *Config) quoteListTemplateFunc(list []any) []string {
 	result := make([]string, len(list))
 	for i, elem := range list {

--- a/internal/cmd/templatefuncs_test.go
+++ b/internal/cmd/templatefuncs_test.go
@@ -270,10 +270,68 @@ func TestQuoteTemplateFunc(t *testing.T) {
 			values:   []any{[]byte{'a'}},
 			expected: `"a"`,
 		},
+		{
+			name:     "escaped_chars",
+			values:   []any{"\\\"a\\\"\n"},
+			expected: `"\\\"a\\\"\n"`,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			var c Config
 			assert.Equal(t, tc.expected, c.quoteTemplateFunc(tc.values...))
+		})
+	}
+}
+
+func TestSquoteTemplateFunc(t *testing.T) {
+	a := "a"
+	for _, tc := range []struct {
+		name     string
+		values   []any
+		expected string
+	}{
+		{
+			name: "empty",
+		},
+		{
+			name:     "single",
+			values:   []any{"a"},
+			expected: `'a'`,
+		},
+		{
+			name:     "multiple",
+			values:   []any{"a", "b", "c"},
+			expected: `'a' 'b' 'c'`,
+		},
+		{
+			name:     "quotes",
+			values:   []any{`'a'`, `"b"`, "c"},
+			expected: `''a'' '"b"' 'c'`,
+		},
+		{
+			name:     "ints",
+			values:   []any{1, 2, 3},
+			expected: `'1' '2' '3'`,
+		},
+		{
+			name:     "string_pointer",
+			values:   []any{&a},
+			expected: `'a'`,
+		},
+		{
+			name:     "byte_slice",
+			values:   []any{[]byte{'a'}},
+			expected: `'a'`,
+		},
+		{
+			name:     "escaped_chars",
+			values:   []any{"\\'a\\'\n"},
+			expected: "'\\'a\\'\n'",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var c Config
+			assert.Equal(t, tc.expected, c.squoteTemplateFunc(tc.values...))
 		})
 	}
 }


### PR DESCRIPTION
<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer-guide/contributing-changes/

-->
Similar to #4009 but for `squote` this time.

As you correctly mentioned on #4007 current implementation of `squote` in `sprig` is far from being correct. Here is my attempt to fix it.

Unfortunately, Go maintainers are not willing to provide an easier way for this in `strconv`: https://github.com/golang/go/issues/69958

Use existing `strconv.Quote` implementation for heavy lifting and escaping chars like `\n` or `\x...`. The only place where `quote` character is used apart from wrapping the string is here: https://github.com/golang/go/blob/c1d9303d82de0bae1b861b17ec4f9812392ea3cb/src/strconv/quote.go#L69
This is effectively a replacement and it can be undone with reverse `replaceAll`.

The final result should be identical to what `quoteWith(s, '\'', false, false)` in Go stdlib would produce if it was available publicly.