### PR TITLE
feat: Show original URL in HTTP progress bars

### DIFF
--- a/internal/chezmoi/sourcestate.go
+++ b/internal/chezmoi/sourcestate.go
@@ -917,7 +917,7 @@ TARGET:
 
 // ReadOptions are options to SourceState.Read.
 type ReadOptions struct {
-	ReadHTTPResponse func(*http.Response) ([]byte, error)
+	ReadHTTPResponse func(string, *http.Response) ([]byte, error)
 	RefreshExternals RefreshExternals
 	TimeNow          func() time.Time
 }
@@ -1634,7 +1634,7 @@ func (s *SourceState) getExternalDataRaw(
 	if options == nil || options.ReadHTTPResponse == nil {
 		data, err = io.ReadAll(resp.Body)
 	} else {
-		data, err = options.ReadHTTPResponse(resp)
+		data, err = options.ReadHTTPResponse(urlStr, resp)
 	}
 	resp.Body.Close()
 	if err != nil {

--- a/internal/cmd/readhttpresponse.go
+++ b/internal/cmd/readhttpresponse.go
@@ -107,7 +107,7 @@ func (m httpSpinnerModel) View() string {
 	return "[" + m.spinner.View() + "] " + m.url
 }
 
-func (c *Config) readHTTPResponse(resp *http.Response) ([]byte, error) {
+func (c *Config) readHTTPResponse(url string, resp *http.Response) ([]byte, error) {
 	switch {
 	case c.noTTY || !c.Progress.Value(c.progressAutoFunc):
 		return io.ReadAll(resp.Body)
@@ -123,7 +123,7 @@ func (c *Config) readHTTPResponse(resp *http.Response) ([]byte, error) {
 		httpProgress.ShowPercentage = false
 
 		model := httpProgressModel{
-			url:           resp.Request.URL.String(),
+			url:           url,
 			contentLength: int(resp.ContentLength),
 			progress:      httpProgress,
 		}


### PR DESCRIPTION
Before this change the HTTP progress bars showed the final request URL after redirects, which makes no sense for the user.

After this change, the HTTP progress bars show the original URL, before redirects, which makes much more sense to the user.