### PR TITLE
chore: Enable Go cache for Docker builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,11 +87,19 @@ jobs:
       contents: read
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+    - uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a
+      with:
+        path: |
+          ~/.go-alpine
+        key: alpine-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          alpine-go-
     - name: test
       env:
         CHEZMOI_GITHUB_TOKEN: ${{ secrets.CHEZMOI_GITHUB_TOKEN }}
       run: |
-        ( cd assets/docker && ./test.sh alpine )
+        export DOCKER_GOCACHE="$HOME/.go-alpine"
+        ./assets/docker/test.sh alpine
   test-archlinux:
     needs: changes
     if: github.event_name == 'push' || needs.changes.outputs.code == 'true'
@@ -100,11 +108,19 @@ jobs:
       contents: read
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+    - uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a
+      with:
+        path: |
+          ~/.go-archlinux
+        key: archlinux-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          archlinux-go-
     - name: test
       env:
         CHEZMOI_GITHUB_TOKEN: ${{ secrets.CHEZMOI_GITHUB_TOKEN }}
       run: |
-        ( cd assets/docker && ./test.sh archlinux )
+        export DOCKER_GOCACHE="$HOME/.go-archlinux"
+        ./assets/docker/test.sh archlinux
   test-macos:
     needs: changes
     if: github.event_name == 'push' || needs.changes.outputs.code == 'true'

--- a/assets/docker/entrypoint.sh
+++ b/assets/docker/entrypoint.sh
@@ -6,6 +6,13 @@ git config --global --add safe.directory /chezmoi
 
 GO=${GO:-go}
 
+if [ -d "/go-cache" ]; then
+	echo "Set GOCACHE to /go-cache"
+	export GOCACHE="/go-cache/cache"
+	echo "Set GOMODCACHE to /go-cache/modcache"
+	export GOMODCACHE="/go-cache/modcache"
+fi
+
 cd /chezmoi
 ${GO} run . doctor || true
 ${GO} test ./...

--- a/assets/docker/test.sh
+++ b/assets/docker/test.sh
@@ -2,7 +2,15 @@
 
 set -eufo pipefail
 
-cd ../..
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+REPO_ROOT=$( cd "${SCRIPT_DIR}/../.." &> /dev/null && pwd )
+cd "${REPO_ROOT}"
+
+if [ "$#" -eq 0 ]; then
+	echo "Usage: $0 distribution1 [distribution2 ... distributionN]"
+	exit 1
+fi
+
 for distribution in "$@"; do
 	echo "${distribution}"
 	dockerfile="assets/docker/${distribution}.Dockerfile"
@@ -11,12 +19,20 @@ for distribution in "$@"; do
 		exit 1
 	fi
 	image="$(docker build . -f "assets/docker/${distribution}.Dockerfile" -q)"
-	docker run \
-		--env "CHEZMOI_GITHUB_ACCESS_TOKEN=${CHEZMOI_GITHUB_ACCESS_TOKEN-}" \
-		--env "CHEZMOI_GITHUB_TOKEN=${CHEZMOI_GITHUB_TOKEN-}" \
-		--env "GITHUB_ACCESS_TOKEN=${GITHUB_ACCESS_TOKEN-}" \
-		--env "GITHUB_TOKEN=${GITHUB_TOKEN-}" \
-		--rm \
-		--volume "${PWD}:/chezmoi" \
-		"${image}"
+	docker_command=(
+		docker run
+		--env "CHEZMOI_GITHUB_ACCESS_TOKEN=${CHEZMOI_GITHUB_ACCESS_TOKEN-}"
+		--env "CHEZMOI_GITHUB_TOKEN=${CHEZMOI_GITHUB_TOKEN-}"
+		--env "GITHUB_ACCESS_TOKEN=${GITHUB_ACCESS_TOKEN-}"
+		--env "GITHUB_TOKEN=${GITHUB_TOKEN-}"
+		--rm
+		--volume "${PWD}:/chezmoi"
+	)
+	if [ -n "${DOCKER_GOCACHE-}" ]; then
+		mkdir -p "${DOCKER_GOCACHE}"
+		docker_command+=(--volume "${DOCKER_GOCACHE}:/go-cache")
+	fi
+	docker_command+=("${image}")
+	# Run docker
+	"${docker_command[@]}"
 done


### PR DESCRIPTION
<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer-guide/contributing-changes/

-->

With ~300 MB per OS, create unique Go caches for Docker builds.

Make `test.sh` a bit more robust by allowing it to run from any directory. And add usage error if no arguments passed.

## Results
- `test-alpine` is down to **47s** from **1m30s**, **48%** improvement
- `test-archlinux` is down to **1m15s** from **1m53s**, **34%** improvement
