### PR TITLE
chore: Remove crumbs of Python virtual environment

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -2,7 +2,6 @@ globs:
 - '**/*.md'
 ignores:
 - .github/ISSUE_TEMPLATE/*.md
-- .venv
 - assets/chezmoi.io/docs/reference/release-history.md
 config:
   line-length: false

--- a/assets/.gitignore
+++ b/assets/.gitignore
@@ -1,6 +1,0 @@
-__pycache__
-
-.venv
-.virtualenv
-venv
-virtualenv

--- a/internal/cmds/lint-whitespace/main.go
+++ b/internal/cmds/lint-whitespace/main.go
@@ -19,7 +19,6 @@ var (
 		regexp.MustCompile(`\A\.idea\z`),
 		regexp.MustCompile(`\A\.ruff_cache\z`),
 		regexp.MustCompile(`\A\.vagrant\z`),
-		regexp.MustCompile(`\b\.?venv\b`),
 		regexp.MustCompile(`\A\.vscode\z`),
 		regexp.MustCompile(`\ACOMMIT\z`),
 		regexp.MustCompile(`\Aassets/chezmoi\.io/site\z`),


### PR DESCRIPTION
Since #3955 we use `uv` exclusively. This PR removes the last traces of the Python virtual environments that used to be used.