### PR TITLE
feat: Remove X.509 fallback roots

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,6 @@ require (
 	go.etcd.io/bbolt v1.4.0
 	go.uber.org/automaxprocs v1.6.0
 	golang.org/x/crypto v0.38.0
-	golang.org/x/crypto/x509roots/fallback v0.0.0-20250515174705-ebc8e4631531
 	golang.org/x/oauth2 v0.30.0
 	golang.org/x/sync v0.14.0
 	golang.org/x/sys v0.33.0

--- a/go.sum
+++ b/go.sum
@@ -503,8 +503,6 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.38.0 h1:jt+WWG8IZlBnVbomuhg2Mdq0+BBQaHbtqHEFEigjUV8=
 golang.org/x/crypto v0.38.0/go.mod h1:MvrbAqul58NNYPKnOra203SB9vpuZW0e+RRZV+Ggqjw=
-golang.org/x/crypto/x509roots/fallback v0.0.0-20250515174705-ebc8e4631531 h1:uEZjxClB4DwZIRL2pFsPPv0Y1rBtHvoqDVg96PJf30Y=
-golang.org/x/crypto/x509roots/fallback v0.0.0-20250515174705-ebc8e4631531/go.mod h1:lxN5T34bK4Z/i6cMaU7frUU57VkDXFD4Kamfl/cp9oU=
 golang.org/x/exp v0.0.0-20250506013437-ce4c2cf36ca6 h1:y5zboxd6LQAqYIhHnB48p0ByQ/GnQx2BE33L8BOHQkI=
 golang.org/x/exp v0.0.0-20250506013437-ce4c2cf36ca6/go.mod h1:U6Lno4MTRCDY+Ba7aCcauB9T60gsv5s4ralQzP72ZoQ=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=

--- a/main.go
+++ b/main.go
@@ -14,7 +14,6 @@ import (
 	"os"
 
 	"go.uber.org/automaxprocs/maxprocs"
-	_ "golang.org/x/crypto/x509roots/fallback" // Embed fallback X.509 trusted roots
 
 	"github.com/twpayne/chezmoi/v2/internal/cmd"
 )


### PR DESCRIPTION
X.509 fallback roots are only needed on systems that do not have any CA certificates installed. This is likely very few, and costs everyone 8ms on every start up, so remove it.

Refs #4353.
Refs https://github.com/golang/go/issues/73691.