### PR TITLE
docs: Move command line flags links closer to commands

### DIFF
--- a/assets/chezmoi.io/docs/reference/index.md
+++ b/assets/chezmoi.io/docs/reference/index.md
@@ -10,6 +10,7 @@ This reference covers the following topics:
 - [Application order of changes](application-order.md)
 - [Configuration file](configuration-file/index.md)
 - [Special files](special-files/index.md) and [special directories](special-directories/index.md)
+- [Command line flags](command-line-flags/index.md)
 - [Commands](commands/index.md)
 - [Templates](templates/index.md)
     - [Variables](templates/variables.md)

--- a/assets/chezmoi.io/mkdocs.yml
+++ b/assets/chezmoi.io/mkdocs.yml
@@ -112,11 +112,6 @@ nav:
   - Source state attributes: reference/source-state-attributes.md
   - Target types: reference/target-types.md
   - Application order: reference/application-order.md
-  - Command line flags:
-    - reference/command-line-flags/index.md
-    - Global: reference/command-line-flags/global.md
-    - Common: reference/command-line-flags/common.md
-    - Developer: reference/command-line-flags/developer.md
   - Configuration file:
     - reference/configuration-file/index.md
     - Variables: reference/configuration-file/variables.md
@@ -141,6 +136,11 @@ nav:
     - .chezmoiexternals: reference/special-directories/chezmoiexternals.md
     - .chezmoiscripts: reference/special-directories/chezmoiscripts.md
     - .chezmoitemplates: reference/special-directories/chezmoitemplates.md
+  - Command line flags:
+    - reference/command-line-flags/index.md
+    - Global: reference/command-line-flags/global.md
+    - Common: reference/command-line-flags/common.md
+    - Developer: reference/command-line-flags/developer.md
   - Commands:
     - reference/commands/index.md
     - add: reference/commands/add.md


### PR DESCRIPTION
<!--

Thanks for contributing!


Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer-guide/contributing-changes/

-->

These pages are closely related to commands, it makes sense to have them next to each other.

## Updated menu

<img width="213" alt="Screenshot 2024-10-28 at 17 18 00" src="https://github.com/user-attachments/assets/7b5d1c2d-5a3e-4535-88cb-fc8e5b204e15">
