### PR TITLE
chore: Run single Ubuntu build if there are no code changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -284,9 +284,11 @@ jobs:
       contents: read
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      if: github.event_name == 'push' || needs.changes.outputs.code == 'true' || (matrix.umask == '022' && matrix.test-index == 0)
       with:
         fetch-depth: 0
     - uses: ./.github/actions/setup-go
+      if: github.event_name == 'push' || needs.changes.outputs.code == 'true' || (matrix.umask == '022' && matrix.test-index == 0)
       with:
         go-version: ${{ env.GO_VERSION }}
     - name: install-age
@@ -297,15 +299,18 @@ jobs:
         sudo install -m 755 age/age /usr/local/bin
         sudo install -m 755 age/age-keygen /usr/local/bin
     - name: install-rage
+      if: github.event_name == 'push' || needs.changes.outputs.code == 'true'
       run: |
         cd "$(mktemp -d)"
         curl -fsSL "https://github.com/str4d/rage/releases/download/v${RAGE_VERSION}/rage-v${RAGE_VERSION}-x86_64-linux.tar.gz" | tar xzf -
         sudo install -m 755 rage/rage /usr/local/bin
         sudo install -m 755 rage/rage-keygen /usr/local/bin
     - name: build
+      if: github.event_name == 'push' || needs.changes.outputs.code == 'true' || (matrix.umask == '022' && matrix.test-index == 0)
       run: |
         go build -v ./...
     - name: run
+      if: github.event_name == 'push' || needs.changes.outputs.code == 'true' || (matrix.umask == '022' && matrix.test-index == 0)
       run: |
         go run . --version
     - name: test-umask-${{ matrix.umask }}


### PR DESCRIPTION
<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer-guide/contributing-changes/

-->

In #4128 we noticed that `test-ubuntu` is running 4 times in different configurations. But because testing is omitted there, all jobs are essentially running the same build. There is no need to do it more than once.

Unfortunately, `matrix` variable is not available on job level (https://github.com/actions/runner/issues/1985), so I added it to every step to make other 3 jobs empty.