### PR TITLE
fix: Fix completion for 'archive --format'

### DIFF
--- a/internal/chezmoi/archive.go
+++ b/internal/chezmoi/archive.go
@@ -38,6 +38,18 @@ const (
 	ArchiveFormatZip     ArchiveFormat = "zip"
 )
 
+var ArchiveFormatFlagCompletionFunc = FlagCompletionFunc([]string{
+	ArchiveFormatTar.String(),
+	ArchiveFormatTarBz2.String(),
+	ArchiveFormatTarGz.String(),
+	ArchiveFormatTarXz.String(),
+	ArchiveFormatTarZst.String(),
+	ArchiveFormatTbz2.String(),
+	ArchiveFormatTgz.String(),
+	ArchiveFormatTxz.String(),
+	ArchiveFormatZip.String(),
+})
+
 type UnknownArchiveFormatError string
 
 func (e UnknownArchiveFormatError) Error() string {

--- a/internal/cmd/archivecmd.go
+++ b/internal/cmd/archivecmd.go
@@ -44,6 +44,10 @@ func (c *Config) newArchiveCmd() *cobra.Command {
 	archiveCmd.Flags().BoolVarP(&c.archive.parentDirs, "parent-dirs", "P", c.archive.parentDirs, "Archive parent directories")
 	archiveCmd.Flags().BoolVarP(&c.archive.recursive, "recursive", "r", c.archive.recursive, "Recurse into subdirectories")
 
+	if err := archiveCmd.RegisterFlagCompletionFunc("format", chezmoi.ArchiveFormatFlagCompletionFunc); err != nil {
+		panic(err)
+	}
+
 	return archiveCmd
 }
 

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -312,10 +312,11 @@ var (
 	whitespaceRx = regexp.MustCompile(`\s+`)
 
 	commonFlagCompletionFuncs = map[string]func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective){
-		"exclude": chezmoi.EntryTypeSetFlagCompletionFunc,
-		"format":  writeDataFormatFlagCompletionFunc,
-		"include": chezmoi.EntryTypeSetFlagCompletionFunc,
-		"secrets": severityFlagCompletionFunc,
+		"exclude":    chezmoi.EntryTypeSetFlagCompletionFunc,
+		"format":     writeDataFormatFlagCompletionFunc,
+		"include":    chezmoi.EntryTypeSetFlagCompletionFunc,
+		"path-style": chezmoi.PathStyleFlagCompletionFunc,
+		"secrets":    severityFlagCompletionFunc,
 	}
 )
 
@@ -2986,6 +2987,9 @@ func prependParentRelPaths(relPaths []chezmoi.RelPath) []chezmoi.RelPath {
 // common flags, recursively. It panics on any error.
 func registerCommonFlagCompletionFuncs(cmd *cobra.Command) {
 	cmd.Flags().VisitAll(func(flag *pflag.Flag) {
+		if _, exist := cmd.GetFlagCompletionFunc(flag.Name); exist {
+			return
+		}
 		if flagCompletionFunc, ok := commonFlagCompletionFuncs[flag.Name]; ok {
 			if err := cmd.RegisterFlagCompletionFunc(flag.Name, flagCompletionFunc); err != nil {
 				panic(err)

--- a/internal/cmd/managedcmd.go
+++ b/internal/cmd/managedcmd.go
@@ -33,10 +33,6 @@ func (c *Config) newManagedCmd() *cobra.Command {
 	managedCmd.Flags().VarP(&c.managed.pathStyle, "path-style", "p", "Path style")
 	managedCmd.Flags().BoolVarP(&c.managed.tree, "tree", "t", c.managed.tree, "Print paths as a tree")
 
-	if err := managedCmd.RegisterFlagCompletionFunc("path-style", chezmoi.PathStyleFlagCompletionFunc); err != nil {
-		panic(err)
-	}
-
 	return managedCmd
 }
 

--- a/internal/cmd/statuscmd.go
+++ b/internal/cmd/statuscmd.go
@@ -45,10 +45,6 @@ func (c *Config) newStatusCmd() *cobra.Command {
 		BoolVarP(&c.Status.parentDirs, "parent-dirs", "P", c.Status.parentDirs, "Show status of all parent directories")
 	statusCmd.Flags().BoolVarP(&c.Status.recursive, "recursive", "r", c.Status.recursive, "Recurse into subdirectories")
 
-	if err := statusCmd.RegisterFlagCompletionFunc("path-style", chezmoi.PathStyleFlagCompletionFunc); err != nil {
-		panic(err)
-	}
-
 	return statusCmd
 }
 

--- a/internal/cmd/testdata/scripts/completion.txtar
+++ b/internal/cmd/testdata/scripts/completion.txtar
@@ -42,14 +42,41 @@ cmp stdout golden/path-style
 exec chezmoi __complete unmanaged --path-style ''
 cmp stdout golden/unmanaged-path-style
 
-# test that write --format values are completed
+# test that "state data --format" values are completed
+exec chezmoi __complete state data --format ''
+cmp stdout golden/output-format
+
+# test that "state dump --format" values are completed
 exec chezmoi __complete state dump --format ''
-cmp stdout golden/write-data
+cmp stdout golden/output-format
 
-# test that write --format values are completed
+# test that "data --format" values are completed
 exec chezmoi __complete data --format ''
-cmp stdout golden/write-data
+cmp stdout golden/output-format
 
+# test that "dump --format" values are completed
+exec chezmoi __complete dump --format ''
+cmp stdout golden/output-format
+
+# test that "dump-config --format" values are completed
+exec chezmoi __complete dump-config --format ''
+cmp stdout golden/output-format
+
+# test that "archive --format" values are completed
+exec chezmoi __complete archive --format ''
+cmp stdout golden/archive-format
+
+-- golden/archive-format --
+tar
+tar.bz2
+tar.gz
+tar.xz
+tar.zst
+tbz2
+tgz
+txz
+zip
+:4
 -- golden/auto-bool-t --
 t
 true
@@ -80,6 +107,10 @@ templates
 file
 symlink
 :4
+-- golden/output-format --
+json
+yaml
+:4
 -- golden/path-style --
 absolute
 relative
@@ -94,8 +125,4 @@ relative
 --use-builtin-age	Use builtin age
 --use-builtin-diff	Use builtin diff
 --use-builtin-git	Use builtin git
-:4
--- golden/write-data --
-json
-yaml
 :4


### PR DESCRIPTION
<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer-guide/contributing-changes/

-->

`chezmoi archive --format` is different from other `--format` flags and expects format of the archive.

I found cleaner way to override completion function for individual command while keeping `commonFlagCompletionFuncs` unchanged.