### PR TITLE
docs: Automatically check that all flags are documented

### DIFF
--- a/assets/chezmoi.io/docs/reference/commands/add.md
+++ b/assets/chezmoi.io/docs/reference/commands/add.md
@@ -6,7 +6,7 @@ destination directory.
 
 ## Flags
 
-### `--autotemplate`
+### `-a`, `--autotemplate`
 
 Automatically generate a template by replacing strings that match variable
 values from the `data` section of the config file with their respective config
@@ -46,7 +46,7 @@ Interactively prompt before adding each file.
 
 Suppress warnings about adding ignored entries.
 
-### `-s`, `--secrets` `ignore`|`warning`|`error`
+### `--secrets` `ignore`|`warning`|`error`
 
 > Configuration: `add.secrets`
 

--- a/assets/chezmoi.io/docs/reference/commands/destroy.md
+++ b/assets/chezmoi.io/docs/reference/commands/destroy.md
@@ -14,7 +14,7 @@ Remove *target* from the source state, the destination directory, and the state.
 
 ## Common flags
 
-### `-f`, `--force`
+### `--force`
 
 Destroy without prompting.
 

--- a/assets/chezmoi.io/docs/reference/commands/execute-template.md
+++ b/assets/chezmoi.io/docs/reference/commands/execute-template.md
@@ -8,7 +8,7 @@ specified, the template is read from stdin.
 
 ## Flags
 
-### `--init`, `-i`
+### `-i`, `--init`
 
 Include simulated functions only available during `chezmoi init`.
 
@@ -37,7 +37,7 @@ from *pairs*. *pairs* is a comma-separated list of *prompt*`=`*value* pairs. If
 `promptInt` is called with a *prompt* that does not match any of *pairs*, then
 it returns zero.
 
-### `--promptString`, `-p` *pairs*
+### `-p`, `--promptString` *pairs*
 
 Simulate the `promptString` template function with a function that returns
 values from *pairs*. *pairs* is a comma-separated list of *prompt*`=`*value*

--- a/assets/chezmoi.io/docs/reference/commands/import.md
+++ b/assets/chezmoi.io/docs/reference/commands/import.md
@@ -10,7 +10,7 @@ The supported archive formats are `tar`, `tar.gz`, `tgz`, `tar.bz2`, `tbz2`,
 
 ## Flags
 
-### `--destination` *directory*
+### `-d`, `--destination` *directory*
 
 Set the destination (in the source state) where the archive will be imported.
 

--- a/assets/chezmoi.io/docs/reference/commands/init.md
+++ b/assets/chezmoi.io/docs/reference/commands/init.md
@@ -35,7 +35,7 @@ own binary.
 
 ## Flags
 
-### `--apply`
+### `-a`, `--apply`
 
 Run `chezmoi apply` after checking out the repo and creating the config file.
 
@@ -43,7 +43,7 @@ Run `chezmoi apply` after checking out the repo and creating the config file.
 
 Check out *branch* instead of the default branch.
 
-### `--config-path` *path*
+### `-C`, `--config-path` *path*
 
 Write the generated config file to *path* instead of the default location.
 
@@ -53,11 +53,11 @@ Include existing template data when creating the config file. This defaults to
 `true`. Set this to `false` to simulate creating the config file with no
 existing template data.
 
-### `--depth` *depth*
+### `-d`, `--depth` *depth*
 
 Clone the repo with depth *depth*.
 
-### `--guess-repo-url` *bool*
+### `-g`, `--guess-repo-url` *bool*
 
 Guess the repo URL from the *repo* argument. This defaults to `true`.
 
@@ -105,11 +105,11 @@ a comma-separated list of *prompt*`=`*value* pairs. If `promptString` is called
 with a *prompt* that does not match any of *pairs*, then it prompts the user for
 a value.
 
-### `--purge`
+### `-p`, `--purge`
 
 Remove the source and config directories after applying.
 
-### `--purge-binary`
+### `-P`, `--purge-binary`
 
 Attempt to remove the chezmoi binary after applying.
 

--- a/assets/chezmoi.io/docs/reference/commands/purge.md
+++ b/assets/chezmoi.io/docs/reference/commands/purge.md
@@ -11,7 +11,7 @@ Purge chezmoi binary.
 
 ## Common flags
 
-### `-f`, `--force`
+### `--force`
 
 Remove without prompting.
 

--- a/assets/chezmoi.io/docs/reference/commands/update.md
+++ b/assets/chezmoi.io/docs/reference/commands/update.md
@@ -9,7 +9,7 @@ If `update.command` is set then chezmoi will run `update.command` with
 
 ## Flags
 
-### `--apply`
+### `-a`, `--apply`
 
 Apply changes after pulling, `true` by default. Can be disabled with `--apply=false`.
 
@@ -32,6 +32,10 @@ defaults to `all`.
 ### `--init`
 
 Recreate config file from template.
+
+### `-P`, `--parent-dirs`
+
+Also perform command on all parent directories of *target*.
 
 ### `-r`, `--recursive`
 

--- a/assets/chezmoi.io/docs/reference/commands/verify.md
+++ b/assets/chezmoi.io/docs/reference/commands/verify.md
@@ -20,6 +20,10 @@ defaults to `all`.
 
 Recreate config file from template.
 
+### `-P`, `--parent-dirs`
+
+Also perform command on all parent directories of *target*.
+
 ### `-r`, `--recursive`
 
 Recurse into subdirectories, `true` by default. Can be disabled with `--recursive=false`.

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -1740,6 +1740,7 @@ func (c *Config) newRootCmd() (*cobra.Command, error) {
 		c.newVerifyCmd(),
 	} {
 		if cmd != nil {
+			ensureAllFlagsDocumented(cmd, persistentFlags)
 			registerCommonFlagCompletionFuncs(cmd)
 			rootCmd.AddCommand(cmd)
 		}

--- a/internal/cmd/doctorcmd.go
+++ b/internal/cmd/doctorcmd.go
@@ -165,7 +165,7 @@ func (c *Config) newDoctorCmd() *cobra.Command {
 		),
 	}
 
-	doctorCmd.PersistentFlags().BoolVar(&c.doctor.noNetwork, "no-network", c.doctor.noNetwork, "do not use network connection")
+	doctorCmd.Flags().BoolVar(&c.doctor.noNetwork, "no-network", c.doctor.noNetwork, "do not use network connection")
 
 	return doctorCmd
 }


### PR DESCRIPTION
<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer-guide/contributing-changes/

-->

This will make commands documentation much easier to maintain and keep in sync with actual implementation.

* Check if all non global command flags are documented on corresponding docs page.
* Check if all flags mentioned in documentation exist either in command itself or globally.
* All fixes in docs are found by this feature.
* Downgrade `doctor --no-network` from persistent to regular flag as it doesn't have subcommands.
* Support `stateInAdmonition` only in long description. Otherwise maintaining correct state is more difficult (need to remember previous state) and it's only used for omitting it from long description.
* It's probably a good idea to add optimisation to not run this on release build. I guess this requires some build tag on release build.