### PR TITLE
chore: Delete pull request caches on close

### DIFF
--- a/.github/workflows/clear-pr-caches.yml
+++ b/.github/workflows/clear-pr-caches.yml
@@ -1,0 +1,12 @@
+on:
+  pull_request:
+    types: [ closed ]
+
+jobs:
+  clear-caches:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: clear-caches
+        uses: theAngularGuy/clear-cache-of-pull-request@60c83956d63c7b3745d6cde10d711aa0e50c2501
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer-guide/contributing-changes/

-->

When PR is closed, caches can be removed immediately to keep more space for caches on master branch. Caches can't be shared between different PRs. And PRs can only use cache from themself or master branch.

There is 10 GB limit for total cache size per repo, although Github allows to go above this limit for short time (caches above threshold seems to be deleted daily).