### PR TITLE
chore: Fix flaky test on macOS GitHub Actions runner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -131,7 +131,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-index: [0, 1, 2, 3]
+        test-index: [0, 1, 2, 3, 4]
     needs: changes
     if: github.event_name == 'push' || needs.changes.outputs.code == 'true'
     runs-on: macos-15
@@ -172,8 +172,10 @@ jobs:
           go test ./internal/cmd -run=TestScript -filter='^[e-hE-H]' -race
         elif [ "${{ matrix.test-index }}" = "2" ]; then
           go test ./internal/cmd -run=TestScript -filter='^[i-lI-L]' -race
+        elif [ "${{ matrix.test-index }}" = "3" ]; then
+          go test ./internal/cmd -run=TestScript -filter='^[m-sM-S]' -race
         else
-          go test ./internal/cmd -run=TestScript -filter='^[m-zM-Z]' -race
+          go test ./internal/cmd -run=TestScript -filter='^[t-zT-Z]' -race
         fi
   test-oldstable-go:
     needs: changes


### PR DESCRIPTION
This should eventually fix #4301. As I can't duplicate the problem locally this will be a bit noisy as I push various commits to find the flaky test.