### PR TITLE
fix: Preserve, don't delete, whitespace-only files in external archives

### DIFF
--- a/internal/chezmoi/targetstateentry.go
+++ b/internal/chezmoi/targetstateentry.go
@@ -203,7 +203,7 @@ func (t *TargetStateFile) Apply(
 	if err != nil {
 		return false, err
 	}
-	if !t.empty && isEmpty(contents) {
+	if !t.sourceAttr.External && !t.empty && isEmpty(contents) {
 		if _, ok := actualStateEntry.(*ActualStateAbsent); ok {
 			return false, nil
 		}
@@ -250,7 +250,7 @@ func (t *TargetStateFile) EntryState(umask fs.FileMode) (*EntryState, error) {
 	if err != nil {
 		return nil, err
 	}
-	if !t.empty && isEmpty(contents) {
+	if !t.sourceAttr.External && !t.empty && isEmpty(contents) {
 		return &EntryState{
 			Type: EntryStateTypeRemove,
 		}, nil

--- a/internal/cmd/testdata/scripts/issue4496.txtar
+++ b/internal/cmd/testdata/scripts/issue4496.txtar
@@ -1,0 +1,19 @@
+hexdecode www/whitespace.txt.hex
+exec tar -cf www/archive.tar www/whitespace.txt
+httpd www
+
+# test that externals files containing only whitespace are preserved
+exec chezmoi apply
+cmp $HOME/.whitespace www/whitespace.txt
+cmp $HOME/.dir/whitespace.txt www/whitespace.txt
+
+-- home/user/.local/share/chezmoi/.chezmoiexternal.toml.tmpl --
+[".whitespace"]
+    type = "file"
+    url = "{{ env "HTTPD_URL" }}/whitespace.txt"
+[".dir"]
+    type = "archive"
+    url = "{{ env "HTTPD_URL" }}/archive.tar"
+    stripComponents = 1
+-- www/whitespace.txt.hex --
+0d0a # "\r\n"


### PR DESCRIPTION
Fixes #4496.