### PR TITLE
docs: Remove extra 'o' from chezmoi external reference

### DIFF
--- a/assets/chezmoi.io/docs/reference/special-files/chezmoiexternal-format.md
+++ b/assets/chezmoi.io/docs/reference/special-files/chezmoiexternal-format.md
@@ -98,7 +98,7 @@ determine whether an archive member is included:
    is excluded.
 4. Otherwise, if only `exclude` patterns were specified then the archive member
    is included.
-5. Otherwise, the archive member is included.o
+5. Otherwise, the archive member is included.
 
 Excluded archive members do not generate source state entries, and, if they are
 directories, all of their children are also excluded.


### PR DESCRIPTION
Hello!

Thanks so much for `chezmoi`! It's made managing my dotfiles a _breeze_.

I was perusing the chezmoi external format documentation and noticed a straggling 'o' in a numbered list.

Tiny PR to remove the typo!

Best :heart:,
@nfielder