### PR TITLE
docs: Fix reference to KeePassXC link

### DIFF
--- a/assets/chezmoi.io/docs/user-guide/password-managers/keepassxc.md
+++ b/assets/chezmoi.io/docs/user-guide/password-managers/keepassxc.md
@@ -1,6 +1,6 @@
 # KeePassXC
 
-chezmoi includes support for [KeePassXC][keepasxc] using the KeePassXC CLI
+chezmoi includes support for [KeePassXC][keepassxc] using the KeePassXC CLI
 (`keepassxc-cli`) to expose data as a template function.
 
 Provide the path to your KeePassXC database in your configuration file:


### PR DESCRIPTION
Fix minor reference link issue in KeePassXC password manager guide.

Currently looks like this on the docs site:
![site-docs](https://github.com/user-attachments/assets/ae1cba85-0f61-4450-bffa-61eda1f2ea84)

and GitHub Markdown:
![gh-md](https://github.com/user-attachments/assets/acc10794-7a58-4026-9aa6-bb26043e180d)

