### PR TITLE
fix: Correct nested groups for keepassxc builtin mode

### DIFF
--- a/internal/cmd/keepassxctemplatefuncs.go
+++ b/internal/cmd/keepassxctemplatefuncs.go
@@ -425,6 +425,9 @@ func keepassxcBuiltinBuildCache(
 				entry,
 				mapper,
 			)
+			if len(mapData) > 0 {
+				return mapData
+			}
 		}
 	}
 	return map[string]string{}


### PR DESCRIPTION
This PR fixes nested groups for keepassxc when run in builtin mode and adds additional tests to assure the functionality.
