### PR TITLE
chore: Use .github/actions/setup-go in govulncheck

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -24,14 +24,10 @@ jobs:
       id: go-version
       run: |
         echo go-version="$(awk '/GO_VERSION:/ { print $2 }' .github/workflows/main.yml | tr -d \')" >> "${GITHUB_OUTPUT}"
-    - uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a
+    - uses: ./.github/actions/setup-go
       with:
-        path: |
-          /home/runner/go/pkg/mod
-          /home/runner/.cache/go-build
-        key: govulncheck-${{ runner.os }}-${{ steps.go-version.outputs.go-version }}-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          govulncheck-${{ runner.os }}-${{ steps.go-version.outputs.go-version }}-
+        go-version: ${{ steps.go-version.outputs.go-version }}
+        upload-cache: false
     - uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee
       with:
         cache: false


### PR DESCRIPTION
<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer-guide/contributing-changes/

-->
* Use common action to deduplicate code.
* Dedicated cache entry for govulncheck shouldn't be needed. Reuse one from linux tests. Saves 250 MB.