### PR TITLE
fix: Fix ignoring exit code 1 from external diff commands for non-files

### DIFF
--- a/assets/chezmoi.io/docs/user-guide/tools/diff.md
+++ b/assets/chezmoi.io/docs/user-guide/tools/diff.md
@@ -51,7 +51,7 @@ example:
 
     ```toml title="~/.config/chezmoi/chezmoi.toml"
     [diff]
-    pager = "delta"
+        pager = "delta"
     ```
 
 === "YAML"

--- a/internal/cmd/testdata/scripts/issue4454.txtar
+++ b/internal/cmd/testdata/scripts/issue4454.txtar
@@ -1,0 +1,29 @@
+# test that chezmoi diff ignores errors from the custom diff command when there are differences in files
+exec chezmoi diff
+
+chhome home2/user
+
+# test that chezmoi diff ignores errors from the custom diff command when there are differences in directories
+exec chezmoi diff
+
+chhome home3/user
+
+# test that chezmoi diff ignores errors from the custom diff command when there are differences in symlinks
+exec chezmoi diff
+
+-- bin/false.cmd --
+@exit 1
+-- home/user/.config/chezmoi/chezmoi.toml --
+[diff]
+    command = "false"
+-- home/user/.local/share/chezmoi/dot_file --
+# contents of .file
+-- home2/user/.config/chezmoi/chezmoi.toml --
+[diff]
+    command = "false"
+-- home2/user/.local/share/chezmoi/dot_dir/.keep --
+-- home3/user/.config/chezmoi/chezmoi.toml --
+[diff]
+    command = "false"
+-- home3/user/.local/share/chezmoi/symlink_symlink --
+target


### PR DESCRIPTION
Fixes #4454.

Draft PR because I would like to add tests for this.