### PR TITLE
docs: Fill reference title page

### DIFF
--- a/assets/chezmoi.io/docs/reference/commands/index.md
+++ b/assets/chezmoi.io/docs/reference/commands/index.md
@@ -1,0 +1,7 @@
+# Commands
+
+This section provides documentation for chezmoi commands and their arguments.
+
+All commands accept [global flags](../command-line-flags/global.md),
+though some flags may have no effect on certain commands.
+Many commands also share [common flags](../command-line-flags/common.md).

--- a/assets/chezmoi.io/docs/reference/index.md
+++ b/assets/chezmoi.io/docs/reference/index.md
@@ -1,3 +1,19 @@
 # Reference
 
-Manage your dotfiles across multiple machines, securely.
+Welcome to the reference section of the chezmoi documentation.
+
+This reference covers the following topics:
+
+- [Key concepts](concepts.md)
+- [Source state attributes](source-state-attributes.md)
+- [Target types](target-types.md)
+- [Application order of changes](application-order.md)
+- [Configuration file](configuration-file/index.md)
+- [Special files](special-files/index.md) and [special directories](special-directories/index.md)
+- [Commands](commands/index.md)
+- [Templates](templates/index.md)
+    - [Variables](templates/variables.md)
+    - [Directives](templates/directives.md)
+    - [Functions](templates/functions/index.md)
+- [Plugins support](plugins.md)
+- [Release history](release-history.md)

--- a/assets/chezmoi.io/mkdocs.yml
+++ b/assets/chezmoi.io/mkdocs.yml
@@ -142,6 +142,7 @@ nav:
     - .chezmoiscripts: reference/special-directories/chezmoiscripts.md
     - .chezmoitemplates: reference/special-directories/chezmoitemplates.md
   - Commands:
+    - reference/commands/index.md
     - add: reference/commands/add.md
     - age: reference/commands/age.md
     - apply: reference/commands/apply.md

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -84,6 +84,9 @@ func init() {
 	}
 
 	for _, dirEntry := range dirEntries {
+		if dirEntry.Name() == "index.md" {
+			continue
+		}
 		command := strings.TrimSuffix(dirEntry.Name(), ".md")
 		data, err := commands.FS.ReadFile(dirEntry.Name())
 		if err != nil {


### PR DESCRIPTION
<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer-guide/contributing-changes/

-->

This page is opened from the top level menu and linked in multiple places. But it's currently empty: https://www.chezmoi.io/reference/

Fill it with high level table of contents.

* Add `commands/index.md` as well to have a link to this section.
* `// go:embed` doesn't allow excluding files from pattern, so just ignore `index.md` in the code.

## New look
![Screenshot 2024-10-25 at 12 14 02](https://github.com/user-attachments/assets/9c1b4f97-6169-4d4c-96b0-a9d9257601c8)

