### PR TITLE
fix: YAML parsing error by escaping `|` in `title`

### DIFF
--- a/assets/chezmoi.io/docs/links/videos.md.yaml
+++ b/assets/chezmoi.io/docs/links/videos.md.yaml
@@ -60,5 +60,5 @@ videos:
 - date: '2024-11-18'
   version: 2.54.0
   lang: AR
-  title: 'Chezmoi, Dotfiles, Workflow, Templates and Encryption | Arabic شرح'
+  title: 'Chezmoi, Dotfiles, Workflow, Templates and Encryption \| Arabic شرح'
   url: https://www.youtube.com/watch?v=Jrrd2dHYBmY


### PR DESCRIPTION
**Root Cause**
The YAML parser interprets the vertical bar `|` in the title as a special character, causing a parsing error. In YAML, `|` is used for literal block scalars, so when it appears in a string, it needs to be escaped to avoid misinterpretation.

**Fix**
Escape the `|` character in the title to prevent YAML parsing issues in HTML docs. The vertical bar is interpreted as a special character in YAML, so adding a backslash `\|` resolves the issue.

Relevant link: https://github.com/twpayne/chezmoi/pull/4096

I couldn't find any configuration in the [[MkDocs documentation](https://www.mkdocs.org/user-guide/configuration/)](https://www.mkdocs.org/user-guide/configuration/) to resolve this bug, and I'm unsure of an alternative fix.

I tried using `""` and `>` in the YAML syntax, but neither worked. Only escaping the character with `\` solved the issue.

<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer-guide/contributing-changes/

-->
