### PR TITLE
feat: Add -0 flag to ignored, managed, and unmanaged commands

### DIFF
--- a/assets/chezmoi.io/docs/reference/commands/ignored.md
+++ b/assets/chezmoi.io/docs/reference/commands/ignored.md
@@ -4,6 +4,10 @@ Print the list of entries ignored by chezmoi.
 
 ## Common flags
 
+### `-0`, `--nul-path-separator`
+
+--8<-- "common-flags/nul-path-separator.md"
+
 ### `-t`, `--tree`
 
 --8<-- "common-flags/tree.md"

--- a/assets/chezmoi.io/docs/reference/commands/managed.md
+++ b/assets/chezmoi.io/docs/reference/commands/managed.md
@@ -18,6 +18,10 @@ the destination directory in alphabetical order.
 
 --8<-- "common-flags/include.md"
 
+### `-0`, `--nul-path-separator`
+
+--8<-- "common-flags/nul-path-separator.md"
+
 ### `-p`, `--path-style` *style*
 
 --8<-- "common-flags/path-style.md:all"

--- a/assets/chezmoi.io/docs/reference/commands/unmanaged.md
+++ b/assets/chezmoi.io/docs/reference/commands/unmanaged.md
@@ -7,6 +7,10 @@ It is an error to supply *path*s that are not found on the file system.
 
 ## Common flags
 
+### `-0`, `--nul-path-separator`
+
+--8<-- "common-flags/nul-path-separator.md"
+
 ### `-p`, `--path-style` *style*
 
 --8<-- "common-flags/path-style.md:no-source-tree"

