### PR TITLE
fix: apply lint rules for missing keepassxc attributes

### DIFF
--- a/internal/cmd/keepassxctemplatefuncs.go
+++ b/internal/cmd/keepassxctemplatefuncs.go
@@ -83,8 +83,6 @@ func (c *Config) keepassxcAttachmentTemplateFunc(entry, name string) string {
 		if data, ok := c.Keepassxc.cache[entry]; ok {
 			if att, ok := data[name]; ok {
 				return att
-			} else {
-				panic(fmt.Sprintf("attachment %s of entry %s not found", name, entry))
 			}
 		}
 		panic(fmt.Sprintf("attachment %s of entry %s not found", name, entry))


### PR DESCRIPTION
This fixes fixes the failing lint checks introduced by #4149
