### PR TITLE
docs: correct the usage of execute-template with the prompt string in the user guide setup

### DIFF
--- a/assets/chezmoi.io/docs/user-guide/setup.md
+++ b/assets/chezmoi.io/docs/user-guide/setup.md
@@ -116,7 +116,7 @@ To test this template, use `chezmoi execute-template` with the `--init` and
 `--promptString` flags, for example:
 
 ```sh
-chezmoi execute-template --init --promptString email=me@home.org < ~/.local/share/chezmoi/.chezmoi.toml.tmpl
+chezmoi execute-template --init --promptString "Email address=me@home.org" < ~/.local/share/chezmoi/.chezmoi.toml.tmpl
 ```
 
 ## Re-create your config file


### PR DESCRIPTION
correct the usage of execute-template with the prompt string in the user guide setup.

according to this issue https://github.com/twpayne/chezmoi/issues/3834#issuecomment-2201211679

<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer-guide/contributing-changes/

-->
