### PR TITLE
feat: Add `getRedirectedURL` template function

### DIFF
--- a/assets/chezmoi.io/docs/reference/templates/functions/getRedirectedURL.md
+++ b/assets/chezmoi.io/docs/reference/templates/functions/getRedirectedURL.md
@@ -1,0 +1,25 @@
+# `getRedirectedURL` *url*
+
+`getRedirectedURL` returns the final URL after following any HTTP redirects
+from the given *url*. If the *url* does not redirect, it returns the original
+*url*.
+
+`getRedirectedURL` is not hermetic: its return value depends on the state of
+the network and the remote server at the moment the template is executed.
+Exercise caution when using it in your templates.
+
+!!! example
+
+    ```
+    {{ getRedirectedURL "https://github.com/twpayne/chezmoi/releases/latest" }}
+    {{ getRedirectedURL "https://github.com/twpayne/chezmoi/raw/HEAD/README.md" }}
+    {{ getRedirectedURL "https://git.io/chezmoi" }}
+    ```
+
+    This will return something like:
+
+    ```
+    https://github.com/twpayne/chezmoi/releases/tag/v2.62.7
+    https://raw.githubusercontent.com/twpayne/chezmoi/aa57d1d773715e02103e87f78c58b99f9b91fc0c/README.md
+    https://raw.githubusercontent.com/twpayne/chezmoi/master/assets/scripts/install.sh
+    ```

--- a/assets/chezmoi.io/mkdocs.yml
+++ b/assets/chezmoi.io/mkdocs.yml
@@ -211,6 +211,7 @@ nav:
       - fromJsonc: reference/templates/functions/fromJsonc.md
       - fromToml: reference/templates/functions/fromToml.md
       - fromYaml: reference/templates/functions/fromYaml.md
+      - getRedirectedURL: reference/templates/functions/getRedirectedURL.md
       - glob: reference/templates/functions/glob.md
       - hexDecode: reference/templates/functions/hexDecode.md
       - hexEncode: reference/templates/functions/hexEncode.md

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -461,6 +461,7 @@ func newConfig(options ...configOption) (*Config, error) {
 		"fromJsonc":                   c.fromJsoncTemplateFunc,
 		"fromToml":                    c.fromTomlTemplateFunc,
 		"fromYaml":                    c.fromYamlTemplateFunc,
+		"getRedirectedURL":            c.getRedirectedURLTemplateFunc,
 		"gitHubKeys":                  c.gitHubKeysTemplateFunc,
 		"gitHubLatestRelease":         c.gitHubLatestReleaseTemplateFunc,
 		"gitHubLatestReleaseAssetURL": c.gitHubLatestReleaseAssetURLTemplateFunc,


### PR DESCRIPTION
<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer-guide/contributing-changes/

-->

This function will allow me to drop the dependency on `curl` and `git` in my chezmoi templates, making them more portable and quicker to execute.

See the documentation for example uses of such function.

~I did not find any Go library that does this (like [Rust](https://docs.rs/follow-redirects/latest/follow_redirects/) or [JavaScript](https://www.npmjs.com/package/follow-redirects)), so I tried to keep the implementation simple.~ EDIT: this leverages [`net/http`'s redirection mechanism](https://cs.opensource.google/go/go/+/refs/tags/go1.24.4:src/net/http/client.go;l=456).

Disclaimer: I used Claude Sonnet 4 through GitHub Copilot to help me build this PR.
