### PR TITLE
chore: Optimize Linux caches on CI

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -24,6 +24,15 @@ jobs:
       id: go-version
       run: |
         echo go-version="$(awk '/GO_VERSION:/ { print $2 }' .github/workflows/main.yml | tr -d \')" >> "${GITHUB_OUTPUT}"
+    - uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a
+      with:
+        path: |
+          /home/runner/go/pkg/mod
+          /home/runner/.cache/go-build
+        key: govulncheck-${{ runner.os }}-${{ steps.go-version.outputs.go-version }}-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          govulncheck-${{ runner.os }}-${{ steps.go-version.outputs.go-version }}-
     - uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee
       with:
+        cache: false
         go-version-input: ${{ steps.go-version.outputs.go-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,8 +68,8 @@ jobs:
     - uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a
       with:
         path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
+          /home/runner/go/pkg/mod
+          /home/runner/.cache/go-build
         key: setup-go-${{ runner.os }}-x64-ubuntu22-go-${{ env.GO_VERSION }}-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           setup-go-${{ runner.os }}-x64-ubuntu22-go-${{ env.GO_VERSION }}-
@@ -207,8 +207,17 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         fetch-depth: 0
+    - uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a
+      with:
+        path: |
+          /home/runner/go/pkg/mod
+          /home/runner/.cache/go-build
+        key: release-go-${{ runner.os }}-${{ env.GO_VERSION }}-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          release-go-${{ runner.os }}-${{ env.GO_VERSION }}-
     - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed
       with:
+        cache: false
         go-version: ${{ env.GO_VERSION }}
     - name: install-release-dependencies
       if: github.event_name == 'push' || needs.changes.outputs.code == 'true'
@@ -268,8 +277,17 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         fetch-depth: 0
+    - uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a
+      with:
+        path: |
+          /home/runner/go/pkg/mod
+          /home/runner/.cache/go-build
+        key: setup-go-${{ runner.os }}-x64-ubuntu22-go-${{ env.GO_VERSION }}-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          setup-go-${{ runner.os }}-x64-ubuntu22-go-${{ env.GO_VERSION }}-
     - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed
       with:
+        cache: false
         go-version: ${{ env.GO_VERSION }}
     - name: install-age
       if: github.event_name == 'push' || needs.changes.outputs.code == 'true'
@@ -308,8 +326,17 @@ jobs:
       contents: read
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+    - uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a
+      with:
+        path: |
+          /home/runner/go/pkg/mod
+          /home/runner/.cache/go-build
+        key: website-go-${{ runner.os }}-${{ env.GO_VERSION }}-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          website-go-${{ runner.os }}-${{ env.GO_VERSION }}-
     - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed
       with:
+        cache: false
         go-version: ${{ env.GO_VERSION }}
     - uses: astral-sh/setup-uv@2e657c127d5b1635d5a8e3fa40e0ac50a5bf6992
       with:
@@ -456,8 +483,17 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         fetch-depth: 0
+    - uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a
+      with:
+        path: |
+          /home/runner/go/pkg/mod
+          /home/runner/.cache/go-build
+        key: release-go-${{ runner.os }}-${{ env.GO_VERSION }}-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          release-go-${{ runner.os }}-${{ env.GO_VERSION }}-
     - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed
       with:
+        cache: false
         go-version: ${{ env.GO_VERSION }}
     - uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da
     - name: create-syso
@@ -484,8 +520,17 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       with:
         fetch-depth: 0
+    - uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a
+      with:
+        path: |
+          /home/runner/go/pkg/mod
+          /home/runner/.cache/go-build
+        key: website-go-${{ runner.os }}-${{ env.GO_VERSION }}-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          website-go-${{ runner.os }}-${{ env.GO_VERSION }}-
     - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed
       with:
+        cache: false
         go-version: ${{ env.GO_VERSION }}
     - uses: astral-sh/setup-uv@2e657c127d5b1635d5a8e3fa40e0ac50a5bf6992
       with:


### PR DESCRIPTION
<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer-guide/contributing-changes/

-->
## Context

I found few issues with current cache keys on Linux:
1. `codeql` doesn't reuse cache with other jobs because paths should also match exactly.
2. `test-ubuntu` writes cache for ubuntu20 and `test-release` reads it. `test-release` should have isolated cache because it builds binaries for many other platforms. `test-ubuntu` should share cache with `lint-ubuntu` and `codeql` jobs.
3. `test-website` writes to cache with the key that is later read by `lint-ubuntu`. `test-website` doesn't build everything and its cache is incomplete. It should have its own cache key.

## Previous setup

For every hash there were 5 cache entries for Linux:
- **setup-go-Linux-x64-ubuntu22-go-1.22.9-\<go-sum-hash\>** 300MB `oldstable-go`(w)
- **setup-go-Linux-x64-ubuntu20-go-1.23.3-\<go-sum-hash\>** 400MB `test-ubuntu`(w), `test-release`(r)
- **setup-go-Linux-x64-ubuntu22-go-1.23.3-\<go-sum-hash\>** 490MB `codeql`(w)
- **setup-go-Linux-x64-ubuntu22-go-1.23.3-\<go-sum-hash\>** 130MB `test-website`(w), `deploy-website`(r), `lint-ubuntu`(r), `check`(r)
- **setup-go-Linux-ubuntu22-go-1.23.3-\<go-sum-hash\>** 250MB `govulncheck`(w)

Total: 1570 MB

## New setup

- **setup-go-Linux-x64-ubuntu22-go-1.22.9-\<go-sum-hash\>** 300MB `oldstable-go`
- **setup-go-Linux-x64-ubuntu22-go-1.23.3-\<go-sum-hash\>** 310MB `codeql`, `lint-ubuntu`, `test-ubuntu`, `check`.
- **website-go-Linux-1.23.3-\<go-sum-hash\>** 130MB `test-website`, `deploy-website`
- **release-go-Linux-1.23.3-\<go-sum-hash\>** X `test-release`, `release`
- **govulncheck-Linux-1.23.3-\<go-sum-hash\>** 250MB `govulncheck`

Total: 990 MB + 2580 MB (for release builds) = 3570 MB
## Notes
- Unfortunately, `actions/setup-go` doesn't provide any control over generated cache key, so use `actions/cache` manually.
- Change `test-ubuntu` cache key to `ubuntu20`, it should be ok to share cache between different versions of ubuntu.
- Rename `release-go` and `govulncheck` cache keys for clarity and for protecting from future accidental changes.