### PR TITLE
docs: Replace common flags descriptions with snippets

### DIFF
--- a/assets/chezmoi.io/docs/reference/command-line-flags/common.md
+++ b/assets/chezmoi.io/docs/reference/command-line-flags/common.md
@@ -10,7 +10,7 @@ The following flags apply to multiple commands where they are relevant.
 
 ### `-f`, `--format` `json`|`yaml`
 
-Set the output format.
+--8<-- "common-flags/format.md"
 
 ### `-h`, `--help`
 
@@ -22,31 +22,23 @@ Print help.
 
 ### `--init`
 
-Regenerate and reread the config file from the config file template before
-computing the target state.
+--8<-- "common-flags/init.md"
 
 ### `-P`, `--parent-dirs`
 
-Also perform command on all parent directories of *target*.
+--8<-- "common-flags/parent-dirs.md"
 
 ### `-p`, `--path-style` *style*
 
-Print paths in the given style. The default is `relative`.
-
-| Style             | Description                                 |
-| ----------------- | ------------------------------------------- |
-| `absolute`        | Absolute paths in the destination directory |
-| `relative`        | Relative paths to the destination directory |
-| `source-absolute` | Absolute paths in the source tree directory |
-| `source-relative` | Relative paths to the source tree directory |
+--8<-- "common-flags/path-style.md:all"
 
 ### `-r`, `--recursive`
 
-Recurse into subdirectories, `true` by default.
+--8<-- "common-flags/recursive.md:default-false"
 
 ### `--tree`
 
-Print paths as a tree instead of a list.
+--8<-- "common-flags/tree.md"
 
 ## Available entry types
 

--- a/assets/chezmoi.io/docs/reference/commands/add.md
+++ b/assets/chezmoi.io/docs/reference/commands/add.md
@@ -82,7 +82,7 @@ overwritten.
 
 ### `-r`, `--recursive`
 
-Recurse into subdirectories, `true` by default. Can be disabled with `--recursive=false`.
+--8<-- "common-flags/recursive.md:default-true"
 
 ## Examples
 

--- a/assets/chezmoi.io/docs/reference/commands/apply.md
+++ b/assets/chezmoi.io/docs/reference/commands/apply.md
@@ -17,15 +17,15 @@ they want to overwrite the file.
 
 ### `--init`
 
-Recreate config file from template.
+--8<-- "common-flags/init.md"
 
 ### `-P`, `--parent-dirs`
 
-Also perform command on all parent directories of *target*.
+--8<-- "common-flags/parent-dirs.md"
 
 ### `-r`, `--recursive`
 
-Recurse into subdirectories, `true` by default. Can be disabled with `--recursive=false`.
+--8<-- "common-flags/recursive.md:default-true"
 
 ### `--source-path`
 

--- a/assets/chezmoi.io/docs/reference/commands/archive.md
+++ b/assets/chezmoi.io/docs/reference/commands/archive.md
@@ -39,15 +39,15 @@ Compress the archive with gzip. This is automatically set if the format is
 
 ### `--init`
 
-Recreate config file from template.
+--8<-- "common-flags/init.md"
 
 ### `-P`, `--parent-dirs`
 
-Also perform command on all parent directories of *target*.
+--8<-- "common-flags/parent-dirs.md"
 
 ### `-r`, `--recursive`
 
-Recurse into subdirectories, `true` by default. Can be disabled with `--recursive=false`.
+--8<-- "common-flags/recursive.md:default-true"
 
 ## Examples
 

--- a/assets/chezmoi.io/docs/reference/commands/chattr.md
+++ b/assets/chezmoi.io/docs/reference/commands/chattr.md
@@ -43,7 +43,7 @@ prevent chezmoi from interpreting `-`*modifier* as an option.
 
 ### `-r`, `--recursive`
 
-Recurse into subdirectories.
+--8<-- "common-flags/recursive.md:default-false"
 
 ## Examples
 

--- a/assets/chezmoi.io/docs/reference/commands/data.md
+++ b/assets/chezmoi.io/docs/reference/commands/data.md
@@ -6,7 +6,7 @@ Write the computed template data to stdout.
 
 ### `-f`, `--format` `json`|`yaml`
 
-Set the output format, `json` by default.
+--8<-- "common-flags/format.md"
 
 ## Examples
 

--- a/assets/chezmoi.io/docs/reference/commands/destroy.md
+++ b/assets/chezmoi.io/docs/reference/commands/destroy.md
@@ -20,4 +20,4 @@ Destroy without prompting.
 
 ### `-r`, `--recursive`
 
-Recurse into subdirectories.
+--8<-- "common-flags/recursive.md:default-false"

--- a/assets/chezmoi.io/docs/reference/commands/diff.md
+++ b/assets/chezmoi.io/docs/reference/commands/diff.md
@@ -46,15 +46,15 @@ Show script contents, defaults to `true`.
 
 ### `--init`
 
-Recreate config file from template.
+--8<-- "common-flags/init.md"
 
 ### `-P`, `--parent-dirs`
 
