### PR TITLE
docs: Improvements for command flags description

### DIFF
--- a/assets/chezmoi.io/docs/reference/command-line-flags/common.md
+++ b/assets/chezmoi.io/docs/reference/command-line-flags/common.md
@@ -2,38 +2,60 @@
 
 The following flags apply to multiple commands where they are relevant.
 
-## `-x`, `--exclude` *types*
+## Flags
 
-Exclude target state entries of type [*types*](#available-types). Defaults to `none`.
+### `-x`, `--exclude` *types*
 
-!!! example
+--8<-- "common-flags/exclude.md"
 
-    `--exclude=scripts` will cause the command to not run scripts and
-    `--exclude=encrypted` will exclude encrypted files.
-
-## `-f`, `--format` `json`|`yaml`
+### `-f`, `--format` `json`|`yaml`
 
 Set the output format.
 
-## `-h`, `--help`
+### `-h`, `--help`
 
 Print help.
 
-## `-i`, `--include` *types*
+### `-i`, `--include` *types*
 
-Include target state entries of type *types*.
+--8<-- "common-flags/include.md"
 
-!!! example
+### `--init`
 
-    `--include=files` specifies all files.
+Regenerate and reread the config file from the config file template before
+computing the target state.
 
-### Available types
+### `-P`, `--parent-dirs`
 
-*types* is a comma-separated list of types:
+Also perform command on all parent directories of *target*.
+
+### `-p`, `--path-style` *style*
+
+Print paths in the given style. The default is `relative`.
+
+| Style             | Description                                 |
+| ----------------- | ------------------------------------------- |
+| `absolute`        | Absolute paths in the destination directory |
+| `relative`        | Relative paths to the destination directory |
+| `source-absolute` | Absolute paths in the source tree directory |
+| `source-relative` | Relative paths to the source tree directory |
+
+### `-r`, `--recursive`
+
+Recurse into subdirectories, `true` by default.
+
+### `--tree`
+
+Print paths as a tree instead of a list.
+
+## Available entry types
+
+You can provide a list of entry types, separated by commas.
+Types can be preceded with `no` to remove them, e.g. `scripts,noalways`.
 
 | Type        | Description                 |
 | ----------- | --------------------------- |
-| `all`       | All entries (default)       |
+| `all`       | All entries                 |
 | `none`      | No entries                  |
 | `dirs`      | Directories                 |
 | `files`     | Files                       |
@@ -44,29 +66,3 @@ Include target state entries of type *types*.
 | `encrypted` | Encrypted entries           |
 | `externals` | External entries            |
 | `templates` | Templates                   |
-
-Types can be preceded with `no` to remove them.
-
-Types can be explicitly excluded with the `--exclude` flag.
-
-## `--init`
-
-Regenerate and reread the config file from the config file template before
-computing the target state.
-
-## `-P`, `--parent-dirs`
-
-Also perform command on all parent directories of *target*.
-
-## `-p`, `--path-style` `absolute`|`relative`|`source-absolute`|`source-relative`
-
-Print paths in the given style. Relative paths are relative to the destination
-directory. The default is `relative`.
-
-## `-r`, `--recursive`
-
-Recurse into subdirectories, `true` by default.
-
-## `--tree`
-
-Print paths as a tree instead of a list.

--- a/assets/chezmoi.io/docs/reference/command-line-flags/developer.md
+++ b/assets/chezmoi.io/docs/reference/command-line-flags/developer.md
@@ -2,10 +2,12 @@
 
 The following flags are global but only relevant for developers and debugging.
 
-## `--cpu-profile` *filename*
+## Flags
+
+### `--cpu-profile` *filename*
 
 Write a [Go CPU profile](https://blog.golang.org/pprof) to *filename*.
 
-## `--debug`
+### `--debug`
 
 Log information helpful for debugging.

--- a/assets/chezmoi.io/docs/reference/command-line-flags/global.md
+++ b/assets/chezmoi.io/docs/reference/command-line-flags/global.md
@@ -1,12 +1,17 @@
 # Global command line flags
 
-## `--cache` *directory*
+The following flags are available for all chezmoi commands.
+Note that some flags may not have any effect on certain commands.
+
+## Flags
+
+### `--cache` *directory*
 
 > Configuration: `cacheDir`
 
 Use *directory* as the cache directory.
 
-## `--color` *value*
+### `--color` *value*
 
 > Configuration: `color`
 
@@ -14,57 +19,57 @@ Colorize diffs, *value* can be `on`, `off`, `auto`, or any boolean-like value
 recognized by `promptBool`. The default is `auto` which will colorize diffs only
 if the environment variable `$NO_COLOR` is not set and stdout is a terminal.
 
-## `-c`, `--config` *filename*
+### `-c`, `--config` *filename*
 
 Read the [configuration](../configuration-file/index.md) from *filename*.
 
-## `--config-format` `json`|`jsonc`|`toml`|`yaml`
+### `--config-format` *format*
 
 Assume the configuration file is in the given format. This is only needed if
 the config filename does not have an extension, for example when it is
-`/dev/stdin`.
+`/dev/stdin`. Supported formats: `json`, `jsonc`, `toml`, `yaml`.
 
-## `-D`, `--destination` *directory*
+### `-D`, `--destination` *directory*
 
 > Configuration: `destDir`
 
 Use *directory* as the destination directory.
 
-## `-n`, `--dry-run`
+### `-n`, `--dry-run`
 
 Set dry run mode. In dry run mode, the destination directory is never modified.
 This is most useful in combination with the `-v` (verbose) flag to print
 changes that would be made without making them.
 
-## `--force`
+### `--force`
 
 Make changes without prompting.
 
-## `--interactive`
+### `--interactive`
 
 Prompt before applying each target.
 
-## `-k`, `--keep-going`
+### `-k`, `--keep-going`
 
 Keep going as far as possible after a encountering an error.
 
-## `--mode` `file`|`symlink`
+### `--mode` `file`|`symlink`
 
 Mode of operation. The default is `file`.
 
-## `--no-pager`
+### `--no-pager`
 
 Do not use the pager.
 
-## `--no-tty`
+### `--no-tty`
 
 Do not attempt to get a TTY for prompts. Instead, read them from stdin.
 
-## `-o`, `--output` *filename*
+### `-o`, `--output` *filename*
 
 Write the output to *filename* instead of stdout.
 
-## `--persistent-state` *filename*
+### `--persistent-state` *filename*
 
 > Configuration: `persistentState`
 
@@ -72,12 +77,12 @@ Read and write the persistent state from *filename*. By default, chezmoi stores
 its persistent state in `chezmoistate.boltdb` in the same directory as its
 configuration file.
 
-## `--progress` *value*
+### `--progress` *value*
 
 Show progress when downloading externals. *value* can be `on`, `off`, or `auto`.
 The default is `auto` which shows progress bars when stdout is a terminal.
 
-## `-R`, `--refresh-externals` [*value*]
+### `-R`, `--refresh-externals` [*value*]
 
 Control the refresh of the externals cache. *value* can be any of `always`,
 `auto`, or `never` and defaults to `always` if no *value* is specified. If no
@@ -92,18 +97,18 @@ their refresh periods.
 `never` (or any other falsey value accepted by `parseBool`) means only download
 if no cached external is available.
 
-## `-S`, `--source` *directory*
+### `-S`, `--source` *directory*
 
 > Configuration: `sourceDir`
 
 Use *directory* as the source directory.
 
-## `--source-path`
+### `--source-path`
 
 Interpret *targets* passed to the command as paths in the source directory
 rather than the destination directory.
 
-## `--use-builtin-age` [*bool*]
+### `--use-builtin-age` [*bool*]
 
 > Configuration: `useBuiltinAge`
 
@@ -115,12 +120,12 @@ builtin age if `age.command` cannot be found in `$PATH`.
 The builtin `age` command does not support passphrases, symmetric encryption,
 or the use of SSH keys.
 
-## `--use-builtin-diff` [*bool*]
+### `--use-builtin-diff` [*bool*]
 
 Use chezmoi's builtin diff, even if the `diff.command` configuration variable
 is set.
 
-## `--use-builtin-git` [*bool*]
+### `--use-builtin-git` [*bool*]
 
 > Configuration: `useBuiltinGit`
 
@@ -134,18 +139,18 @@ builtin git if `git.command` cannot be found in `$PATH`.
     chezmoi's builtin git has only supports the HTTP and HTTPS transports and
     does not support `git-repo` externals.
 
-## `-v`, `--verbose`
+### `-v`, `--verbose`
 
 Set verbose mode. In verbose mode, chezmoi prints the changes that it is making
 as approximate shell commands, and any differences in files between the target
 state and the destination set are printed as unified diffs.
 
-## `--version`
+### `--version`
 
 Print the version of chezmoi, the commit at which it was built, and the build
 timestamp.
 
-## `-w`, `--working-tree` *directory*
+### `-w`, `--working-tree` *directory*
 
 Use *directory* as the git working tree directory. By default, chezmoi searches
 the source directory and then its ancestors for the first directory that

--- a/assets/chezmoi.io/docs/reference/commands/add.md
+++ b/assets/chezmoi.io/docs/reference/commands/add.md
@@ -69,8 +69,7 @@ directory, create a symlink template with `.chezmoi.sourceDir` or
 
 ### `-x`, `--exclude` *types*
 
-Exclude entries of type [*types*](../command-line-flags/common.md#available-types),
-defaults to `none`.
+--8<-- "common-flags/exclude.md"
 
 ### `-f`, `--force`
 
@@ -79,8 +78,7 @@ overwritten.
 
 ### `-i`, `--include` *types*
 
-Only add entries of type [*types*](../command-line-flags/common.md#available-types),
-defaults to `all`.
+--8<-- "common-flags/include.md"
 
 ### `-r`, `--recursive`
 

--- a/assets/chezmoi.io/docs/reference/commands/apply.md
+++ b/assets/chezmoi.io/docs/reference/commands/apply.md
@@ -9,13 +9,11 @@ they want to overwrite the file.
 
 ### `-x`, `--exclude` *types*
 
-Exclude entries of type [*types*](../command-line-flags/common.md#available-types),
-defaults to `none`.
+--8<-- "common-flags/exclude.md"
 
 ### `-i`, `--include` *types*
 
-Only add entries of type [*types*](../command-line-flags/common.md#available-types),
-defaults to `all`.
+--8<-- "common-flags/include.md"
 
 ### `--init`
 

--- a/assets/chezmoi.io/docs/reference/commands/archive.md
+++ b/assets/chezmoi.io/docs/reference/commands/archive.md
@@ -31,13 +31,11 @@ Compress the archive with gzip. This is automatically set if the format is
 
 ### `-x`, `--exclude` *types*
 
-Exclude entries of type [*types*](../command-line-flags/common.md#-i-include-types),
-defaults to `none`.
+--8<-- "common-flags/exclude.md"
 
 ### `-i`, `--include` *types*
 
-Only add entries of type [*types*](../command-line-flags/common.md#available-types),
-defaults to `all`.
+--8<-- "common-flags/include.md"
 
 ### `--init`
 

--- a/assets/chezmoi.io/docs/reference/commands/diff.md
+++ b/assets/chezmoi.io/docs/reference/commands/diff.md
@@ -38,13 +38,11 @@ Show script contents, defaults to `true`.
 
 ### `-x`, `--exclude` *types*
 
-Exclude entries of type [*types*](../command-line-flags/common.md#available-types),
-defaults to `none`.
+--8<-- "common-flags/exclude.md"
 
 ### `-i`, `--include` *types*
 
-Only add entries of type [*types*](../command-line-flags/common.md#available-types),
-defaults to `all`.
+--8<-- "common-flags/include.md"
 
 ### `--init`
 

--- a/assets/chezmoi.io/docs/reference/commands/dump.md
+++ b/assets/chezmoi.io/docs/reference/commands/dump.md
@@ -7,8 +7,7 @@ entire target state.
 
 ### `-x`, `--exclude` *types*
 
-Exclude entries of type [*types*](../command-line-flags/common.md#available-types),
-defaults to `none`.
+--8<-- "common-flags/exclude.md"
 
 ### `-f`, `--format` `json`|`yaml`
 
@@ -16,8 +15,7 @@ Set the output format, default to `json`.
 
 ### `-i`, `--include` *types*
 
-Only add entries of type [*types*](../command-line-flags/common.md#available-types),
-defaults to `all`.
+--8<-- "common-flags/include.md"
 
 ### `--init`
 

--- a/assets/chezmoi.io/docs/reference/commands/edit.md
+++ b/assets/chezmoi.io/docs/reference/commands/edit.md
@@ -46,13 +46,11 @@ Automatically apply changes when files are saved, with the following limitations
 
 ### `-x`, `--exclude` *types*
 
-Exclude entries of type [*types*](../command-line-flags/common.md#available-types),
-defaults to `none`.
+--8<-- "common-flags/exclude.md"
 
 ### `-i`, `--include` *types*
 
-Only add entries of type [*types*](../command-line-flags/common.md#available-types),
-defaults to `all`.
+--8<-- "common-flags/include.md"
 
 ### `--init`
 

--- a/assets/chezmoi.io/docs/reference/commands/import.md
+++ b/assets/chezmoi.io/docs/reference/commands/import.md
@@ -30,13 +30,11 @@ Strip *n* leading components from paths.
 
 ### `-x`, `--exclude` *types*
 
-Exclude entries of type [*types*](../command-line-flags/common.md#available-types),
-defaults to `none`.
+--8<-- "common-flags/exclude.md"
 
 ### `-i`, `--include` *types*
 
-Only add entries of type [*types*](../command-line-flags/common.md#available-types),
-defaults to `all`.
+--8<-- "common-flags/include.md"
 
 ## Examples
 

--- a/assets/chezmoi.io/docs/reference/commands/init.md
+++ b/assets/chezmoi.io/docs/reference/commands/init.md
@@ -125,13 +125,11 @@ Guess an SSH repo URL instead of an HTTPS repo.
 
 ### `-x`, `--exclude` *types*
 
-Exclude entries of type [*types*](../command-line-flags/common.md#available-types),
-defaults to `none`.
+--8<-- "common-flags/exclude.md"
 
 ### `-i`, `--include` *types*
 
-Only add entries of type [*types*](../command-line-flags/common.md#available-types),
-defaults to `all`.
+--8<-- "common-flags/include.md"
 
 ## Examples
 

--- a/assets/chezmoi.io/docs/reference/commands/managed.md
+++ b/assets/chezmoi.io/docs/reference/commands/managed.md
@@ -8,13 +8,11 @@ the destination directory in alphabetical order.
 
 ### `-x`, `--exclude` *types*
 
-Exclude entries of type [*types*](../command-line-flags/common.md#available-types),
-defaults to `none`.
+--8<-- "common-flags/exclude.md"
 
 ### `-i`, `--include` *types*
 
-Only add entries of type [*types*](../command-line-flags/common.md#available-types),
-defaults to `all`.
+--8<-- "common-flags/include.md"
 
 ### `-p`, `--path-style` `absolute`|`relative`|`source-absolute`|`source-relative`
 

--- a/assets/chezmoi.io/docs/reference/commands/re-add.md
+++ b/assets/chezmoi.io/docs/reference/commands/re-add.md
@@ -11,13 +11,11 @@ more *target*s are given then only those targets are re-added.
 
 ### `-x`, `--exclude` *types*
 
-Exclude entries of type [*types*](../command-line-flags/common.md#available-types),
-defaults to `none`.
+--8<-- "common-flags/exclude.md"
 
 ### `-i`, `--include` *types*
 
-Only add entries of type [*types*](../command-line-flags/common.md#available-types),
-defaults to `all`.
+--8<-- "common-flags/include.md"
 
 ### `-r`, `--recursive`
 

--- a/assets/chezmoi.io/docs/reference/commands/status.md
+++ b/assets/chezmoi.io/docs/reference/commands/status.md
@@ -20,13 +20,11 @@ running [`chezmoi apply`](apply.md) will have.
 
 ### `-x`, `--exclude` *types*
 
-Exclude entries of type [*types*](../command-line-flags/common.md#available-types),
-defaults to `none`.
+--8<-- "common-flags/exclude.md"
 
 ### `-i`, `--include` *types*
 
-Only add entries of type [*types*](../command-line-flags/common.md#available-types),
-defaults to `all`.
+--8<-- "common-flags/include.md"
 
 ### `--init`
 

--- a/assets/chezmoi.io/docs/reference/commands/update.md
+++ b/assets/chezmoi.io/docs/reference/commands/update.md
@@ -21,13 +21,11 @@ Update submodules recursively. This defaults to `true`. Can be disabled with `--
 
 ### `-x`, `--exclude` *types*
 
-Exclude entries of type [*types*](../command-line-flags/common.md#available-types),
-defaults to `none`.
+--8<-- "common-flags/exclude.md"
 
 ### `-i`, `--include` *types*
 
-Only add entries of type [*types*](../command-line-flags/common.md#available-types),
-defaults to `all`.
+--8<-- "common-flags/include.md"
 
 ### `--init`
 

--- a/assets/chezmoi.io/docs/reference/commands/verify.md
+++ b/assets/chezmoi.io/docs/reference/commands/verify.md
@@ -8,13 +8,11 @@ no targets are specified then all targets are checked.
 
 ### `-x`, `--exclude` *types*
 
-Exclude entries of type [*types*](../command-line-flags/common.md#available-types),
-defaults to `none`.
+--8<-- "common-flags/exclude.md"
 
 ### `-i`, `--include` *types*
 
-Only add entries of type [*types*](../command-line-flags/common.md#available-types),
-defaults to `all`.
+--8<-- "common-flags/include.md"
 
 ### `--init`
 

--- a/assets/chezmoi.io/mkdocs.yml
+++ b/assets/chezmoi.io/mkdocs.yml
@@ -357,6 +357,11 @@ markdown_extensions:
 - admonition
 - meta
 - pymdownx.details
+- pymdownx.snippets:
+    base_path:
+      - assets/chezmoi.io/snippets
+      - snippets
+    check_paths: true
 - pymdownx.superfences:
     custom_fences:
     - name: mermaid
@@ -378,3 +383,6 @@ plugins:
 
 extra_javascript:
 - extra/refresh_on_toggle_dark_light.js
+
+watch:
+  - snippets

--- a/assets/chezmoi.io/snippets/common-flags/exclude.md
+++ b/assets/chezmoi.io/snippets/common-flags/exclude.md
@@ -1,0 +1,9 @@
+Exclude target state entries of specific [*types*](/reference/command-line-flags/common.md#available-entry-types).
+The default is `none`.
+
+Types can be explicitly included with the `--include` flag.
+
+!!! example
+
+    `--exclude=scripts` will cause the command to not run scripts and
+    `--exclude=encrypted` will exclude encrypted files.

--- a/assets/chezmoi.io/snippets/common-flags/include.md
+++ b/assets/chezmoi.io/snippets/common-flags/include.md
@@ -1,0 +1,8 @@
+Include target state entries of specific [*types*](/reference/command-line-flags/common.md#available-entry-types).
+The default is `all`.
+
+Types can be explicitly excluded with the `--exclude` flag.
+
+!!! example
+
+    `--include=files` specifies all files.


### PR DESCRIPTION
<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer-guide/contributing-changes/

-->
* Move global and common flags from `h2` to `h3` to have consistent formatting with commands docs.
* Add description for global flags page.
* Improve description for `--path-style`. Having long list of values in the title doesn't look good in table of contents. Describe values in a table instead.
* Similar for `--config-format`.
* Address feedback from #3997 to move available entry types to its own separate section.
* Use snippets to deduplicate descriptions for `--include` and `--exclude`. This requires `validation.absolute_links=relative_to_docs`. Rest will be done in the next PR.