### PR TITLE
fix: Accept only supported values to 'unmanaged --path-style'

### DIFF
--- a/internal/chezmoi/pathstyle.go
+++ b/internal/chezmoi/pathstyle.go
@@ -5,7 +5,10 @@ import (
 	"strings"
 )
 
-type PathStyle string
+type (
+	PathStyle       string
+	PathStyleSimple string
+)
 
 const (
 	PathStyleAbsolute       PathStyle = "absolute"
@@ -23,6 +26,13 @@ var (
 	}
 
 	PathStyleFlagCompletionFunc = FlagCompletionFunc(PathStyleStrings)
+
+	PathStyleSimpleStrings = []string{
+		PathStyleAbsolute.String(),
+		PathStyleRelative.String(),
+	}
+
+	PathStyleSimpleFlagCompletionFunc = FlagCompletionFunc(PathStyleSimpleStrings)
 )
 
 // Set implements github.com/spf13/pflag.Value.Set.
@@ -47,4 +57,32 @@ func (p PathStyle) Type() string {
 
 func (p PathStyle) Copy() *PathStyle {
 	return &p
+}
+
+// Set implements github.com/spf13/pflag.Value.Set.
+func (p *PathStyleSimple) Set(s string) error {
+	uniqueAbbreviations := UniqueAbbreviations(PathStyleSimpleStrings)
+	pathStyleStr, ok := uniqueAbbreviations[s]
+	if !ok {
+		return fmt.Errorf("%s: unknown path style", s)
+	}
+	*p = PathStyleSimple(pathStyleStr)
+	return nil
+}
+
+func (p PathStyleSimple) String() string {
+	return string(p)
+}
+
+// Type implements github.com/spf13/pflag.Value.Type.
+func (p PathStyleSimple) Type() string {
+	return strings.Join(PathStyleSimpleStrings, "|")
+}
+
+func (p PathStyleSimple) Copy() *PathStyleSimple {
+	return &p
+}
+
+func (p PathStyleSimple) ToPathStyle() PathStyle {
+	return PathStyle(p)
 }

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -312,11 +312,10 @@ var (
 	whitespaceRx = regexp.MustCompile(`\s+`)
 
 	commonFlagCompletionFuncs = map[string]func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective){
-		"exclude":    chezmoi.EntryTypeSetFlagCompletionFunc,
-		"format":     writeDataFormatFlagCompletionFunc,
-		"include":    chezmoi.EntryTypeSetFlagCompletionFunc,
-		"path-style": chezmoi.PathStyleFlagCompletionFunc,
-		"secrets":    severityFlagCompletionFunc,
+		"exclude": chezmoi.EntryTypeSetFlagCompletionFunc,
+		"format":  writeDataFormatFlagCompletionFunc,
+		"include": chezmoi.EntryTypeSetFlagCompletionFunc,
+		"secrets": severityFlagCompletionFunc,
 	}
 )
 
@@ -383,7 +382,7 @@ func newConfig(options ...configOption) (*Config, error) {
 			recursive: true,
 		},
 		unmanaged: unmanagedCmdConfig{
-			pathStyle: chezmoi.PathStyleRelative,
+			pathStyle: chezmoi.PathStyleSimple(chezmoi.PathStyleRelative),
 		},
 
 		// Configuration.

--- a/internal/cmd/managedcmd.go
+++ b/internal/cmd/managedcmd.go
@@ -31,6 +31,10 @@ func (c *Config) newManagedCmd() *cobra.Command {
 	managedCmd.Flags().VarP(&c.managed.pathStyle, "path-style", "p", "Path style")
 	managedCmd.Flags().BoolVarP(&c.managed.tree, "tree", "t", c.managed.tree, "Print paths as a tree")
 
+	if err := managedCmd.RegisterFlagCompletionFunc("path-style", chezmoi.PathStyleFlagCompletionFunc); err != nil {
+		panic(err)
+	}
+
 	return managedCmd
 }
 

--- a/internal/cmd/statuscmd.go
+++ b/internal/cmd/statuscmd.go
@@ -45,6 +45,10 @@ func (c *Config) newStatusCmd() *cobra.Command {
 		BoolVarP(&c.Status.parentDirs, "parent-dirs", "P", c.Status.parentDirs, "Show status of all parent directories")
 	statusCmd.Flags().BoolVarP(&c.Status.recursive, "recursive", "r", c.Status.recursive, "Recurse into subdirectories")
 
+	if err := statusCmd.RegisterFlagCompletionFunc("path-style", chezmoi.PathStyleFlagCompletionFunc); err != nil {
+		panic(err)
+	}
+
 	return statusCmd
 }
 

