### PR TITLE
docs: add example of passing in account param

### DIFF
--- a/assets/chezmoi.io/docs/reference/templates/1password-functions/onepasswordRead.md
+++ b/assets/chezmoi.io/docs/reference/templates/1password-functions/onepasswordRead.md
@@ -22,6 +22,12 @@ interactively prompted to sign in.
     $ op read --no-newline op://vault/item/field
     ```
 
+    Specify an account by passing in a string argument after the `url`
+
+    ```console
+    {{ onepasswordRead "op://vault/item/field" "account_name" }}
+    ```
+
 !!! warning
 
     When using [1Password secrets


### PR DESCRIPTION
I had to read the source to figure out how to pass in the `account` param.