### PR TITLE
chore: Upgrade Mermaid version

### DIFF
--- a/assets/chezmoi.io/docs/extra/refresh_on_toggle_dark_light.js
+++ b/assets/chezmoi.io/docs/extra/refresh_on_toggle_dark_light.js
@@ -1,10 +1,14 @@
-var paletteSwitcher1 = document.getElementById("__palette_1");
-var paletteSwitcher2 = document.getElementById("__palette_2");
+// The light palette is always the first palette. In some cases, it is numbered
+// as __palette_0 and in others it is numbered as __palette_1. The dark palette
+// is numbered as __palette_1 or __palette_2, depending on the index used for
+// the light palette.
+var paletteSwitcherLight = document.getElementById("__palette_0");
+var paletteSwitcherDark = document.getElementById("__palette_1");
 
-paletteSwitcher1.addEventListener("change", function () {
-  location.reload();
-});
+if (!paletteSwitcherLight) {
+  paletteSwitcherLight = paletteSwitcherDark;
+  paletteSwitcherDark = document.getElementById("__palette_2");
+}
 
-paletteSwitcher2.addEventListener("change", function () {
-  location.reload();
-});
+paletteSwitcherLight.addEventListener("change", () => location.reload());
+paletteSwitcherDark.addEventListener("change", () => location.reload());

--- a/assets/chezmoi.io/mkdocs.yml
+++ b/assets/chezmoi.io/mkdocs.yml
@@ -380,8 +380,9 @@ hooks:
 
 plugins:
 - mermaid2:
+    version: 11.4.1
     arguments:
-        # test if its __palette_1 (dark) or __palette_2 (light)
+        # test if its __palette_0/1 (dark) or __palette_1/2 (light)
       theme: |
         ^(JSON.parse(__md_get("__palette").index == 1)) ? 'dark' : 'light'
 - search

--- a/uv.lock
+++ b/uv.lock
@@ -187,13 +187,16 @@ wheels = [
 
 [[package]]
 name = "jsbeautifier"
-version = "1.15.1"
+version = "1.15.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "editorconfig" },
     { name = "six" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/69/3e/dd37e1a7223247e3ef94714abf572415b89c4e121c4af48e9e4c392e2ca0/jsbeautifier-1.15.1.tar.gz", hash = "sha256:ebd733b560704c602d744eafc839db60a1ee9326e30a2a80c4adb8718adc1b24", size = 75606 }
+sdist = { url = "https://files.pythonhosted.org/packages/cf/74/a37cc6fe8ab3f217657d345dfba0612758807536dca5ca5d2f6a81e3623d/jsbeautifier-1.15.3.tar.gz", hash = "sha256:5f1baf3d4ca6a615bb5417ee861b34b77609eeb12875555f8bbfabd9bf2f3457", size = 75261 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/09/cabdf2ed67ba8281ed2025e322c2fc9502a135f756c0a3a3eb60c12eb4fa/jsbeautifier-1.15.3-py3-none-any.whl", hash = "sha256:b207a15ab7529eee4a35ae7790e9ec4e32a2b5026d51e2d0386c3a65e6ecfc91", size = 94706 },
+]
 
 [[package]]
 name = "markdown"


### PR DESCRIPTION
Force `mermaid2` to the latest version (11.4.1).

This resulted in a minor bug on rendering where the palette numbering was apparently changed from 1 (light) and 2 (dark) to 0 (light) and 1 (dark). Updated the `refresh_on_toggle_dark_light.js` script to work with either scenario. `document.getElementById("__palette_0")` will return `null` if using 1 indexing, so we swap the dark palette switcher with the light palette switcher and set the dark palette switcher to `__palette_2`.