### PR TITLE
chore: Trigger builds on changes in setup-go/action.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,7 @@ jobs:
         filters: |
           code:
           - '**/*.go'
+          - '.github/actions/setup-go/action.yml'
           - '.github/workflows/main.yml'
           - '.goreleaser.yaml'
           - 'Makefile'


### PR DESCRIPTION
<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer-guide/contributing-changes/

-->

My goal in this PR was figure out why Windows builds are slow (~90s) on the latest image (`20241125.1.0`) of github runners when they were much faster (~10s) on previous image version. Unfortunately, I haven't found a solution.

1. It's not that cache was created on one image and being used on different one.
2. In new image Go is used from tool cache of runner (`RUNNER_TOOL_CACHE`) but there is no easy way to always download it. So I was unable to verify if something is wrong with version in the tool cache.