### PR TITLE
chore: Change clear-pr-caches trigger to pull_request_target

### DIFF
--- a/.github/workflows/clear-pr-caches.yml
+++ b/.github/workflows/clear-pr-caches.yml
@@ -9,9 +9,16 @@ permissions:
 
 jobs:
   clear-caches:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: clear-caches
-        uses: theAngularGuy/clear-cache-of-pull-request@60c83956d63c7b3745d6cde10d711aa0e50c2501
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          BRANCH: refs/pull/${{ github.event.pull_request.number }}/merge
+        run: |
+          cacheKeysForPR=$(gh cache list --ref "$BRANCH" --limit 100 --json id --jq '.[].id')
+          set +e
+          for cacheKey in $cacheKeysForPR; do
+            gh cache delete "$cacheKey"
+          done

--- a/.github/workflows/clear-pr-caches.yml
+++ b/.github/workflows/clear-pr-caches.yml
@@ -1,7 +1,7 @@
 name: clear-pr-caches
 
 on:
-  pull_request:
+  pull_request_target:
     types: [ closed ]
 
 permissions:


### PR DESCRIPTION
<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer-guide/contributing-changes/

-->

This is actually mentioned in docs: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#managing-caches

> To run the following example on cross-repository pull requests or pull requests from forks, you can trigger the workflow with the pull_request_target event. If you do use pull_request_target to trigger the workflow, there are security considerations to keep in mind.

Security consideration here is that running or building PR code in this workflow is unsafe. But as this workflow doesn't do that, it's fine.

More notes on security are in "warning" section here: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target

Also implement caches removal manually using the example from docs. This reduces security risk further if action owner modifies the code and action is updated without changes audit.