### PR TITLE
fix: remove default submission when nothing is selected during promptMultichoice

### DIFF
--- a/internal/chezmoibubbles/multichoiceinputmodel.go
+++ b/internal/chezmoibubbles/multichoiceinputmodel.go
@@ -222,9 +222,6 @@ func (m MultichoiceInputModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		case key.Matches(msg, km.Submit):
 			m.quitting = true
-			if m.numSelected < 1 {
-				m.items[m.index].selected = true
-			}
 			m.submitted = true
 			return m, tea.Quit
 		}


### PR DESCRIPTION
The default behavior from the gum multi-selection example when nothing is selected and we submit, is that the currently selected entry will be added to selection. In my eyes, this is counter intuitive, because if I want explicitly deselect an entry, it should not be submitted.

I want to use promptMultichoice as a "profile" where I can select which package-types (common, desktop, study, etc) i want to install. My config had a promptBool at the end of init asking if I wanted to do "manual" setup so don't install any packages. With the new promptMultichoice, I wanted to refactor and set manualSetup to true, wenn no package profiles are selected, sadly this didn't work because of the above mentioned behavior. 

If any more info is needed for this to merge, i'd be happy to provide.

Cheers

