### PR TITLE
chore: Remove links to Twitter

### DIFF
--- a/assets/chezmoi.io/docs/links/social-media.md
+++ b/assets/chezmoi.io/docs/links/social-media.md
@@ -6,6 +6,4 @@
 | LinkedIn       | [`chezmoi dotfiles`](https://www.linkedin.com/search/results/all/?keywords=chezmoi%20dotfiles&origin=GLOBAL_SEARCH_HEADER) |
 | Reddit         | [`chezmoi`](https://www.reddit.com/search/?q=chezmoi&sort=new)                                                             |
 | Stack Overflow | [`chezmoi`](https://stackoverflow.com/questions/tagged/chezmoi)                                                            |
-| Twitter        | [`chezmoi dotfiles`](https://twitter.com/search?q=chezmoi%20dotfiles&f=live)                                               |
-| Twitter        | [`chezmoi.io`](https://twitter.com/search?q=chezmoi.io&f=live)                                                             |
 | YouTube        | [`chezmoi dotfiles`](https://www.youtube.com/results?search_query=%22chezmoi%22+dotfiles)                                  |

--- a/assets/chezmoi.io/docs/why-use-chezmoi.md
+++ b/assets/chezmoi.io/docs/why-use-chezmoi.md
@@ -29,7 +29,7 @@ you work in.
     safe. Overall, I love the way Chezmoi fits so perfectly into the niche of
     managing dotfiles.
 
-    &mdash; [@mike_kasberg](https://www.mikekasberg.com/blog/2021/05/12/my-dotfiles-story.html)
+    — [@mike_kasberg](https://www.mikekasberg.com/blog/2021/05/12/my-dotfiles-story.html)
 
 !!! quote
 
@@ -46,14 +46,14 @@ you work in.
     things sanely, and once I took some time to learn how to do things with
     chezmoi, I have never looked back.
 
-    &mdash; [njt](https://news.ycombinator.com/item?id=31015669)
+    — [njt](https://news.ycombinator.com/item?id=31015669)
 
 !!! quote
 
     Regular reminder that chezmoi is the best dotfile manager utility I've used
     and you can too
 
-    &mdash; [@mbbroberg](https://twitter.com/mbbroberg/status/1355644967625125892)
+    — @mbbroberg
 
 If you're using any of the following methods:
 
@@ -92,7 +92,7 @@ to machine differences, if needed.
     and more, but it was easier to keep it private for security, I'm ok mostly
     though. I'm using chezmoi and it's easier now
 
-    — [@sheldon_hull](https://twitter.com/sheldon_hull/status/1308139570597371907)
+    — @sheldon_hull
 
 If your system stores secrets in plain text, then you must be very careful about
 where you clone your dotfiles. If you clone them on your work machine then
@@ -113,7 +113,7 @@ machine.
     I've offloaded my dotfiles deployment from a homespun shell script to chezmoi.
     I'm quite happy with this decision.
 
-    — [@gotgenes](https://twitter.com/gotgenes/status/1251008845163319297)
+    — @gotgenes
 
 !!! quote
 
@@ -122,7 +122,7 @@ machine.
 
     in case you're wondering I have written 0 code
 
-    — [@buritica](https://twitter.com/buritica/status/1361062902451630089)
+    — @buritica
 
 !!! quote
 


### PR DESCRIPTION
Twitter search links seem to require you to be logged in, and direct links no longer seem to work.
