### PR TITLE
chore: Fix permissions for clear-pr-caches job

### DIFF
--- a/.github/workflows/clear-pr-caches.yml
+++ b/.github/workflows/clear-pr-caches.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   clear-caches:
     runs-on: ubuntu-22.04
+    permissions:
+      actions: write
     steps:
       - name: clear-caches
         uses: theAngularGuy/clear-cache-of-pull-request@60c83956d63c7b3745d6cde10d711aa0e50c2501


### PR DESCRIPTION
<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer-guide/contributing-changes/

-->

`DELETE /actions/caches` endpoint required `action: write` permission.

Failed job: https://github.com/twpayne/chezmoi/actions/runs/11769128068/job/32779753381