### PR TITLE
chore: Improve info message in install script

### DIFF
--- a/assets/scripts/install-local-bin.sh
+++ b/assets/scripts/install-local-bin.sh
@@ -40,7 +40,7 @@ main() {
 	TAG="$(real_tag "${TAGARG}")"
 	VERSION="${TAG#v}"
 
-	log_info "found version ${VERSION} for ${TAGARG}/${GOOS}/${GOARCH}"
+	log_info "found chezmoi version ${VERSION} for ${TAGARG}/${GOOS}/${GOARCH}"
 
 	BINSUFFIX=
 	FORMAT=tar.gz

--- a/assets/scripts/install.sh
+++ b/assets/scripts/install.sh
@@ -40,7 +40,7 @@ main() {
 	TAG="$(real_tag "${TAGARG}")"
 	VERSION="${TAG#v}"
 
-	log_info "found version ${VERSION} for ${TAGARG}/${GOOS}/${GOARCH}"
+	log_info "found chezmoi version ${VERSION} for ${TAGARG}/${GOOS}/${GOARCH}"
 
 	BINSUFFIX=
 	FORMAT=tar.gz

--- a/internal/cmds/generate-install.sh/install.sh.tmpl
+++ b/internal/cmds/generate-install.sh/install.sh.tmpl
@@ -40,7 +40,7 @@ main() {
 	TAG="$(real_tag "${TAGARG}")"
 	VERSION="${TAG#v}"
 
-	log_info "found version ${VERSION} for ${TAGARG}/${GOOS}/${GOARCH}"
+	log_info "found chezmoi version ${VERSION} for ${TAGARG}/${GOOS}/${GOARCH}"
 
 	BINSUFFIX=
 	FORMAT=tar.gz


### PR DESCRIPTION
As the install script also detects the version of glibc on Linux, this makes it clear when the version refers to chezmoi's version.