### PR TITLE
chore: Use newer Linux and Mac Github runners

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       matrix:
         os:
-        - macos-13
+        - macos-15
         - ubuntu-20.04
         #- windows-2022 # fails with "debug http_download_curl received HTTP status 000"
     needs: changes
@@ -75,7 +75,7 @@ jobs:
     strategy:
       matrix:
         os:
-        - macos-13
+        - macos-15
         - ubuntu-20.04
         - windows-2022
     needs: changes


### PR DESCRIPTION
<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer-guide/contributing-changes/

-->

- Switch remaining MacOS jobs to `macos-15`.
- Use latest `ubuntu-24.04`.