### PR TITLE
chore: Fix potential clean-up issue in test

### DIFF
--- a/internal/chezmoi/persistentstate_test.go
+++ b/internal/chezmoi/persistentstate_test.go
@@ -18,6 +18,7 @@ func testPersistentState(t *testing.T, constructor func() PersistentState) {
 	)
 
 	s1 := constructor()
+	defer s1.Close()
 
 	assert.NoError(t, s1.Delete(bucket1, value))
 
@@ -42,6 +43,8 @@ func testPersistentState(t *testing.T, constructor func() PersistentState) {
 	}))
 
 	s2 := constructor()
+	defer s2.Close()
+
 	assert.NoError(t, s1.CopyTo(s2))
 	actualValue, err = s2.Get(bucket1, key)
 	assert.NoError(t, err)


### PR DESCRIPTION
On Windows, the temporary directory cannot be removed until the files in it are closed.