--- a/assets/chezmoi.io/snippets/common-flags/nul-path-separator.md
+++ b/assets/chezmoi.io/snippets/common-flags/nul-path-separator.md
@@ -1,0 +1,1 @@
+Separate paths with the NUL character instead of a newline.

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -31,7 +31,7 @@ var (
 
 	deDuplicateErrorRx = regexp.MustCompile(`:\s+`)
 	trailingSpaceRx    = regexp.MustCompile(` +\n`)
-	helpFlagsRx        = regexp.MustCompile("^### (?:`-([a-zA-Z])`, )?`--([a-zA-Z-]+)`")
+	helpFlagsRx        = regexp.MustCompile("^### (?:`-([0-9A-Za-z])`, )?`--([-0-9A-Za-z]+)`")
 
 	helps = make(map[string]*help)
 )

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -2848,17 +2848,23 @@ func (c *Config) writeOutput(data []byte) error {
 }
 
 type writePathsOptions struct {
-	tree bool
+	nulPathSeparator bool
+	tree             bool
 }
 
 func (c *Config) writePaths(paths []string, options writePathsOptions) error {
+	pathSeparator := byte('\n')
+	if options.nulPathSeparator {
+		pathSeparator = '\x00'
+	}
 	builder := strings.Builder{}
 	if options.tree {
 		newPathListTreeFromPathsSlice(paths).writeChildren(&builder, "", "  ")
 	} else {
 		slices.Sort(paths)
 		for _, path := range paths {
-			fmt.Fprintln(&builder, path)
+			builder.WriteString(path)
+			builder.WriteByte(pathSeparator)
 		}
 	}
 	return c.writeOutputString(builder.String())

--- a/internal/cmd/ignoredcmd.go
+++ b/internal/cmd/ignoredcmd.go
@@ -7,7 +7,8 @@ import (
 )
 
 type ignoredCmdConfig struct {
-	tree bool
+	nulPathSeparator bool
+	tree             bool
 }
 
 func (c *Config) newIgnoredCmd() *cobra.Command {
@@ -24,12 +25,15 @@ func (c *Config) newIgnoredCmd() *cobra.Command {
 	}
 
 	ignoredCmd.Flags().BoolVarP(&c.ignored.tree, "tree", "t", c.ignored.tree, "Print paths as a tree")
+	ignoredCmd.Flags().
+		BoolVarP(&c.ignored.nulPathSeparator, "nul-path-separator", "0", c.ignored.nulPathSeparator, "Use the NUL character as a path separator")
 
 	return ignoredCmd
 }
 
 func (c *Config) runIgnoredCmd(cmd *cobra.Command, args []string, sourceState *chezmoi.SourceState) error {
 	return c.writePaths(stringersToStrings(sourceState.Ignored()), writePathsOptions{
-		tree: c.ignored.tree,
+		nulPathSeparator: c.ignored.nulPathSeparator,
+		tree:             c.ignored.tree,
 	})
 }

--- a/internal/cmd/managedcmd.go
+++ b/internal/cmd/managedcmd.go
@@ -10,10 +10,11 @@ import (
 )
 
 type managedCmdConfig struct {
-	filter    *chezmoi.EntryTypeFilter
-	format    *choiceFlag
-	pathStyle *choiceFlag
-	tree      bool
+	filter           *chezmoi.EntryTypeFilter
+	format           *choiceFlag
+	nulPathSeparator bool
+	pathStyle        *choiceFlag
+	tree             bool
 }
 
 func (c *Config) newManagedCmd() *cobra.Command {
@@ -33,6 +34,8 @@ func (c *Config) newManagedCmd() *cobra.Command {
 	managedCmd.Flags().VarP(c.managed.filter.Exclude, "exclude", "x", "Exclude entry types")
 	managedCmd.Flags().VarP(c.managed.format, "format", "f", "Format")
 	managedCmd.Flags().VarP(c.managed.filter.Include, "include", "i", "Include entry types")
+	managedCmd.Flags().
+		BoolVarP(&c.managed.nulPathSeparator, "nul-path-separator", "0", c.managed.nulPathSeparator, "Use the NUL character as a path separator")
 	managedCmd.Flags().VarP(c.managed.pathStyle, "path-style", "p", "Path style")
 	must(managedCmd.RegisterFlagCompletionFunc("path-style", c.managed.pathStyle.FlagCompletionFunc()))
 	managedCmd.Flags().BoolVarP(&c.managed.tree, "tree", "t", c.managed.tree, "Print paths as a tree")
@@ -116,7 +119,8 @@ func (c *Config) runManagedCmd(cmd *cobra.Command, args []string, sourceState *c
 			}
 		}
 		return c.writePaths(paths, writePathsOptions{
-			tree: c.managed.tree,
+			nulPathSeparator: c.managed.nulPathSeparator,
+			tree:             c.managed.tree,
 		})
 	case pathStyleAll:
 		allEntryPathsMap := make(map[string]*entryPaths, len(allEntryPaths))

--- a/internal/cmd/managedcmd_test.go
+++ b/internal/cmd/managedcmd_test.go
@@ -28,6 +28,19 @@ func TestManagedCmd(t *testing.T) {
 			),
 		},
 		{
+			name: "nul_path_separator",
+			root: map[string]any{
+				"/home/user/.local/share/chezmoi": map[string]any{
+					"dot_file1": "# contents of .file1\n",
+					"dot_file2": "# contents of .file2\n",
+				},
+			},
+			args: []string{
+				"-0",
+			},
+			expectedOutput: ".file1\x00.file2\x00",
+		},
+		{
 			name: "template",
 			root: map[string]any{
 				"/home/user/.local/share/chezmoi/dot_template.tmpl": templateContents,

--- a/internal/cmd/unmanagedcmd.go
+++ b/internal/cmd/unmanagedcmd.go
@@ -12,8 +12,9 @@ import (
 )
 
 type unmanagedCmdConfig struct {
-	pathStyle *choiceFlag
-	tree      bool
+	nulPathSeparator bool
+	pathStyle        *choiceFlag
+	tree             bool
 }
 
 func (c *Config) newUnmanagedCmd() *cobra.Command {
@@ -29,6 +30,8 @@ func (c *Config) newUnmanagedCmd() *cobra.Command {
 		),
 	}
 
+	unmanagedCmd.Flags().
+		BoolVarP(&c.unmanaged.nulPathSeparator, "nul-path-separator", "0", c.unmanaged.nulPathSeparator, "Use the NUL character as a path separator")
 	unmanagedCmd.Flags().VarP(c.unmanaged.pathStyle, "path-style", "p", "Path style")
 	must(unmanagedCmd.RegisterFlagCompletionFunc("path-style", c.unmanaged.pathStyle.FlagCompletionFunc()))
 	unmanagedCmd.Flags().BoolVarP(&c.unmanaged.tree, "tree", "t", c.unmanaged.tree, "Print paths as a tree")
@@ -112,6 +115,7 @@ func (c *Config) runUnmanagedCmd(cmd *cobra.Command, args []string, sourceState 
 	}
 
 	return c.writePaths(stringersToStrings(paths), writePathsOptions{
-		tree: c.unmanaged.tree,
+		nulPathSeparator: c.unmanaged.nulPathSeparator,
+		tree:             c.unmanaged.tree,
 	})
 }

--- a/internal/cmd/unmanagedcmd_test.go
+++ b/internal/cmd/unmanagedcmd_test.go
@@ -33,6 +33,20 @@ func TestUnmanagedCmd(t *testing.T) {
 			),
 		},
 		{
+			name: "nul_path_separator",
+			root: map[string]any{
+				"/home/user": map[string]any{
+					".file":                         "",
+					".local/share/chezmoi/dot_file": "# contents of .file\n",
+					".unmanaged":                    "",
+				},
+			},
+			args: []string{
+				"-0",
+			},
+			expectedOutput: ".local\x00.unmanaged\x00",
+		},
+		{
 			name: "private_subdir",
 			root: map[string]any{
 				"/home/user": map[string]any{


### PR DESCRIPTION
Refs #4194.

The goal here is to handle filenames with spaces so that a command like

    chezmoi managed -0 | xargs -0 tar czf chezmoi-backup-$(date -Iseconds).tar.gz

would work.

PR in progress. Needs tests. Draft for now.