### PR TITLE
docs: Clarify `modify_` documentation

### DIFF
--- a/assets/chezmoi.io/docs/reference/target-types.md
+++ b/assets/chezmoi.io/docs/reference/target-types.md
@@ -32,14 +32,16 @@ unchanged.
 Files with the `modify_` prefix are treated as scripts that modify an existing
 file.
 
-If the file contains a line with the text `chezmoi:modify-template` then that
-line is removed and the rest of the script is executed template with the
-existing file's contents passed as a string in `.chezmoi.stdin`. The result of
-executing the template are the new contents of the file.
+If the file contains the string `chezmoi:modify-template`, then all lines
+containing that string will be removed, and the rest of the file will be
+interpreted as a template. The template is executed with the existing file's
+contents passed as a string in `.chezmoi.stdin`. The result of the template
+execution becomes the new contents of the file.
 
-Otherwise, the contents of the existing file (which maybe empty if the existing
-file does not exist or is empty) are passed to the script's standard input, and
-the new contents are read from the script's standard output.
+Otherwise, the script receives the current contents of the target file on
+standard input and must write the new contents to standard output.
+If the target file does not exist, the script's standard input will be empty,
+and the script is responsible for generating the complete file contents.
 
 ### Remove entry
 

--- a/assets/chezmoi.io/docs/user-guide/manage-different-types-of-file.md
+++ b/assets/chezmoi.io/docs/user-guide/manage-different-types-of-file.md
@@ -71,9 +71,10 @@ example using `sed`.
     will be empty and it is the script's responsibility to write a complete
     file to the standard output.
 
-`modify_` scripts that contain the string `chezmoi:modify-template` are executed
-as templates with the current contents of the file passed as `.chezmoi.stdin`
-and the result of the template execution used as the new contents of the file.
+`modify_` scripts that contain the string `chezmoi:modify-template` will have all lines
+containing that string removed, and the rest of the file will be interpreted as a template.
+The template is executed with the current contents of the file passed as `.chezmoi.stdin`,
+and the result of the template execution becomes the new contents of the file.
 
 !!! example
 


### PR DESCRIPTION
I found that the documentation of the `modify_` target type [in the reference](https://www.chezmoi.io/reference/target-types/#modify-file) is a bit harder to comprehend and inconsistent with what is described [in the user guide](https://www.chezmoi.io/user-guide/manage-different-types-of-file/#manage-part-but-not-all-of-a-file) ("contains a line with the text `chezmoi:modify-template`" has a very different meaning from "containing the string").

This commit replaces the current explanation in the reference with the one that is in the user guide.

