### PR TITLE
docs: add link to auto-commit docs to quick-start.md

### DIFF
--- a/assets/chezmoi.io/docs/quick-start.md
+++ b/assets/chezmoi.io/docs/quick-start.md
@@ -81,7 +81,7 @@ git push -u origin main
 
 !!! hint
 
-    chezmoi can be configured to automatically add, commit, and push changes to
+    chezmoi can be configured to automatically [add, commit, and push](./user-guide/daily-operations.md#automatically-commit-and-push-changes-to-your-repo) changes to
     your repo.
 
 chezmoi can also be used with [GitLab](https://gitlab.com), or


### PR DESCRIPTION
Stumbled upon this in the [quick start guide](https://www.chezmoi.io/quick-start)

> chezmoi can be configured to automatically add, commit, and push changes to your repo.

tho it took me a while to find the actual docs on how to configure that also tried clicking, so I figured why not include a link

<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer-guide/contributing-changes/

-->
