### PR TITLE
docs: Fix chassis detection for newer MacBooks

### DIFF
--- a/assets/chezmoi.io/docs/user-guide/machines/general.md
+++ b/assets/chezmoi.io/docs/user-guide/machines/general.md
@@ -8,7 +8,7 @@ The following template sets the `$chassisType` variable to `"desktop"` or
 ```text
 {{- $chassisType := "desktop" }}
 {{- if eq .chezmoi.os "darwin" }}
-{{-   if contains "MacBook" (output "sysctl" "-n" "hw.model") }}
+{{-   if contains "MacBook" (output "system_profiler" "SPHardwareDataType") }}
 {{-     $chassisType = "laptop" }}
 {{-   else }}
 {{-     $chassisType = "desktop" }}


### PR DESCRIPTION
For newer M-series MacBooks, the `hw.data` reports strings of the type "Mac15,6" so it can no longer be used to determine if the Mac is a MacBook or not.  This change just switches to using the `system_profiler` output (in particular the `SPHardwareDataType`) to find the Macbook string.

Not a major or earth shattering change - but just to make sure the examples work as expected. 

