### PR TITLE
chore: Build flatpak package

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -269,6 +269,15 @@ jobs:
       with:
         name: chezmoi-windows-amd64
         path: dist/chezmoi-nocgo_windows_amd64_v1/chezmoi.exe
+    - name: create-flatpak
+      if: github.event_name == 'push' || needs.changes.outputs.code == 'true'
+      run: |
+        sudo apt-get --no-install-suggests --no-install-recommends --quiet --yes install flatpak flatpak-builder
+        flatpak --version
+        flatpak-builder --version
+        flatpak remote-add --if-not-exists --user flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+        flatpak-builder --force-clean --user --install-deps-from=flathub --repo=repo --install builddir io.chezmoi.chezmoi.yml
+        flatpak run io.chezmoi.chezmoi --version
   test-ubuntu:
     name: test-ubuntu-umask${{ matrix.umask }}-${{ matrix.test-index }}
     strategy:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.flatpak-builder
 /.vagrant
 /COMMIT
 /bin/actionlint
@@ -9,9 +10,11 @@
 /bin/golangci-lint
 /bin/goreleaser
 /bin/goversioninfo
+/builddir
 /chezmoi
 /chezmoi.exe
 /coverage.out
 /dist
+/repo
 /resource_windows_*.syso
 /versioninfo.json

--- a/io.chezmoi.chezmoi.yml
+++ b/io.chezmoi.chezmoi.yml
@@ -1,0 +1,18 @@
+id: io.chezmoi.chezmoi
+runtime: org.freedesktop.Platform
+runtime-version: '23.08'
+sdk: org.freedesktop.Sdk
+command: chezmoi
+modules:
+- name: chezmoi
+  buildsystem: simple
+  build-commands:
+  - install -Dm755 chezmoi /app/bin/chezmoi
+  sources:
+  - type: file
+    path: dist/chezmoi-cgo-glibc_linux_amd64_v1/chezmoi
+finish-args:
+- --share=network
+- --filesystem=host
+- --filesystem=host-etc
+- --filesystem=host-os


### PR DESCRIPTION
Refs #1800.

This PR attempts to build a Flatpak package of chezmoi.

As far as I can tell, Flatpak in its current form is incompatible with chezmoi:

* Flatpak's sandbox is too restrictive. Even with full filesystem access, chezmoi cannot execute other processes, which breaks password manager integration, encryption, and several template functions.
* Flatpak mangles XDG directory specification directories like `$XDG_DATA_HOME`, making Flatpak-installed chezmoi incompatible with conventionally-installed chezmoi.

There are likely other problems.

This is a draft PR for discussion.