### PR TITLE
chore: Optimize Go caches in Github Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,6 +65,14 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         fetch-depth: 1
+    - uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: setup-go-${{ runner.os }}-x64-ubuntu22-go-${{ env.GO_VERSION }}-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          setup-go-${{ runner.os }}-x64-ubuntu22-go-${{ env.GO_VERSION }}-
     - uses: github/codeql-action/init@662472033e021d55d94146f66f6058822b0b39fd
       with:
         languages: go
@@ -304,17 +312,15 @@ jobs:
     runs-on: windows-2022
     permissions:
       contents: read
+    env:
+      GOPATH: 'D:\golang\go'
+      GOCACHE: 'D:\golang\cache'
+      GOMODCACHE: 'D:\golang\modcache'
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
     - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed
       with:
         go-version: ${{ env.GO_VERSION }}
-    - uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
     - name: build
       run: |
         go build ./...
@@ -386,6 +392,11 @@ jobs:
     runs-on: ${{ matrix.runs-on }}
     permissions:
       contents: read
+    env:
+      GOPATH: ${{ startsWith(matrix.runs-on, 'windows') && 'D:\golang\go' || '' }}
+      GOCACHE: ${{ startsWith(matrix.runs-on, 'windows') && 'D:\golang\cache' || '' }}
+      GOMODCACHE: ${{ startsWith(matrix.runs-on, 'windows') && 'D:\golang\modcache' || '' }}
+      USERPROFILE: ${{ startsWith(matrix.runs-on, 'windows') && 'D:\homedir' || '' }}
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
     - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed


### PR DESCRIPTION
<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer-guide/contributing-changes/

-->

* Set `GOPATH`, `GOCACHE` and `GOMODCACHE` on Windows jobs. Drive `C:/` on Windows workers is extremely slow and now these jobs are as fast as on MacOS or Linux.
  * `test-windows` job is down to **6m8s** from **18m30s**, **67%** imrovement!
  * `lint-windows-2022` is down to **58s** from **3m10s**, **70%** improvement!
* This also saves 1.2 GB per cache version for duplicated Windows cache.
* Enable cache for `codeql` job. Re-use cache key generated by `actions/setup-go`. Run time is improved from [**2m19s**](https://github.com/twpayne/chezmoi/actions/runs/11709612098?pr=4063) to [**1m49s**](https://github.com/twpayne/chezmoi/actions/runs/11710960439?pr=4064), by **~22%**.