### PR TITLE
chore: update top-level password manager docs

### DIFF
--- a/assets/chezmoi.io/docs/user-guide/password-managers/index.md
+++ b/assets/chezmoi.io/docs/user-guide/password-managers/index.md
@@ -23,8 +23,3 @@ In this example, the `OPENAI_API_KEY` is retrieved from a 1Password vault
 named `Personal`, specifically from an item called `openai-api-key` in the
 `password` field. When Chezmoi applies this template, it will automatically
 fetch the current value from 1Password and insert it into the generated file.
-
-This approach allows you to version control your dotfiles while keeping
-sensitive information secure in your password manager. When you update a
-secret in your password manager, the next `chezmoi apply` will automatically use
-the updated value.

--- a/assets/chezmoi.io/docs/user-guide/password-managers/index.md
+++ b/assets/chezmoi.io/docs/user-guide/password-managers/index.md
@@ -1,9 +1,9 @@
 # Password Manager Integration in Chezmoi
 
-Integrating a password manager with Chezmoi enables you to maintain a public
-dotfiles repository while keeping your secrets secure. This integration allows
-you to synchronize sensitive information across multiple machines through your
-password manager while managing your dotfiles with Chezmoi.
+Using a password manager with Chezmoi enables you to maintain a public dotfiles
+repository while keeping your secrets secure. Chezmoi provides template functions
+for many popular password managers so that your templates can render sensitive
+information across multiple machines.
 
 ## Understanding Templates
 

--- a/assets/chezmoi.io/docs/user-guide/password-managers/index.md
+++ b/assets/chezmoi.io/docs/user-guide/password-managers/index.md
@@ -1,6 +1,92 @@
-# Password manager integration
+# Password Manager Integration in Chezmoi
 
-Template functions allow you to retrieve secrets from many popular password
-managers. Using a password manager allows you to keep all your secrets in one
-place, make your dotfiles repo public, and synchronize changes to secrets
-across multiple machines.
+Integrating a password manager with Chezmoi enables you to maintain a public
+dotfiles repository while keeping your secrets secure. This integration allows
+you to synchronize sensitive information across multiple machines through your
+password manager while managing your dotfiles with Chezmoi.
+
+## Understanding Templates
+
+Templates are a core concept in Chezmoi that allow files to contain dynamic
+content, including secrets from password managers. Instead of storing
+sensitive information directly in your dotfiles, templates can reference
+secrets stored safely in your password manager.
+
+**Important:** For a dotfile to retrieve information from a password manager
+during the `chezmoi apply` command, it must be configured as a template.
+
+
+## Working with Template Files
+
+There are two ways to create template files in Chezmoi:
+
+1. Creating a new template file:
+
+       chezmoi add --template <filename>
+
+2. Converting an existing file to a template using the `chattr` (change
+   attribute) command:
+
+       chezmoi chattr +template <filename>
+
+All template files must have the `.tmpl` extension for Chezmoi to process them during chezmoi apply.
+
+
+## Password Manager Functions
+
+Chezmoi supports multiple password managers through built-in functions. These
+functions are wrapped in double curly braces `{{ }}` to indicate that Chezmoi
+should evaluate them dynamically during chezmoi apply.
+
+Common password manager examples:
+
+* 1Password:
+
+      {{ onepasswordRead "op://vault/item/field" }}
+
+* Bitwarden:
+
+      {{ (bitwarden "item_id").login.password }}
+
+## Example: Template with Password Manager Integration
+
+Here's a practical example of a `.zshrc.tmpl` file that retrieves an OpenAI API
+key from 1Password while maintaining other standard shell configurations:
+
+```
+# OpenAI API Key retrieved from 1Password
+export OPENAI_API_KEY='{{ onepasswordRead "op://Personal/openai-api-key/password" }}'
+
+# Common aliases
+alias ll='ls -la'
+alias c='clear'
+alias ..='cd ..'
+
+# Git aliases
+alias gs='git status'
+alias ga='git add'
+alias gc='git commit'
+alias gp='git push'
+
+# Path exports
+export PATH=$HOME/bin:/usr/local/bin:$PATH
+
+# Auto-completion settings
+autoload -Uz compinit
+compinit
+
+# Custom functions
+function mkcd() {
+    mkdir -p "$1" && cd "$1"
+}
+```
+
+In this example, the `OPENAI_API_KEY` is retrieved from a 1Password vault
+named `Personal`, specifically from an item called `openai-api-key` in the
+`password` field. When Chezmoi applies this template, it will automatically
+fetch the current value from 1Password and insert it into the generated file.
+
+This approach allows you to version control your dotfiles while keeping
+sensitive information secure in your password manager. When you update a
+secret in your password manager, the next `chezmoi apply` will automatically use
+the updated value.

--- a/assets/chezmoi.io/docs/user-guide/password-managers/index.md
+++ b/assets/chezmoi.io/docs/user-guide/password-managers/index.md
@@ -9,32 +9,14 @@ information across multiple machines.
 Here's a practical example of a `.zshrc.tmpl` file that retrieves an OpenAI API
 key from 1Password while maintaining other standard shell configurations:
 
-```
+```zsh
+# set up $PATH
+# …
+
 # OpenAI API Key retrieved from 1Password
 export OPENAI_API_KEY='{{ onepasswordRead "op://Personal/openai-api-key/password" }}'
 
