### PR TITLE
chore: Pre-render license

### DIFF
--- a/assets/chezmoi.io/docs/docs.go
+++ b/assets/chezmoi.io/docs/docs.go
@@ -6,4 +6,4 @@ import _ "embed"
 // License is the license.
 //
 //go:embed license.md
-var License []byte
+var License string

--- a/internal/cmd/license.gen.go
+++ b/internal/cmd/license.gen.go
@@ -1,0 +1,27 @@
+package cmd
+
+var license = "" +
+	"\n" +
+	"  The MIT License (MIT)\n" +
+	"\n" +
+	"  Copyright (c) 2018-2025 Tom Payne\n" +
+	"\n" +
+	"  Permission is hereby granted, free of charge, to any person obtaining a copy\n" +
+	"  of this software and associated documentation files (the \"Software\"), to\n" +
+	"  deal in the Software without restriction, including without limitation the\n" +
+	"  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or\n" +
+	"  sell copies of the Software, and to permit persons to whom the Software is\n" +
+	"  furnished to do so, subject to the following conditions:\n" +
+	"\n" +
+	"  The above copyright notice and this permission notice shall be included in\n" +
+	"  all copies or substantial portions of the Software.\n" +
+	"\n" +
+	"  THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n" +
+	"  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n" +
+	"  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\n" +
+	"  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\n" +
+	"  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING\n" +
+	"  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS\n" +
+	"  IN THE SOFTWARE.\n" +
+	"\n" +
+	""

--- a/internal/cmd/licensecmd.go
+++ b/internal/cmd/licensecmd.go
@@ -1,13 +1,7 @@
 package cmd
 
 import (
-	"bytes"
-
-	"github.com/charmbracelet/glamour"
-	"github.com/charmbracelet/glamour/styles"
 	"github.com/spf13/cobra"
-
-	"github.com/twpayne/chezmoi/v2/assets/chezmoi.io/docs"
 )
 
 func (c *Config) newLicenseCmd() *cobra.Command {
@@ -28,19 +22,5 @@ func (c *Config) newLicenseCmd() *cobra.Command {
 }
 
 func (c *Config) runLicenseCmd(cmd *cobra.Command, args []string) error {
-	renderer, err := glamour.NewTermRenderer(
-		glamour.WithStyles(styles.ASCIIStyleConfig),
-		glamour.WithWordWrap(80),
-	)
-	if err != nil {
-		return err
-	}
-
-	licenseMarkdown := bytes.TrimPrefix(docs.License, []byte("# License\n\n"))
-	license, err := renderer.RenderBytes(licenseMarkdown)
-	if err != nil {
-		return err
-	}
-
-	return c.writeOutput(license)
+	return c.writeOutputString(license)
 }

--- a/internal/cmds/generate-license/license.go.tmpl
+++ b/internal/cmds/generate-license/license.go.tmpl
@@ -1,0 +1,4 @@
+package cmd
+
+var license = "" +
+    {{ . | splitAndQuoteLines }}

--- a/internal/cmds/generate-license/main.go
+++ b/internal/cmds/generate-license/main.go
@@ -1,0 +1,92 @@
+package main
+
+// FIXME merge this with internal/cmds/generate-helps
+
+import (
+	"bytes"
+	_ "embed"
+	"flag"
+	"fmt"
+	"go/format"
+	"os"
+	"strconv"
+	"strings"
+	"text/template"
+	"unicode"
+
+	"github.com/charmbracelet/glamour"
+	"github.com/charmbracelet/glamour/styles"
+
+	"github.com/twpayne/chezmoi/v2/assets/chezmoi.io/docs"
+)
+
+//go:embed license.go.tmpl
+var licenseGoTmpl string
+
+var output = flag.String("o", "", "output")
+
+func run() error {
+	flag.Parse()
+
+	renderer, err := glamour.NewTermRenderer(
+		glamour.WithStyles(styles.ASCIIStyleConfig),
+		glamour.WithWordWrap(80),
+	)
+	if err != nil {
+		return err
+	}
+
+	licenseMarkdown := strings.TrimPrefix(docs.License, "# License\n\n")
+	license, err := renderer.Render(licenseMarkdown)
+	if err != nil {
+		return err
+	}
+
+	licenseGoTemplate, err := template.New("license.go.tmpl").Funcs(template.FuncMap{
+		"splitAndQuoteLines": func(s string) string {
+			lines := strings.Split(s, "\n")
+			quotedLines := make([]string, len(lines))
+			for i, line := range lines {
+				line = strings.TrimRightFunc(line, unicode.IsSpace)
+				if i == len(lines)-1 {
+					quotedLines[i] = strconv.Quote(line)
+				} else {
+					quotedLines[i] = strconv.Quote(line + "\n")
+				}
+			}
+			return strings.Join(quotedLines, " +\n")
+		},
+	}).Parse(licenseGoTmpl)
+	if err != nil {
+		return err
+	}
+
+	var buffer bytes.Buffer
+	if err := licenseGoTemplate.ExecuteTemplate(&buffer, "license.go.tmpl", license); err != nil {
+		return err
+	}
+
+	outputBytes := buffer.Bytes()
+	if formattedOutput, err := format.Source(outputBytes); err == nil {
+		outputBytes = formattedOutput
+	}
+
+	if *output == "" || *output == "-" {
+		if _, err := os.Stdout.Write(outputBytes); err != nil {
+			return err
+		}
+	} else {
+		if err := os.WriteFile(*output, outputBytes, 0o666); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1,4 +1,5 @@
 //go:generate go run ./internal/cmds/generate-helps -o internal/cmd/helps.gen.go
+//go:generate go run ./internal/cmds/generate-license -o internal/cmd/license.gen.go
 //go:generate go run . completion bash -o completions/chezmoi-completion.bash
 //go:generate go run . completion fish -o completions/chezmoi.fish
 //go:generate go run . completion powershell -o completions/chezmoi.ps1


### PR DESCRIPTION
This avoids linking github.com/charmbracelet/glamour and its dependencies into the binary, which saves another 7MB.

Refs #4356.