-Also perform command on all parent directories of *target*.
+--8<-- "common-flags/parent-dirs.md"
 
 ### `-r`, `--recursive`
 
-Recurse into subdirectories.
+--8<-- "common-flags/recursive.md:default-false"
 
 ## Examples
 

--- a/assets/chezmoi.io/docs/reference/commands/dump-config.md
+++ b/assets/chezmoi.io/docs/reference/commands/dump-config.md
@@ -6,7 +6,7 @@ Dump the configuration.
 
 ### `-f`, `--format` `json`|`yaml`
 
-Set the output format, `json` by default.
+--8<-- "common-flags/format.md"
 
 ## Examples
 

--- a/assets/chezmoi.io/docs/reference/commands/dump.md
+++ b/assets/chezmoi.io/docs/reference/commands/dump.md
@@ -11,7 +11,7 @@ entire target state.
 
 ### `-f`, `--format` `json`|`yaml`
 
-Set the output format, default to `json`.
+--8<-- "common-flags/format.md"
 
 ### `-i`, `--include` *types*
 
@@ -19,15 +19,15 @@ Set the output format, default to `json`.
 
 ### `--init`
 
-Recreate config file from template.
+--8<-- "common-flags/init.md"
 
 ### `-P`, `--parent-dirs`
 
-Also perform command on all parent directories of *target*.
+--8<-- "common-flags/parent-dirs.md"
 
 ### `-r`, `--recursive`
 
-Recurse into subdirectories, `true` by default. Can be disabled with `--recursive=false`.
+--8<-- "common-flags/recursive.md:default-true"
 
 ## Examples
 

--- a/assets/chezmoi.io/docs/reference/commands/edit.md
+++ b/assets/chezmoi.io/docs/reference/commands/edit.md
@@ -54,7 +54,7 @@ Automatically apply changes when files are saved, with the following limitations
 
 ### `--init`
 
-Recreate config file from template.
+--8<-- "common-flags/init.md"
 
 ## Examples
 

--- a/assets/chezmoi.io/docs/reference/commands/ignored.md
+++ b/assets/chezmoi.io/docs/reference/commands/ignored.md
@@ -6,7 +6,7 @@ Print the list of entries ignored by chezmoi.
 
 ### `-t`, `--tree`
 
-Print paths as a tree.
+--8<-- "common-flags/tree.md"
 
 ## Examples
 

--- a/assets/chezmoi.io/docs/reference/commands/managed.md
+++ b/assets/chezmoi.io/docs/reference/commands/managed.md
@@ -14,14 +14,13 @@ the destination directory in alphabetical order.
 
 --8<-- "common-flags/include.md"
 
-### `-p`, `--path-style` `absolute`|`relative`|`source-absolute`|`source-relative`
+### `-p`, `--path-style` *style*
 
-Print paths in the given style. Relative paths are relative to the destination
-directory. The default is `relative`.
+--8<-- "common-flags/path-style.md:all"
 
 ### `-t`, `--tree`
 
-Print paths as a tree.
+--8<-- "common-flags/tree.md"
 
 ## Examples
 

--- a/assets/chezmoi.io/docs/reference/commands/merge-all.md
+++ b/assets/chezmoi.io/docs/reference/commands/merge-all.md
@@ -7,11 +7,11 @@ state. The merge is performed with `chezmoi merge`.
 
 ### `--init`
 
-Recreate config file from template.
+--8<-- "common-flags/init.md"
 
 ### `-r`, `--recursive`
 
-Recurse into subdirectories, `true` by default. Can be disabled with `--recursive=false`.
+--8<-- "common-flags/recursive.md:default-true"
 
 ## Examples
 

--- a/assets/chezmoi.io/docs/reference/commands/re-add.md
+++ b/assets/chezmoi.io/docs/reference/commands/re-add.md
@@ -19,7 +19,7 @@ more *target*s are given then only those targets are re-added.
 
 ### `-r`, `--recursive`
 
-Recursively add files in subdirectories, `true` by default. Can be disabled with `--recursive=false`.
+--8<-- "common-flags/recursive.md:default-true"
 
 ## Examples
 

--- a/assets/chezmoi.io/docs/reference/commands/status.md
+++ b/assets/chezmoi.io/docs/reference/commands/status.md
@@ -28,20 +28,19 @@ running [`chezmoi apply`](apply.md) will have.
 
 ### `--init`
 
-Recreate config file from template.
+--8<-- "common-flags/init.md"
 
 ### `-P`, `--parent-dirs`
 
-Also perform command on all parent directories of *target*.
+--8<-- "common-flags/parent-dirs.md"
 
-### `-p`, `--path-style` `absolute`|`relative`|`source-absolute`|`source-relative`
+### `-p`, `--path-style` *style*
 
-Print paths in the given style. Relative paths are relative to the destination
-directory. The default is `relative`.
+--8<-- "common-flags/path-style.md:all"
 
 ### `-r`, `--recursive`
 
