### PR TITLE
docs: Update shell completions section

### DIFF
--- a/assets/chezmoi.io/docs/user-guide/frequently-asked-questions/usage.md
+++ b/assets/chezmoi.io/docs/user-guide/frequently-asked-questions/usage.md
@@ -188,7 +188,7 @@ Or, approximate the week number with template functions:
 ``` title="~/.local/share/chezmoi/run_once_weekly.tmpl"
 #!/bin/sh
 
-# {{ min (ceil (divf now.YearDay 7)) 52 }}
+# {{ div now.YearDay 7 }}
 echo "new week"
 ```
 
@@ -196,13 +196,15 @@ echo "new week"
 
 chezmoi includes shell completions for
 [`bash`](https://www.gnu.org/software/bash/), [`fish`](https://fishshell.com/),
-[PowerShell](https://learn.microsoft.com/en-us/powershell/), and
+[`powershell`](https://learn.microsoft.com/en-us/powershell/), and
 [`zsh`](https://zsh.sourceforge.io/). If you have installed chezmoi via your
-package manager then the shell completion should already be installed. Please
-[open an issue](https://github.com/twpayne/chezmoi/issues/new/choose) if this is
-not working correctly.
+package manager then the shell completion should already be installed.
+For PowerShell, you need to manually add the completion script to your profile.
+Please [open an issue](https://github.com/twpayne/chezmoi/issues/new/choose)
+if this is not working correctly.
 
-chezmoi provides a `completion` command and a `completion` template function
-which return the shell completions for the given shell. These can be used
-either as a one-off or as part of your dotfiles repo. The details of how to use
-these depend on your shell.
+chezmoi provides a [`completion`](/reference/commands/completion.md) command
+and a [`completion`](/reference/templates/functions/completion.md) template
+function which return the shell completions for the given shell.
+These can be used either as a one-off or as part of your dotfiles repo.
+The details of how to use these depend on your shell.


### PR DESCRIPTION
<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer-guide/contributing-changes/

-->
Few small improvements here:
* Write `powershell` in the same format as other shells.
* Add note that for powershell, completions need to be installed manually. Neither winget nor scoop install them. And there is no common convention where these scripts should be placed on Windows.
* Add links to `completion` command and template function.
* Simplify example nearby, IMO it was overly complex. Basically this changes for 1-indexing to 0-indexing for week number. And the last 2-3 days of the year are treated as a new 53rd week.

## How it looks now
![Screenshot 2024-10-23 at 20 27 11](https://github.com/user-attachments/assets/88fb32bc-57d7-473c-b2f1-bed0ff935360)
