### PR TITLE
chore: Fix encryption warnings in tests

### DIFF
--- a/internal/cmd/datacmd_test.go
+++ b/internal/cmd/datacmd_test.go
@@ -23,6 +23,7 @@ func TestDataCmd(t *testing.T) {
 					`{`,
 					`  "mode": "symlink",`,
 					`  "sourceDir": "/tmp/source",`,
+					`  "encryption": "age",`,
 					`  "age": {`,
 					`    "args": [`,
 					`      "arg"`,
@@ -42,6 +43,7 @@ func TestDataCmd(t *testing.T) {
 				"/home/user/.config/chezmoi/chezmoi.yaml": chezmoitest.JoinLines(
 					`mode: symlink`,
 					`sourceDir: /tmp/source`,
+					`encryption: age`,
 					`age:`,
 					`  args:`,
 					`  - arg`,

--- a/internal/cmd/testdata/scripts/doctor_unix.txtar
+++ b/internal/cmd/testdata/scripts/doctor_unix.txtar
@@ -210,6 +210,7 @@ echo "0.2.1, git sha (8d9af42c8b98c9527741a239b23a3e384812f514), go1.20.4 arm64"
 -- home4/user/.config/chezmoi/chezmoi.json --
 -- home4/user/.config/chezmoi/chezmoi.yaml --
 -- home5/user/.config/chezmoi/chezmoi.toml --
+encryption = "age"
 [age]
     suffix = ".age-encrypted"
 -- home5/user/.local/share/chezmoi/dot_config/chezmoi/encrypted_chezmoi.toml.age-encrypted --

--- a/internal/cmd/testdata/scripts/gpgencryption.txtar
+++ b/internal/cmd/testdata/scripts/gpgencryption.txtar
@@ -26,6 +26,8 @@ cmp $HOME/.encrypted golden/.encrypted
 removeline $CHEZMOICONFIGDIR/chezmoi.toml 'encryption = "gpg"'
 exec chezmoi cat $HOME${/}.encrypted
 cmp stdout golden/.encrypted
+stderr 'chezmoi: warning: ''encryption'' not set, using gpg configuration. Check if ''encryption'' is correctly set as the top-level key.'
+prependline $CHEZMOICONFIGDIR/chezmoi.toml 'encryption = "gpg"'
 
 # test that chezmoi decrypt decrypts stdin
 stdin $CHEZMOISOURCEDIR${/}encrypted_dot_encrypted.asc

--- a/internal/cmd/testdata/scripts/gpgencryptionsymmetric.txtar
+++ b/internal/cmd/testdata/scripts/gpgencryptionsymmetric.txtar
@@ -26,6 +26,8 @@ cmp $HOME/.encrypted golden/.encrypted
 removeline $CHEZMOICONFIGDIR/chezmoi.toml 'encryption = "gpg"'
 exec chezmoi cat $HOME${/}.encrypted
 cmp stdout golden/.encrypted
+stderr 'chezmoi: warning: ''encryption'' not set, using gpg configuration. Check if ''encryption'' is correctly set as the top-level key.'
+prependline $CHEZMOICONFIGDIR/chezmoi.toml 'encryption = "gpg"'
 
 # test that chezmoi edit --apply transparently decrypts and re-encrypts
 exec chezmoi edit --apply --force $HOME${/}.encrypted

--- a/internal/cmd/testdata/scripts/issue3582.txtar
+++ b/internal/cmd/testdata/scripts/issue3582.txtar
@@ -6,6 +6,7 @@ stdout '"pager": "my-diff-pager"'
 stdout '"identity": ".*/my-age-identity"'
 
 -- home/user/.config/chezmoi/chezmoi.toml --
+encryption = "age"
 pager = "my-pager"
 [diff]
     pager = "my-diff-pager"


### PR DESCRIPTION
<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer-guide/contributing-changes/

-->

While checking issue which was fixed by #4048, I ran `go test ./... -v` and noticed few warnings which were introduced by #3981 . Either fix or check them in tests.