### PR TITLE
fix: Set .chezmoi.sourceFile in execute-template command

### DIFF
--- a/internal/cmd/testdata/scripts/executetemplate.txtar
+++ b/internal/cmd/testdata/scripts/executetemplate.txtar
@@ -114,6 +114,13 @@ stdout 'alphabeta'
 exec chezmoi execute-template --file $HOME${/}file.tmpl
 stdout '# contents of file.tmpl'
 
+exec chezmoi execute-template --file $HOME${/}.local${/}share${/}chezmoi${/}path${/}to${/}template.tmpl
+stdout '# contents of path[/\\]to[/\\]template.tmpl'
+
+exec chezmoi execute-template --file $HOME${/}path${/}to${/}template.tmpl
+# \S+ stands in here for the opaque $WORK directory
+stdout '# contents of \S+[/\\]home[/\\]user[/\\]path[/\\]to[/\\]template.tmpl'
+
 chhome home2/user
 
 # test that files in .chezmoidata must have known extensions
@@ -160,7 +167,11 @@ last:
 {{ "invalid template"
 -- home/user/.local/share/chezmoi/.chezmoitemplates/partial --
 {{ cat "hello" "world" }}
+-- home/user/.local/share/chezmoi/path/to/template.tmpl --
+# contents of {{ .chezmoi.sourceFile }}
 -- home/user/file.tmpl --
 # contents of file.tmpl
+-- home/user/path/to/template.tmpl --
+# contents of {{ .chezmoi.sourceFile }}
 -- home2/user/.local/share/chezmoi/.chezmoidata/unknown --
 -- home3/user/.local/share/chezmoi/.chezmoidata/.chezmoiignore --


### PR DESCRIPTION
If a template file's path is in the chezmoi source directory, when
running `chezmoi execute-template -f FILENAME`, set
`.chezmoi.sourceFile` to the same source directory-relative path that a
template executing via `chezmoi apply` would have.

If a template's path is *not* in the source directory, then set
`.chezmoi.sourceFile` to the filename exactly as it is given on the
command line.

Previously, all template files executed via `chezmoi execute-template`
would get `.chezmoi.sourceFile` set to the string `"argN"`, where N is
the argument position on the command line, which breaks testing any
templates that use `sourceFile`.

Fixes #4406 
