### PR TITLE
feat: Warn if the user is using the Helix editor with chezmoi edit

### DIFF
--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -2495,6 +2495,9 @@ func (c *Config) runEditor(args []string) error {
 	if err != nil {
 		return err
 	}
+	if c.Edit.Hardlink && filepath.Base(editor) == "hx" {
+		c.errorf("warning: helix editor cannot edit hardlinks, see https://github.com/helix-editor/helix/issues/11279 and https://github.com/twpayne/chezmoi/issues/3971")
+	}
 	start := time.Now()
 	err = c.run(chezmoi.EmptyAbsPath, editor, editorArgs)
 	if runtime.GOOS != "windows" && c.Edit.MinDuration != 0 {

--- a/internal/cmd/testdata/scripts/issue4107.txtar
+++ b/internal/cmd/testdata/scripts/issue4107.txtar
@@ -1,0 +1,18 @@
+[windows] skip
+
+chmod 777 bin/hx
+
+# test that chezmoi edit prints a warning if the editor is hx (helix) with hardlinks enabled
+exec chezmoi edit $HOME${/}.file
+stderr 'warning: helix editor cannot edit hardlinks'
+
+-- bin/hx --
+#!/bin/sh
+
+echo "helix 24.7 (079f5442)"
+-- home/user/.config/chezmoi/chezmoi.toml --
+[edit]
+    command = "hx"
+    hardlink = true
+-- home/user/.local/share/chezmoi/dot_file --
+# contents of .file


### PR DESCRIPTION
Fixes #4107.

Of course, we can be more precise with our detection of the Helix editor, but right now the current Helix release has been buggy for five months, so I propose to add more refined detection if/when Helix releases a fix.