### PR TITLE
docs: Update docs for using delta

### DIFF
--- a/assets/chezmoi.io/docs/user-guide/tools/diff.md
+++ b/assets/chezmoi.io/docs/user-guide/tools/diff.md
@@ -47,13 +47,12 @@ following to your config:
 ## Use delta as the diff tool
 
 To use [delta](https://dandavison.github.io/delta/) as the diff tool you must
-set both `diff.command` and `diff.pager` to delta, for example:
+set `diff.pager` to delta, for example:
 
 === "TOML"
 
     ```toml title="~/.config/chezmoi/chezmoi.toml"
     [diff]
-    command = "delta"
     pager = "delta"
     ```
 
@@ -61,7 +60,6 @@ set both `diff.command` and `diff.pager` to delta, for example:
 
     ```yaml title="~/.config/chezmoi/chezmoi.yaml"
     diff:
-      command: "delta"
       pager: "delta"
     ```
 


### PR DESCRIPTION
<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer-guide/contributing-changes/

-->

Delta documentation suggests to set it only as pager for Git, not as diff command. For chezmoi we need the same to have paging work correctly. Pager should be configured for delta separately, either as command line flag, `.gitconfig` or `BAT_PAGER` env var.

Closes #4205 