-Recurse into subdirectories, `true` by default. Can be disabled with `--recursive=false`.
+--8<-- "common-flags/recursive.md:default-true"
 
 ## Examples
 

--- a/assets/chezmoi.io/docs/reference/commands/unmanaged.md
+++ b/assets/chezmoi.io/docs/reference/commands/unmanaged.md
@@ -7,14 +7,13 @@ It is an error to supply *path*s that are not found on the filesystem.
 
 ## Common flags
 
-### `-p`, `--path-style` `absolute`|`relative`|`source-absolute`|`source-relative`
+### `-p`, `--path-style` *style*
 
-Print paths in the given style. Relative paths are relative to the destination
-directory. The default is `relative`.
+--8<-- "common-flags/path-style.md:no-source-tree"
 
 ### `-t`, `--tree`
 
-Print paths as a tree.
+--8<-- "common-flags/tree.md"
 
 ## Examples
 

--- a/assets/chezmoi.io/docs/reference/commands/update.md
+++ b/assets/chezmoi.io/docs/reference/commands/update.md
@@ -29,15 +29,15 @@ Update submodules recursively. This defaults to `true`. Can be disabled with `--
 
 ### `--init`
 
-Recreate config file from template.
+--8<-- "common-flags/init.md"
 
 ### `-P`, `--parent-dirs`
 
-Also perform command on all parent directories of *target*.
+--8<-- "common-flags/parent-dirs.md"
 
 ### `-r`, `--recursive`
 
-Recurse into subdirectories, `true` by default. Can be disabled with `--recursive=false`.
+--8<-- "common-flags/recursive.md:default-true"
 
 ## Examples
 

--- a/assets/chezmoi.io/docs/reference/commands/verify.md
+++ b/assets/chezmoi.io/docs/reference/commands/verify.md
@@ -16,15 +16,15 @@ no targets are specified then all targets are checked.
 
 ### `--init`
 
-Recreate config file from template.
+--8<-- "common-flags/init.md"
 
 ### `-P`, `--parent-dirs`
 
-Also perform command on all parent directories of *target*.
+--8<-- "common-flags/parent-dirs.md"
 
 ### `-r`, `--recursive`
 
-Recurse into subdirectories, `true` by default. Can be disabled with `--recursive=false`.
+--8<-- "common-flags/recursive.md:default-true"
 
 ## Examples
 

--- a/assets/chezmoi.io/snippets/common-flags/format.md
+++ b/assets/chezmoi.io/snippets/common-flags/format.md
@@ -1,0 +1,1 @@
+Set the output format, `json` by default.

--- a/assets/chezmoi.io/snippets/common-flags/init.md
+++ b/assets/chezmoi.io/snippets/common-flags/init.md
@@ -1,0 +1,2 @@
+Regenerate and reload the config file from its template before computing
+the target state.

--- a/assets/chezmoi.io/snippets/common-flags/parent-dirs.md
+++ b/assets/chezmoi.io/snippets/common-flags/parent-dirs.md
@@ -1,0 +1,1 @@
+Execute the command on *target* and all its parent directories.

--- a/assets/chezmoi.io/snippets/common-flags/path-style.md
+++ b/assets/chezmoi.io/snippets/common-flags/path-style.md
@@ -1,0 +1,12 @@
+--8<-- [start:all]
+--8<-- [start:no-source-tree]
+Print paths in the given style. The default is `relative`.
+
+| Style             | Description                                 |
+| ----------------- | ------------------------------------------- |
+| `absolute`        | Absolute paths in the destination directory |
+| `relative`        | Relative paths to the destination directory |
+--8<-- [end:no-source-tree]
+| `source-absolute` | Absolute paths in the source tree directory |
+| `source-relative` | Relative paths to the source tree directory |
+--8<-- [end:all]

--- a/assets/chezmoi.io/snippets/common-flags/recursive.md
+++ b/assets/chezmoi.io/snippets/common-flags/recursive.md
@@ -1,0 +1,6 @@
+--8<-- [start:default-true]
+--8<-- [start:default-false]
+Recurse into subdirectories.
+--8<-- [end:default-false]
+Enabled by default. Can be disabled with `--recursive=false`.
+--8<-- [end:default-true]

--- a/assets/chezmoi.io/snippets/common-flags/tree.md
+++ b/assets/chezmoi.io/snippets/common-flags/tree.md
@@ -1,0 +1,1 @@
+Print paths as a tree instead of a list.


### PR DESCRIPTION
<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer-guide/contributing-changes/

-->

Finish what was started for `--include`/`--exclude` and deduplicate remaining common flags descriptions.

* Update descriptions for `--init` and `--parent-dirs` a bit.
* Fix description for `chezmoi unmanaged --path-style`. It only supports 2 values there.
* Use ["snippet sections"](https://facelessuser.github.io/pymdown-extensions/extensions/snippets/#snippet-sections) for `--recursive` and `--path-style` to cover differences in behaviour for different commands.