### PR TITLE
docs: Extend special files and directories docs

### DIFF
--- a/assets/chezmoi.io/docs/quick-start.md
+++ b/assets/chezmoi.io/docs/quick-start.md
@@ -80,8 +80,8 @@ git push -u origin main
 
 !!! hint
 
-    chezmoi can be configured to automatically add, commit, and push changes to
-    your repo.
+    chezmoi can be configured to automatically [add, commit, and push][autogit]
+    changes to your repo.
 
 chezmoi can also be used with [GitLab][gitlab], or [BitBucket][bitbucket],
 [Source Hut][srht], or any other git hosting service.
@@ -238,3 +238,4 @@ from your password manager. Read the [user guide][user-guide] to explore and see
 [repos]: /links/dotfile-repos.md
 [srht]: https://sr.ht/
 [user-guide]: /user-guide/setup.md
+[autogit]: /user-guide/daily-operations.md#automatically-commit-and-push-changes-to-your-repo

--- a/assets/chezmoi.io/docs/reference/commands/add.md
+++ b/assets/chezmoi.io/docs/reference/commands/add.md
@@ -102,5 +102,37 @@ chezmoi add ~/.oh-my-zsh --exact --recursive
     implicitly created by an [external][external]. See [issue #1574][issue-1574]
     for details.
 
+!!! warning
+
+    `chezmoi add --exact --recursive DIR` works in predictable but surprising
+    ways and its use is not recommended for nested directories without taking
+    precautions.
+
+    If you have not previously added any files from `~/.config` to chezmoi and
+    run `chezmoi add --exact --recursive ~/.config/nvim`, chezmoi wlll consider
+    all files under `~/.config` to be managed, and any file *not* in
+    `~/.config/nvim` will be removed on your next `chezmoi apply`. This is
+    because `~/.config/nvim` is added as:
+
+    ```text
+    exact_dot_config/
+        exact_nvim/
+          exact_lua/
+            …
+          …
+    ```
+
+    To prevent this, add a `.keep` file *first* before adding the subdirectory
+    recursively.
+
+    ```sh
+    touch ~/.config/.keep
+    chezmoi add ~/.config/.keep
+    chezmoi add --recursive --exact ~/.config/nvim
+    ```
+
+    See [issure #4223][issue-4223] for details.
+
 [external]: /reference/special-files/chezmoiexternal-format.md
 [issue-1574]: https://github.com/twpayne/chezmoi/issues/1574
+[issue-4223]: https://github.com/twpayne/chezmoi/issues/4223

--- a/assets/chezmoi.io/docs/reference/special-directories/chezmoidata.md
+++ b/assets/chezmoi.io/docs/reference/special-directories/chezmoidata.md
@@ -1,9 +1,8 @@
-# `.chezmoidata`
+# `.chezmoidata/`
 
-If `.chezmoidata` directories exist in the source state, all files within them
-are interpreted as structured static data in the given formats. This data can
-then be used in templates. See also
-[`.chezmoidata.$FORMAT`][chezmoidata-format].
+If any `.chezmoidata/` directories exist in the source state, all files within
+them are interpreted as structured static data in the given formats. This data
+can then be used in templates. See also [`.chezmoidata.$FORMAT`][data-format].
 
 --8<-- "config-format.md"
 
@@ -66,7 +65,7 @@ then be used in templates. See also
     [`output`][output], [`fromJson`][fromjson], [`fromJson`][fromjson], or
     similar functions.
 
-[chezmoidata-format]: /reference/special-files/chezmoidata-format.md
+[data-format]: /reference/special-files/chezmoidata-format.md
 [config]: /reference/special-files/chezmoidata-format.md
 [fromjson]: /reference/templates/functions/fromJson.md
 [fromyaml]: /reference/templates/functions/fromYaml.md

--- a/assets/chezmoi.io/docs/reference/special-directories/chezmoiexternals.md
+++ b/assets/chezmoi.io/docs/reference/special-directories/chezmoiexternals.md
@@ -1,6 +1,14 @@
-# `.chezmoiexternals`
+# `.chezmoiexternals/`
 
-If a directory called `.chezmoiexternals` exists, then all files in this
-directory are treated as [`.chezmoiexternal.<format>`][external] files.
+If any `.chezmoiexternals/` directories exist in the source state, then all
+files in this directory are treated as [`.chezmoiexternal.<format>`][external]
+files relative to the source directory.
+
+!!! warning
+
+    `.chezmoiexternals/` directories do not support externals for subdirectories
+    within the `.chezmoiexternals/` directories. See [#4274][issue-4274] for
+    details.
 
 [external]: /reference/special-files/chezmoiexternal-format.md
+[issue-4274]: https://github.com/twpayne/chezmoi/issues/4274

--- a/assets/chezmoi.io/docs/reference/special-directories/chezmoiscripts.md
+++ b/assets/chezmoi.io/docs/reference/special-directories/chezmoiscripts.md
@@ -1,5 +1,6 @@
-# `.chezmoiscripts`
+# `.chezmoiscripts/`
 
-If a directory called `.chezmoiscripts` exists in the root of the source
-directory then any scripts in it are executed as normal scripts without
-creating a corresponding directory in the target state.
+If a directory called `.chezmoiscripts/` exists in the root of the source
+directory, then any scripts in it are executed as normal scripts without
+creating a corresponding directory in the target state. The `script_` attribute
+is not required.

--- a/assets/chezmoi.io/docs/reference/special-directories/chezmoitemplates.md
+++ b/assets/chezmoi.io/docs/reference/special-directories/chezmoitemplates.md
@@ -1,12 +1,13 @@
-# `.chezmoitemplates`
+# `.chezmoitemplates/`
 
-If a directory called `.chezmoitemplates` exists, then all files in this
-directory are available as templates with a name equal to the relative path
-to the `.chezmoitemplates` directory.
+If any directory called `.chezmoitemplates/` exists in the source state, then
+all files in this directory are available as templates with a name equal to the
+relative path to the `.chezmoitemplates/` directory.
 
-The [`template` action][action] can be used to include these templates in
-another template. The value of `.` must be set explicitly if needed, otherwise
-the template will be executed with `nil` data.
+The [`template` action][action] or [`includeTemplate` function][function] can be
+used to include these templates in another template. The context value (`.`)
+must be set explicitly if needed, otherwise the template will be executed with
+`nil` context data.
 
 !!! example
 
@@ -22,4 +23,8 @@ the template will be executed with `nil` data.
 
     The target state of `.file` will be `bar`.
 
+While `.chezmoitemplates/` directories can reside anywhere in the source state,
+it easiest to manage a single directory in the root of your source directory.
+
 [action]: https://pkg.go.dev/text/template#hdr-Actions
+[function]: /reference/templates/functions/includeTemplate.md

--- a/assets/chezmoi.io/docs/reference/special-directories/index.md
+++ b/assets/chezmoi.io/docs/reference/special-directories/index.md
@@ -1,6 +1,27 @@
 # Special directories
 
 All directories in the source state whose name begins with `.` are ignored by
-default, unless they are one of the special directories listed here.
-`.chezmoidata` and `.chezmoitemplates` are read before all other files so that
-they can be used in templates.
+default, unless they are one of the special directories listed here. All of
+these directories are optional and are evaluated in a specific order described
+in [special files][special-files].
+
+- The files in [`.chezmoidata/`][data-dir] directories are read in lexical order
+  with any [`.chezmoidata.$FORMAT`][data] files in the source state.
+
+- The files in [`.chezmoitemplates/`][templates] are made available for use in
+  source templates.
+
+- The files in [`.chezmoiscripts/`][scripts] are read, templated, and according
+  to their phase attributes (`run_after_`, `run_before_`, etc.) and lexical
+  ordering.
+
+- Files in [`.chezmoiexternals/`][externals-dir] are read in lexical order with
+  any [`.chezmoiexternal.$FORMAT`][external] files.
+
+[data-dir]: /reference/special-directories/chezmoidata.md
+[data]: /reference/special-files/chezmoidata-format.md
+[external]: /reference/special-files/chezmoiexternal-format.md
+[externals-dir]: /reference/special-directories/chezmoiexternals.md
+[scripts]: /reference/special-directories/chezmoiscripts.md
+[templates]: /reference/special-directories/chezmoitemplates.md
+[special-files]: /reference/special-files/index.md

--- a/assets/chezmoi.io/docs/reference/special-files/chezmoi-format-tmpl.md
+++ b/assets/chezmoi.io/docs/reference/special-files/chezmoi-format-tmpl.md
@@ -1,17 +1,41 @@
 # `.chezmoi.$FORMAT.tmpl`
 
-If a file called `.chezmoi.$FORMAT.tmpl` exists then `chezmoi init` will use it
-to create an initial config file. `$FORMAT` must be one of the supported config
-file formats. Templates defined in `.chezmoitemplates` are not available because
-the template is executed before the source state is read.
+If a file called `.chezmoi.$FORMAT.tmpl` exists in the root of the source state
+then [`chezmoi init`][init] will use it to create or update the chezmoi config
+file. `$FORMAT` must be one of the supported config file formats.
+
+This template differs from source state templates because this template is
+executed prior to the reading of the source state.
+
+| Feature                                            | Available? |
+| -------------------------------------------------- | ---------- |
+| data in the [config file][config]                  | ✅         |
+| data in [`.chezmoidata.$FORMAT`][data-files] files | 🚫         |
+| data in [`.chezmoidata/`][data-dirs] directories   | 🚫         |
+| templates in [`.chezmoitemplates`][templates]      | 🚫         |
+| [template functions][functions]                    | ✅         |
+| [init functions][init-functions]                   | ✅         |
 
 !!! example
 
     ``` title="~/.local/share/chezmoi/.chezmoi.yaml.tmpl"
-    {{ $email := promptString "email" -}}
+    {{ $email := promptStringOnce . "email" "What is your email address" -}}
 
     data:
         email: {{ $email | quote }}
     ```
 
 --8<-- "config-format.md"
+
+!!! info
+
+    This file will also be used to update the config file when a command
+    supports the `--init` flag, such as `chezmoi update --init`.
+
+[config]: /reference/configuration-file/index.md
+[data-dirs]: /reference/special-directories/chezmoidata.md
+[data-files]: /reference/special-files/chezmoidata-format.md
+[functions]: /reference/templates/functions/index.md
+[init-functions]: /reference/templates/init-functions/index.md
+[init]: /reference/commands/init.md
+[templates]: /reference/special-directories/chezmoitemplates.md

--- a/assets/chezmoi.io/docs/reference/special-files/chezmoidata-format.md
+++ b/assets/chezmoi.io/docs/reference/special-files/chezmoidata-format.md
@@ -2,7 +2,7 @@
 
 If `.chezmoidata.$FORMAT` files exist in the source state, they are interpreted
 as structured static data in the given format. This data can then be used in
-templates. See also [`.chezmoidata/`][chezmoidata-dir].
+templates. See also [`.chezmoidata/`][data-dir].
 
 !!! example
 
@@ -85,7 +85,7 @@ templates. See also [`.chezmoidata/`][chezmoidata-dir].
     similar functions.
 
 [config]: /reference/special-files/chezmoidata-format.md
+[data-dir]: /reference/special-directories/chezmoidata.md
 [fromjson]: /reference/templates/functions/fromJson.md
 [fromyaml]: /reference/templates/functions/fromYaml.md
 [output]: /reference/templates/functions/output.md
-[chezmoidata-dir]: /reference/special-directories/chezmoidata.md

--- a/assets/chezmoi.io/docs/reference/special-files/chezmoiexternal-format.md
+++ b/assets/chezmoi.io/docs/reference/special-files/chezmoiexternal-format.md
@@ -1,20 +1,22 @@
 # `.chezmoiexternal.$FORMAT{,.tmpl}`
 
 If a file called `.chezmoiexternal.$FORMAT` (with an optional `.tmpl` extension)
-exists anywhere in the source state (either `~/.local/share/chezmoi` or directory
-defined inside `.chezmoiroot`), it is interpreted as a list of external files and
-archives to be included as if they were in the source state.
+exists anywhere in the source state (either `~/.local/share/chezmoi` or
+directory defined inside `.chezmoiroot`), it is interpreted as a list of
+external files and archives to be included as if they were in the source state.
+See also [`.chezmoiexternals/` directories][external-dir].
 
 `$FORMAT` must be one of chezmoi's supported configuration file formats.
 
 --8<-- "config-format.md"
 
-`.chezmoiexternal.$FORMAT` is always interpreted as a template. This allows
-different externals to be included on different machines.
+`.chezmoiexternal.$FORMAT` is interpreted as a template, whether or not it has a
+`.tmpl` extension. This allows different externals to be included on different
+machines.
 
 If a `.chezmoiexternal.$FORMAT` file is located in an ignored directory (one
-listed in [`.chezmoiignore`][ignore]), all entries within the file are
-also ignored.
+listed in [`.chezmoiignore`][ignore]), all entries within the file are also
+ignored.
 
 Entries are indexed by target name relative to the directory of the
 `.chezmoiexternal.$FORMAT` file, and must have a `type` and a `url` and/or a
@@ -91,14 +93,14 @@ extracted.
 
 The optional `include` and `exclude` fields are lists of patterns specify which
 archive members to include or exclude respectively. Patterns match paths in the
-archive, not the target state. chezmoi uses the following algorithm to
-determine whether an archive member is included:
+archive, not the target state. chezmoi uses the following algorithm to determine
+whether an archive member is included:
 
 1. If the archive member name matches any `exclude` pattern, then the archive
    member is excluded. In addition, if the archive member is a directory, then
    all contained files and sub-directories will be excluded, too (recursively).
-2. Otherwise, if the archive member name matches any `include` pattern, then
-   the archive member is included.
+2. Otherwise, if the archive member name matches any `include` pattern, then the
+   archive member is included.
 3. Otherwise, if only `include` patterns were specified then the archive member
    is excluded.
 4. Otherwise, if only `exclude` patterns were specified then the archive member
@@ -115,10 +117,10 @@ archive before comparing them with `path`. The behavior of `format` is the same
 as for `archive`. If `executable` is `true` then chezmoi will set the executable
 bits on the target file, even if they are not set in the archive.
 
-If `type` is `git-repo` then chezmoi will run `git clone $URL $TARGET_NAME`
-with the optional `clone.args` if the target does not exist. If the target
-exists, then chezmoi will run `git pull` with the optional `pull.args` to
-update the target.
+If `type` is `git-repo` then chezmoi will run `git clone $URL $TARGET_NAME` with
+the optional `clone.args` if the target does not exist. If the target exists,
+then chezmoi will run `git pull` with the optional `pull.args` to update the
+target.
 
 For `file` and `archive` externals, chezmoi will cache downloaded URLs. The
 optional duration `refreshPeriod` field specifies how often chezmoi will
@@ -165,7 +167,7 @@ re-download unless forced. To force chezmoi to re-download URLs, pass the
 
     Some more examples can be found in the [user guide][elsewhere].
 
-
 [ignore]: /reference/special-files/chezmoiignore.md
+[external-dir]: /reference/special-directories/chezmoiexternals.md
 [elsewhere]: /user-guide/include-files-from-elsewhere.md
 [appledouble]: https://en.wikipedia.org/wiki/AppleSingle_and_AppleDouble_formats

--- a/assets/chezmoi.io/docs/reference/special-files/chezmoiignore.md
+++ b/assets/chezmoi.io/docs/reference/special-files/chezmoiignore.md
@@ -8,13 +8,16 @@ not the source path.
 Patterns can be excluded by prefixing them with a `!` character. All excludes
 take priority over all includes.
 
-Comments are introduced with the `#` character and run until the end of the
-line.
+Comments in `.chezmoiignore` files are introduced with the `#` character and run
+to the end of the line. If there is a `#` character introduced after the
+beginning of the line, it must be preceded by whitespace to be recognized as
+a comment and not part of the file.
 
 `.chezmoiignore` is interpreted as a template, whether or not it has a `.tmpl`
 extension. This allows different files to be ignored on different machines.
 
-`.chezmoiignore` files in subdirectories apply only to that subdirectory.
+`.chezmoiignore` files in source state subdirectories apply only to that
+subdirectory.
 
 !!! example
 
@@ -25,6 +28,8 @@ extension. This allows different files to be ignored on different machines.
     */*.txt # ignore *.txt in subdirectories of the target directory
             # but not in subdirectories of subdirectories;
             # so a/b/c.txt would *not* be ignored
+
+    */*.org# # Ignore org-mode backup files that end with `#`
 
     backups/   # ignore the backups folder, but not its contents
     backups/** # ignore the contents of backups folder but not the folder itself

--- a/assets/chezmoi.io/docs/reference/special-files/chezmoiversion.md
+++ b/assets/chezmoi.io/docs/reference/special-files/chezmoiversion.md
@@ -1,12 +1,15 @@
 # `.chezmoiversion`
 
-If a file called `.chezmoiversion` exists, then its contents are interpreted as
-a semantic version defining the minimum version of chezmoi required to
-interpret the source state correctly. chezmoi will refuse to interpret the
-source state if the current version is too old.
+If a file called `.chezmoiversion` exists anywhere in the source directory (not
+just the source state), then its contents are interpreted as a semantic version
+defining the minimum version of chezmoi required to interpret the source state
+correctly. chezmoi will refuse to interpret the source state if the current
+version is too old.
+
+This file is evaluated before any operation.
 
 !!! example
 
     ``` title="~/.local/share/chezmoi/.chezmoiversion"
-    1.5.0
+    2.50.0
     ```

--- a/assets/chezmoi.io/docs/reference/special-files/index.md
+++ b/assets/chezmoi.io/docs/reference/special-files/index.md
@@ -1,6 +1,47 @@
 # Special files
 
-All files in the source state whose name begins with `.` are ignored by default,
-unless they are one of the special files listed here. `.chezmoidata.$FORMAT` and
-files in `.chezmoidata` folders are read before all other files so that it can
-be used in templates.
+All files in the source directory whose name begins with `.` are ignored by
+default, unless they are one of the special files listed here. All of these
+files are optional and are evaluated in a specific order.
+
+1. [`.chezmoiroot`][root] is read from the root of the source directory before
+   anything other file, setting the source state path. The location of all other
+   files, except `.chezmoiversion`, is relative to the source state path.
+
+2. [`.chezmoi.$FORMAT.tmpl`][config] is used by [`chezmoi init`][init] to
+   prepare or update the chezmoi config file. This is also used when the command
+   supports the `--init` flag, such as `chezmoi apply --init`. This will be
+   applied _prior_ to any remaining special files or directories.
+
+3. Data files ([`.chezmoidata.$FORMAT`][data] files or files in
+   [`.chezmoidata/` directories][data-dir]) are read before any templates are
+   processed so that data contained within are available to the templates.
+
+4. [`.chezmoitemplates/`][templates-dir] directories are made available for use
+   in source templates.
+
+5. [`.chezmoiignore`][ignore] determines files and directories that should be
+   ignored.
+
+6. [`.chezmoiremove`][remove] determines files that should be removed during an
+   apply.
+
+7. External sources ([`.chezmoiexternal.$FORMAT`][external] or files in
+   [`.chezmoiexternals/`][externals-dir]) are read in lexical order to include
+   external files and archives as if they were in the source state.
+
+8. [`.chezmoiversion`][version] is processed before any operation is applied, to
+   ensure that the running version of chezmoi is new enough.
+
+[config]: /reference/special-files/chezmoi-format-tmpl.md
+[data-dir]: /reference/special-directories/chezmoidata.md
+[data]: /reference/special-files/chezmoidata-format.md
+[external-dir]: /reference/special-directories/chezmoiexternals.md
+[external]: /reference/special-files/chezmoiexternal-format.md
+[externals-dir]: /reference/special-directories/chezmoiexternals.md
+[ignore]: /reference/special-files/chezmoiignore.md
+[init]: /reference/commands/init.md
+[remove]: /reference/special-files/chezmoiremove.md
+[root]: /reference/special-files/chezmoiroot.md
+[templates-dir]: /reference/special-directories/chezmoitemplates.md
+[version]: /reference/special-files/chezmoiversion.md

--- a/assets/chezmoi.io/docs/reference/templates/hcp-vault-secrets-functions/hcpVaultSecret.md
+++ b/assets/chezmoi.io/docs/reference/templates/hcp-vault-secrets-functions/hcpVaultSecret.md
@@ -14,4 +14,10 @@ omitted, then chezmoi will use the value from the
     {{ hcpVaultSecret "username" }}
     ```
 
+!!! info
+
+    If you access HCP Vault Secrets through the `hcp`, this function **will not
+    work**. See [`vlt` vs `hcp`: Upgrades that Break][break].
+
 [secrets]: https://developer.hashicorp.com/hcp/docs/vault-secrets
+[break]: /user-guide/password-managers/hcp-vault-secrets.md#hcp-broken

--- a/assets/chezmoi.io/docs/reference/templates/hcp-vault-secrets-functions/hcpVaultSecretJson.md
+++ b/assets/chezmoi.io/docs/reference/templates/hcp-vault-secrets-functions/hcpVaultSecretJson.md
@@ -14,4 +14,10 @@ omitted, then chezmoi will use the value from the
     {{ (hcpVaultSecretJson "secret_name" "application_name").created_by.email }}
     ```
 
+!!! info
+
+    If you access HCP Vault Secrets through the `hcp`, this function **will not
+    work**. See [`vlt` vs `hcp`: Upgrades that Break][break].
+
 [secrets]: https://developer.hashicorp.com/hcp/docs/vault-secrets
+[break]: /user-guide/password-managers/hcp-vault-secrets.md#hcp-broken

--- a/assets/chezmoi.io/docs/reference/templates/hcp-vault-secrets-functions/index.md
+++ b/assets/chezmoi.io/docs/reference/templates/hcp-vault-secrets-functions/index.md
@@ -1,7 +1,13 @@
 # HCP Vault Secrets
 
-chezmoi includes support for [HCP Vault Secrets][secrets] using the `vlt` CLI
-to expose data through the `hcpVaultSecret` and `hcpVaultSecretJson` template
+chezmoi includes support for [HCP Vault Secrets][secrets] using the `vlt` CLI to
+expose data through the `hcpVaultSecret` and `hcpVaultSecretJson` template
 functions.
 
+!!! info
+
+    If you access HCP Vault Secrets through the `hcp`, these functions **will
+    not work**. See [`vlt` vs `hcp`: Upgrades that Break][break].
+
 [secrets]: https://developer.hashicorp.com/hcp/docs/vault-secrets
+[break]: /user-guide/password-managers/hcp-vault-secrets.md#hcp-broken

--- a/assets/chezmoi.io/docs/user-guide/password-managers/index.md
+++ b/assets/chezmoi.io/docs/user-guide/password-managers/index.md
@@ -1,6 +1,32 @@
-# Password manager integration
+# Password Manager Integration
 
-Template functions allow you to retrieve secrets from many popular password
-managers. Using a password manager allows you to keep all your secrets in one
-place, make your dotfiles repo public, and synchronize changes to secrets
-across multiple machines.
+Using a password manager with chezmoi enables you to maintain a public dotfiles
+repository while keeping your secrets secure. chezmoi extends its [templating
+capabilities][templating] by providing password manager specific *template
+functions* for many popular password managers.
+
+When chezmoi applies a template with a secret referenced from a password
+manager, it will automatically fetch the secret value and insert it into the
+generated destination file.
+
+!!! example
+
+    Here's a practical example of a `.zshrc.tmpl` file that retrieves an
+    CloudFlare API token from 1Password while maintaining other standard shell
+    configurations:
+
+    ```zsh
+    # set up $PATH
+    # …
+
+    # Cloudflare API Token retrieved from 1Password for use with flarectl
+    export CF_API_TOKEN='{{ onepasswordRead "op://Personal/cloudlfare-api-token/password" }}'
+
+    # set up aliases and useful functions
+    ```
+
+    In this example, the `CF_API_TOKEN` is retrieved from a 1Password vault
+    named `Personal`, an item called `cloudflare-api-token`, and the `password`
+    field.
+
+[templating]: /user-guide/templating.md

--- a/assets/chezmoi.io/mkdocs.yml
+++ b/assets/chezmoi.io/mkdocs.yml
@@ -133,10 +133,10 @@ nav:
     - .chezmoiversion: reference/special-files/chezmoiversion.md
   - Special directories:
     - reference/special-directories/index.md
-    - .chezmoidata: reference/special-directories/chezmoidata.md
-    - .chezmoiexternals: reference/special-directories/chezmoiexternals.md
-    - .chezmoiscripts: reference/special-directories/chezmoiscripts.md
-    - .chezmoitemplates: reference/special-directories/chezmoitemplates.md
+    - .chezmoidata/: reference/special-directories/chezmoidata.md
+    - .chezmoiexternals/: reference/special-directories/chezmoiexternals.md
+    - .chezmoiscripts/: reference/special-directories/chezmoiscripts.md
+    - .chezmoitemplates/: reference/special-directories/chezmoitemplates.md
   - Command line flags:
     - reference/command-line-flags/index.md
     - Global: reference/command-line-flags/global.md


### PR DESCRIPTION
There are a few changes here:

- The index files are now _partial_ documentation for the files (blurb only), but more importantly express the processing order.

- All of the special directories now explicitly end with `/` in the documentation to be clear we are always referring to the directory form. I have not updated this in all locations.

- The external and data files and directories now cross-link explicitly.

- Since I expanded the `data` details, I felt it was worth being more explicit about what is permitted in the config file template used with `chezmoi init`. After trying to write a few non-confusing sentences, I gave up and fell back to a table.

- Added an example of a file with a `#` (see #4210) in `.chezmoiignore`.

- Expanded `.chezmoiroot` and `.chezmoiversion` documentation, and used a more modern version for `.chezmoiversion`.