### PR TITLE
docs: Remove unnecessary `--no-lock` Brew option

### DIFF
--- a/assets/chezmoi.io/docs/user-guide/machines/macos.md
+++ b/assets/chezmoi.io/docs/user-guide/machines/macos.md
@@ -11,7 +11,7 @@ a `run_once_` script. For example, create a file in your source directory called
 {{- if eq .chezmoi.os "darwin" -}}
 #!/bin/bash
 
-brew bundle --no-lock --file=/dev/stdin <<EOF
+brew bundle --file=/dev/stdin <<EOF
 brew "git"
 cask "google-chrome"
 EOF


### PR DESCRIPTION
This option made my chezmoi fail.

See Homebrew/homebrew-bundle#1630

<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer-guide/contributing-changes/

-->