--- a/internal/cmd/testdata/scripts/completion.txtar
+++ b/internal/cmd/testdata/scripts/completion.txtar
@@ -30,9 +30,17 @@ cmp stdout golden/entry-type-set
 exec chezmoi __complete --mode ''
 cmp stdout golden/mode
 
-# test that path style values are completed
+# test that status path style values are completed
+exec chezmoi __complete status --path-style ''
+cmp stdout golden/path-style
+
+# test that managed path style values are completed
 exec chezmoi __complete managed --path-style ''
 cmp stdout golden/path-style
+
+# test that unmanaged path style values are completed
+exec chezmoi __complete unmanaged --path-style ''
+cmp stdout golden/unmanaged-path-style
 
 # test that write --format values are completed
 exec chezmoi __complete state dump --format ''
@@ -77,6 +85,10 @@ absolute
 relative
 source-absolute
 source-relative
+:4
+-- golden/unmanaged-path-style --
+absolute
+relative
 :4
 -- golden/use-builtin-flags --
 --use-builtin-age	Use builtin age

--- a/internal/cmd/testdata/scripts/unmanaged.txtar
+++ b/internal/cmd/testdata/scripts/unmanaged.txtar
@@ -31,6 +31,10 @@ cmp stdout golden/unmanaged-with-some-managed
 [unix] exec chezmoi unmanaged --path-style=absolute
 [unix] cmpenv stdout golden/unmanaged-absolute
 
+# test chezmoi unmanaged --path-style=source-absolute
+! exec chezmoi unmanaged --path-style=source-absolute
+stderr 'source-absolute: unknown path style'
+
 -- golden/unmanaged --
 .local
 -- golden/unmanaged-absolute --

--- a/internal/cmd/unmanagedcmd.go
+++ b/internal/cmd/unmanagedcmd.go
@@ -12,7 +12,7 @@ import (
 )
 
 type unmanagedCmdConfig struct {
-	pathStyle chezmoi.PathStyle
+	pathStyle chezmoi.PathStyleSimple
 	tree      bool
 }
 
@@ -29,6 +29,10 @@ func (c *Config) newUnmanagedCmd() *cobra.Command {
 
 	unmanagedCmd.Flags().VarP(&c.unmanaged.pathStyle, "path-style", "p", "Path style")
 	unmanagedCmd.Flags().BoolVarP(&c.unmanaged.tree, "tree", "t", c.unmanaged.tree, "Print paths as a tree")
+
+	if err := unmanagedCmd.RegisterFlagCompletionFunc("path-style", chezmoi.PathStyleSimpleFlagCompletionFunc); err != nil {
+		panic(err)
+	}
 
 	return unmanagedCmd
 }
@@ -97,7 +101,7 @@ func (c *Config) runUnmanagedCmd(cmd *cobra.Command, args []string, sourceState 
 	paths := make([]fmt.Stringer, 0, len(unmanagedRelPaths.Elements()))
 	for relPath := range unmanagedRelPaths {
 		var path fmt.Stringer
-		if c.unmanaged.pathStyle == chezmoi.PathStyleAbsolute {
+		if c.unmanaged.pathStyle.ToPathStyle() == chezmoi.PathStyleAbsolute {
 			path = c.DestDirAbsPath.Join(relPath)
 		} else {
 			path = relPath


### PR DESCRIPTION
<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer-guide/contributing-changes/

-->
Currently `unmanaged --path-style` accepts the same options as `managed --path-style`. And this is reflected in `unmanaged --help`. Misleading help message is reason why I added unsupported values to documentation initially.

But in fact, only `relative` and `absolute` values are expected there, unmanaged files are not present in the source tree. Every value which is not `absolute` is treated as `relative` which doesn't seem right.

* Add `PathStyleSimple` similar to `PathStyle` but with only 2 values.
* This also fixes values for shell completion.
* Added test to validate new behaviour.

## `chezmoi unmanaged --help`
```console
Description:
  List all unmanaged files in paths. When no paths are supplied, list all
  unmanaged files in the destination directory.

  It is an error to supply paths that are not found on the filesystem.

Usage:
  chezmoi unmanaged [path]... [flags]

Examples:
  $ chezmoi unmanaged
  $ chezmoi unmanaged ~/.config/chezmoi ~/.ssh

Flags:
  -h, --help                           help for unmanaged
  -p, --path-style absolute|relative   Path style (default relative)
  -t, --tree                           Print paths as a tree
```