### PR TITLE
Update doc on declarative package installation

### DIFF
--- a/assets/chezmoi.io/docs/user-guide/advanced/install-packages-declaratively.md
+++ b/assets/chezmoi.io/docs/user-guide/advanced/install-packages-declaratively.md
@@ -27,7 +27,7 @@ the package manager to install those packages, for example:
 {{ if eq .chezmoi.os "darwin" -}}
 #!/bin/bash
 
-brew bundle --no-lock --file=/dev/stdin <<EOF
+brew bundle --file=/dev/stdin <<EOF
 {{ range .packages.darwin.brews -}}
 brew {{ . | quote }}
 {{ end -}}


### PR DESCRIPTION
Hombrew removed the `--no-lock` option in [Commit 98d8ad7 ](https://github.com/Homebrew/homebrew-bundle/commit/98d8ad7ddcca7e7b700cd496207d51fa042c0b00)

<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer-guide/contributing-changes/

-->
