### PR TITLE
chore: Set permissions for clear-pr-caches workflow

### DIFF
--- a/.github/workflows/clear-pr-caches.yml
+++ b/.github/workflows/clear-pr-caches.yml
@@ -4,11 +4,12 @@ on:
   pull_request:
     types: [ closed ]
 
+permissions:
+  actions: write
+
 jobs:
   clear-caches:
     runs-on: ubuntu-22.04
-    permissions:
-      actions: write
     steps:
       - name: clear-caches
         uses: theAngularGuy/clear-cache-of-pull-request@60c83956d63c7b3745d6cde10d711aa0e50c2501


### PR DESCRIPTION
<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer-guide/contributing-changes/

-->

It seems write permission can't be set on job level, but can be set on workflow level, similar to how `lock-threads` does this.
