### PR TITLE
docs: Update "how scripts work" section

### DIFF
--- a/assets/chezmoi.io/docs/user-guide/use-scripts-to-perform-actions.md
+++ b/assets/chezmoi.io/docs/user-guide/use-scripts-to-perform-actions.md
@@ -2,40 +2,56 @@
 
 ## Understand how scripts work
 
-chezmoi supports scripts, which are executed when you run `chezmoi apply`. The
-scripts can either run every time you run `chezmoi apply`, only when their
-contents have changed, or only if they have not been run before.
+chezmoi supports scripts that are executed when you run
+[`chezmoi apply`](/reference/commands/apply.md). These scripts can be configured
+to run every time, only when their contents have changed, or only if they
+haven't been run before.
 
-In verbose mode, the script's contents will be printed before executing it. In
-dry-run mode, the script is not executed.
+Scripts are any file in the source directory with the prefix `run_`, and
+they are executed in alphabetical order.
 
-Scripts are any file in the source directory with the prefix `run_`, and are
-executed in alphabetical order. Scripts that should be run whenever their
-contents change have the `run_onchange_` prefix. Scripts that should only be run
-if they have not been run before have the prefix `run_once_`.
+- **`run_` scripts**: These scripts are executed every time you run `chezmoi apply`.
+- **`run_onchange_` scripts**: These scripts are only executed if their content
+has changed since the last time they were run.
+- **`run_once_` scripts**: These scripts are executed once for each unique
+version of the content. If the script is a template, the content is hashed after
+template execution. chezmoi tracks the content's SHA256 hash and stores it in
+a database. If the content has been run before (even under a different filename),
+the script will not run again unless the content itself changes.
 
-Scripts break chezmoi's declarative approach, and as such should be used
-sparingly. Any script should be idempotent, even `run_onchange_` and `run_once_`
-scripts.
+Scripts break chezmoi's declarative approach and should be used sparingly.
+All scripts should be idempotent, including `run_onchange_` and `run_once_` scripts.
 
-Scripts are normally run while chezmoi updates your dotfiles. To configure
-scripts to run before or after your dotfiles are updated use the `before_` and
-`after_` attributes respectively, e.g.
-`run_once_before_install-password-manager.sh`.
+Scripts are normally run while chezmoi updates your dotfiles. For example,
+`run_b.sh` will be run after updating `a.txt` and before updating `c.txt`.
+To run scripts before or after the updates, use the `before_` or `after_`
+attributes, respectively, e.g., `run_once_before_install-password-manager.sh`.
 
 Scripts must be created manually in the source directory, typically by running
-`chezmoi cd` and then creating a file with a `run_` prefix. There is no need to
-set the executable bit on the script.
+[`chezmoi cd`](/reference/commands/cd.md) and then creating a file with a `run_`
+prefix. There is no need to set the executable bit on the script.
 
-Scripts with the suffix `.tmpl` are treated as templates, with the usual
-template variables available. If, after executing the template, the result is
-only whitespace or an empty string, then the script is not executed. This is
-useful for disabling scripts.
+Scripts with the `.tmpl` suffix are treated as templates, with the usual
+template variables available. If the template resolves to only whitespace
+or an empty string, the script will not be executed, which is useful for
+disabling scripts dynamically.
+
+When executing a script, chezmoi generates the script contents in a file in a
+temporary directory with the executable bit set and then executes it using `exec(3)`.
+As a result, the script must either include a `#!` line or be an executable binary.
 
 When chezmoi executes a script, it first generates the script contents in a
 file in a temporary directory with the executable bit set, and then executes
 the contents with `exec(3)`. Consequently, the script's contents must either
-include a `#!` line or be an executable binary.
+include a `#!` line or be an executable binary. Script working directory is
+set to the first existing parent directory in the destination tree.
+
+If a `.chezmoiscripts` directory exists at the root of the source directory,
+scripts in this directory are executed as normal scripts, without creating
+a corresponding directory in the target state.
+
+In _verbose_ mode, the scripts' contents are printed before execution.
+In _dry-run_ mode, scripts are not executed.
 
 ## Set environment variables
 
@@ -83,7 +99,8 @@ In this file create your package installation script, e.g.
 sudo apt install ripgrep
 ```
 
-The next time you run `chezmoi apply` or `chezmoi update` this script will be
+The next time you run [`chezmoi apply`](/reference/commands/apply.md) or
+[`chezmoi update`](/reference/commands/update.md) this script will be
 run. As it has the `run_onchange_` prefix, it will not be run again unless its
 contents change, for example if you add more packages to be installed.
 
@@ -104,7 +121,8 @@ This will install `ripgrep` on both Debian/Ubuntu Linux systems and macOS.
 
 ## Run a script when the contents of another file changes
 
-chezmoi's `run_` scripts are run every time you run `chezmoi apply`, whereas
+chezmoi's `run_` scripts are run every time you run
+[`chezmoi apply`](/reference/commands/apply.md), whereas
 `run_onchange_` scripts are run only when their contents have changed, after
 executing them as templates. You can use this to cause a `run_onchange_` script
 to run when the contents of another file has changed by including a checksum of
@@ -127,7 +145,8 @@ contents of the script will change whenever the contents of `dconf.ini` are
 changed, so chezmoi will re-run the script whenever the contents of `dconf.ini`
 change.
 
-In this example you should also add `dconf.ini` to `.chezmoiignore` so chezmoi
+In this example you should also add `dconf.ini` to
+[`.chezmoiignore`](/reference/special-files/chezmoiignore.md) so chezmoi
 does not create `dconf.ini` in your home directory.
 
 ## Clear the state of all `run_onchange_` and `run_once_` scripts


### PR DESCRIPTION
<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer-guide/contributing-changes/

-->
I realised that `run_once_` scripts work differently from what I thought, so I decided to update the documentation to make the whole section more clear. This is inspired by reply in https://github.com/twpayne/chezmoi/issues/1955.

Also:
* Describe how working directory is set.
* Example order in which `run_` scripts are executed.
* Add links.

I spent quite some time refining this section, I'd appreciate your feedback and suggestions how to improve it further.

## Before

https://www.chezmoi.io/user-guide/use-scripts-to-perform-actions/#understand-how-scripts-work

## After

![Screenshot 2024-10-25 at 00 56 29](https://github.com/user-attachments/assets/68364c7e-8651-46d6-b6fc-5b4790025238)

