### PR TITLE
chore: Cross-compile Windows binaries with zig

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,7 @@ env:
   PYTHON_VERSION: '3.10' # https://www.python.org/downloads/
   RAGE_VERSION: 0.11.1 # https://github.com/str4d/rage/releases
   UV_VERSION: 0.6.12 # https://github.com/astral-sh/uv/releases
+  ZIG_VERSION: 0.13.0 # https://ziglang.org/download/
 jobs:
   changes:
     runs-on: ubuntu-22.04
@@ -187,6 +188,9 @@ jobs:
       with:
         cache-prefix: release-go
         go-version: ${{ env.GO_VERSION }}
+    - uses: mlugg/setup-zig@a67e68dc5c8281d9608136d3d7ca1b282213e4ac
+      with:
+        version: ${{ env.ZIG_VERSION }}
     - name: install-release-dependencies
       if: github.event_name == 'push' || needs.changes.outputs.code == 'true'
       run: |
@@ -464,6 +468,9 @@ jobs:
       with:
         cache-prefix: release-go
         go-version: ${{ env.GO_VERSION }}
+    - uses: mlugg/setup-zig@a67e68dc5c8281d9608136d3d7ca1b282213e4ac
+      with:
+        version: ${{ env.ZIG_VERSION }}
     - uses: sigstore/cosign-installer@d7d6bc7722e3daa8354c50bcb52f4837da5e9b6a
     - name: create-syso
       run: |

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -41,6 +41,23 @@ builds:
   - -X main.builtBy=goreleaser
   - -linkmode external
   - --extldflags "-static"
+- id: chezmoi-cgo-windows
+  env:
+  - CGO_ENABLED=1
+  - CC="zig cc -target {{ if eq .Runtime.Goarch "amd64" }}x86_64{{ else if eq .Runtime.Goarch "arm64" }}aarch64{{ end }}-windows"
+  - CXX="zig c++ -target {{ if eq .Runtime.Goarch "amd64" }}x86_64{{ else if eq .Runtime.Goarch "arm64" }}aarch64{{ end }}-windows"
+  goos:
+  - windows
+  goarch:
+  - amd64
+  - arm64
+  ldflags:
+  - -s
+  - -w
+  - -X main.version={{ .Version }}
+  - -X main.commit={{ .Commit }}
+  - -X main.date={{ .Date }}
+  - -X main.builtBy=goreleaser
 - id: chezmoi-nocgo
   env:
   - CGO_ENABLED=0
@@ -83,10 +100,15 @@ builds:
     goarch: '386'
   - goos: linux
     goarch: amd64
+  - goos: windows
+    goarch: amd64
+  - goos: windows
+    goarch: arm64
 
 archives:
 - ids:
   - chezmoi-cgo-glibc # Required for chezmoi upgrade for versions <= 2.0.5
+  - chezmoi-cgo-windows
   - chezmoi-nocgo
   files:
   - LICENSE
@@ -148,7 +170,7 @@ checksum:
     name_template: chezmoi-linux-amd64
   - glob: ./dist/chezmoi-cgo-musl_linux_amd64_v1/chezmoi
     name_template: chezmoi-linux-amd64-musl
-  - glob: ./dist/chezmoi-nocgo_windows_amd64_v1/chezmoi.exe
+  - glob: ./dist/chezmoi-cgo-windows_windows_amd64_v1/chezmoi.exe
     name_template: chezmoi-windows-amd64.exe
 
 nfpms:


### PR DESCRIPTION
This enables Windows binaries to be compiled with cgo.

Zig, in theory, also allows cross-compiling Darwin binaries, but in practice you hit [this problem](https://forum.golangbridge.org/t/cgo-zig-netgo-and-libresolv/33842) which does not seem to have a solution.

I probably won't merge this PR as there is no benefit to enabling cgo on Windows, but I wanted to record the changes in case they're useful later.