### PR TITLE
fix: Replace Expand-Archive with System.IO.Compression.ZipFile

### DIFF
--- a/assets/scripts/install.ps1
+++ b/assets/scripts/install.ps1
@@ -191,7 +191,8 @@ function Expand-ChezmoiArchive ($path) {
         & tar --extract --gzip --file $path --directory $parent
     }
     if ($path.EndsWith('.zip')) {
-        Expand-Archive -Path $path -DestinationPath $parent
+        Add-Type -AssemblyName System.IO.Compression.FileSystem
+        [System.IO.Compression.ZipFile]::ExtractToDirectory($path, $parent)
     }
 }
 


### PR DESCRIPTION
<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer-guide/contributing-changes/

-->

`Expand-Archive` may work incorrectly if default locale is not `en-US`. There is the fix (https://github.com/PowerShell/Microsoft.PowerShell.Archive/pull/46) but it's not available by default, e.g. my Windows 11 only has `Microsoft.PowerShell.Archive` version `1.0.1.0`. And bug was fixed in `1.2.1.0`.

I remember there was another issue if [Pscx](https://github.com/Pscx/Pscx) is installed, it can mask default version of `Expand-Archive` with its own which has different arguments.

Using dotnet function should be safer.