### PR TITLE
chore: Fix typo in entrypoint.sh

### DIFF
--- a/assets/docker/entrypoint.sh
+++ b/assets/docker/entrypoint.sh
@@ -7,10 +7,10 @@ git config --global --add safe.directory /chezmoi
 GO=${GO:-go}
 
 if [ -d "/go-cache" ]; then
-	echo "Set GOCACHE to /go-cache"
 	export GOCACHE="/go-cache/cache"
-	echo "Set GOMODCACHE to /go-cache/modcache"
+	echo "Set GOCACHE to ${GOCACHE}"
 	export GOMODCACHE="/go-cache/modcache"
+	echo "Set GOMODCACHE to ${GOMODCACHE}"
 fi
 
 cd /chezmoi


### PR DESCRIPTION
<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer-guide/contributing-changes/

-->

Noticed small typo from #4065 in `GOCACHE` printed value. Use variables instead.