-# Common aliases
-alias ll='ls -la'
-alias c='clear'
-alias ..='cd ..'
-
-# Git aliases
-alias gs='git status'
-alias ga='git add'
-alias gc='git commit'
-alias gp='git push'
-
-# Path exports
-export PATH=$HOME/bin:/usr/local/bin:$PATH
-
-# Auto-completion settings
-autoload -Uz compinit
-compinit
-
-# Custom functions
-function mkcd() {
-    mkdir -p "$1" && cd "$1"
-}
+# set up aliases and useful functions
 ```
 
 In this example, the `OPENAI_API_KEY` is retrieved from a 1Password vault

--- a/assets/chezmoi.io/docs/user-guide/password-managers/index.md
+++ b/assets/chezmoi.io/docs/user-guide/password-managers/index.md
@@ -22,5 +22,9 @@ export OPENAI_API_KEY='{{ onepasswordRead "op://Personal/openai-api-key/password
 
 In this example, the `OPENAI_API_KEY` is retrieved from a 1Password vault
 named `Personal`, specifically from an item called `openai-api-key` in the
-`password` field. When Chezmoi applies this template, it will automatically
-fetch the current value from 1Password and insert it into the generated file.
+`password` field.
+
+!!! info
+
+    When Chezmoi applies this template, it will automatically fetch the
+    current value from 1Password and insert it into the generated file.

--- a/assets/chezmoi.io/docs/user-guide/password-managers/index.md
+++ b/assets/chezmoi.io/docs/user-guide/password-managers/index.md
@@ -1,9 +1,22 @@
-# Password Manager Integration in Chezmoi
+# Password Manager Integration
 
-Using a password manager with Chezmoi enables you to maintain a public dotfiles
-repository while keeping your secrets secure. Chezmoi provides template functions
-for many popular password managers so that your templates can render sensitive
-information across multiple machines.
+This guide explains how to securely manage sensitive information in your
+dotfiles using Chezmoi's password manager integration. This allows you to
+maintain a public dotfiles repository while keeping your secrets protected.
+
+## Key Requirements
+* Source files must be saved as templates with the `.tmpl` extension
+* A supported password manager must be installed and configured
+
+## How It Works
+  1.	Create a source `.tmpl` file containing one or more _template commands_ to fetch secrets
+  2.	When you run `chezmoi apply`:
+        * Chezmoi reads your templates
+        * Fetches secrets from your password manager using the specified template functions
+        * Renders the destination files with the secrets inserted as plain text
+
+For more information about how to create template files or convert existing
+files to templates, see the applicable [templating](/assets/chezmoi.io/docs/user-guide/templating.md) documentation.
 
 ## Example: Template with Password Manager Integration
 
@@ -20,11 +33,6 @@ export OPENAI_API_KEY='{{ onepasswordRead "op://Personal/openai-api-key/password
 # set up aliases and useful functions
 ```
 
-In this example, the `OPENAI_API_KEY` is retrieved from a 1Password vault
-named `Personal`, specifically from an item called `openai-api-key` in the
-`password` field.
-
-!!! info
-
-    When Chezmoi applies this template, it will automatically fetch the
-    current value from 1Password and insert it into the generated file.
+In this example, the `OPENAI_API_KEY` environment variable is set by
+retrieving a value from a 1Password vault named `Personal`, specifically from
+an item called `openai-api-key` in the `password` field.

--- a/assets/chezmoi.io/docs/user-guide/password-managers/index.md
+++ b/assets/chezmoi.io/docs/user-guide/password-managers/index.md
@@ -4,50 +4,6 @@ Using a password manager with Chezmoi enables you to maintain a public dotfiles
 repository while keeping your secrets secure. Chezmoi provides template functions
 for many popular password managers so that your templates can render sensitive
 information across multiple machines.
-
-## Understanding Templates
-
-Templates are a core concept in Chezmoi that allow files to contain dynamic
-content, including secrets from password managers. Instead of storing
-sensitive information directly in your dotfiles, templates can reference
-secrets stored safely in your password manager.
-
-**Important:** For a dotfile to retrieve information from a password manager
-during the `chezmoi apply` command, it must be configured as a template.
-
-
-## Working with Template Files
-
-There are two ways to create template files in Chezmoi:
-
-1. Creating a new template file:
-
-       chezmoi add --template <filename>
-
-2. Converting an existing file to a template using the `chattr` (change
-   attribute) command:
-
-       chezmoi chattr +template <filename>
-
-All template files must have the `.tmpl` extension for Chezmoi to process them during chezmoi apply.
-
-
-## Password Manager Functions
-
-Chezmoi supports multiple password managers through built-in functions. These
-functions are wrapped in double curly braces `{{ }}` to indicate that Chezmoi
-should evaluate them dynamically during chezmoi apply.
-
-Common password manager examples:
-
-* 1Password:
-
-      {{ onepasswordRead "op://vault/item/field" }}
-
-* Bitwarden:
-
-      {{ (bitwarden "item_id").login.password }}
-
 ## Example: Template with Password Manager Integration
 
 Here's a practical example of a `.zshrc.tmpl` file that retrieves an OpenAI API

--- a/assets/chezmoi.io/docs/user-guide/password-managers/index.md
+++ b/assets/chezmoi.io/docs/user-guide/password-managers/index.md
@@ -4,6 +4,7 @@ Using a password manager with Chezmoi enables you to maintain a public dotfiles
 repository while keeping your secrets secure. Chezmoi provides template functions
 for many popular password managers so that your templates can render sensitive
 information across multiple machines.
+
 ## Example: Template with Password Manager Integration
 
 Here's a practical example of a `.zshrc.tmpl` file that retrieves an OpenAI API


### PR DESCRIPTION
It was very difficult for me to wade through the documentation to find out how to use a password manager with Chezmoi. The key piece that I wasn't able to easily figure out is that the source file needed to be a template for the `chezmoi apply` command to interpolate the template string `{{ cmd }}`.

Hopefully this top-level documentation will help others that are in a similar position.