### PR TITLE
feat: Backup replaced files option added to init, apply, update, and edit

### DIFF
--- a/assets/chezmoi.io/docs/reference/command-line-flags/global.md
+++ b/assets/chezmoi.io/docs/reference/command-line-flags/global.md
@@ -11,6 +11,13 @@ may not have any effect on certain commands.
 
 Use *directory* as the cache directory.
 
+### `--backup` *archive*
+
+> Configuration: `backup`
+
+Back up replaced files that differ from the target to *archive*. The archive is
+created if it does not exist, and subsequent runs append to it.
+
 ### `--color` *value*
 
 > Configuration: `color`

--- a/assets/chezmoi.io/docs/reference/commands/apply.md
+++ b/assets/chezmoi.io/docs/reference/commands/apply.md
@@ -27,6 +27,10 @@ they want to overwrite the file.
 
 --8<-- "common-flags/recursive.md:default-true"
 
+### `--backup`
+
+--8<-- "common-flags/backup.md"
+
 ### `--source-path`
 
 Specify targets by source path, rather than target path. This is useful for

--- a/assets/chezmoi.io/docs/reference/commands/edit.md
+++ b/assets/chezmoi.io/docs/reference/commands/edit.md
@@ -62,6 +62,10 @@ Automatically apply changes when files are saved, with the following limitations
 
 --8<-- "common-flags/init.md"
 
+### `--backup`
+
+--8<-- "common-flags/backup.md"
+
 ## Examples
 
   ```sh

--- a/assets/chezmoi.io/docs/reference/commands/init.md
+++ b/assets/chezmoi.io/docs/reference/commands/init.md
@@ -156,6 +156,10 @@ Guess an SSH repo URL instead of an HTTPS repo.
 
 --8<-- "common-flags/include.md"
 
+### `--backup`
+
+--8<-- "common-flags/backup.md"
+
 ## Examples
 
 ```sh

--- a/assets/chezmoi.io/docs/reference/commands/update.md
+++ b/assets/chezmoi.io/docs/reference/commands/update.md
@@ -39,6 +39,11 @@ Update submodules recursively. This defaults to `true`. Can be disabled with `--
 
 --8<-- "common-flags/recursive.md:default-true"
 
+### `--backup`
+
+--8<-- "common-flags/backup.md"
+
+
 ## Examples
 
 ```sh

--- a/assets/chezmoi.io/snippets/common-flags/backup.md
+++ b/assets/chezmoi.io/snippets/common-flags/backup.md
@@ -1,0 +1,5 @@
+Backups all files replaced or modified during the operation to the specified tar file. Appends to the file if it exists.
+
+!!! example
+
+    `--backup=$HOME/.chezmoi-backup.tar` backups all files which were overwritten / modified to $HOME/.chezmoi-backup.tar.

--- a/internal/cmd/applycmd.go
+++ b/internal/cmd/applycmd.go
@@ -45,6 +45,6 @@ func (c *Config) runApplyCmd(cmd *cobra.Command, args []string) error {
 		parentDirs:   c.apply.parentDirs,
 		recursive:    c.apply.recursive,
 		umask:        c.Umask,
-		preApplyFunc: c.defaultPreApplyFunc,
+		preApplyFunc: c.preApplyFunc(),
 	})
 }

--- a/internal/cmd/backupflag.go
+++ b/internal/cmd/backupflag.go
@@ -1,0 +1,80 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	"github.com/go-viper/mapstructure/v2"
+
+	"github.com/twpayne/chezmoi/internal/chezmoi"
+)
+
+// A backupFlag represents the value of the --backup flag which specifies the
+// path to a tar archive for backed up files. An empty value disables backups.
+type backupFlag struct{ path chezmoi.AbsPath }
+
+// MarshalJSON implements json.Marshaler.
+func (b backupFlag) MarshalJSON() ([]byte, error) { return json.Marshal(b.path.String()) }
+
+// MarshalText implements encoding.TextMarshaler.
+func (b backupFlag) MarshalText() ([]byte, error) { return []byte(b.path.String()), nil }
+
+// Set implements pflag.Value.Set.
+func (b *backupFlag) Set(s string) error {
+	if s == "" {
+		b.path = chezmoi.EmptyAbsPath
+		return nil
+	}
+	homeDirAbsPath, err := chezmoi.HomeDirAbsPath()
+	if err != nil {
+		return err
+	}
+	absPath, err := chezmoi.NewAbsPathFromExtPath(s, homeDirAbsPath)
+	if err != nil {
+		return err
+	}
+	b.path = absPath
+	return nil
+}
+
+func (b backupFlag) String() string { return b.path.String() }
+
+func (b backupFlag) Type() string { return "path" }
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (b *backupFlag) UnmarshalJSON(data []byte) error {
+	if len(data) == 0 || (len(data) == 2 && string(data) == "\"\"") {
+		b.path = chezmoi.EmptyAbsPath
+		return nil
+	}
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	return b.Set(s)
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (b *backupFlag) UnmarshalText(text []byte) error { return b.Set(string(text)) }
+
+// StringToBackupFlagHookFunc returns a DecodeHookFunc that parses a backupFlag
+// from a string.
+func StringToBackupFlagHookFunc() mapstructure.DecodeHookFunc {
+	return func(from, to reflect.Type, data any) (any, error) {
+		if to != reflect.TypeOf(backupFlag{}) {
+			return data, nil
+		}
+		var bf backupFlag
+		if v, ok := data.(string); ok {
+			if v == "" {
+				return bf, nil
+			}
+			if err := bf.Set(v); err != nil {
+				return nil, err
+			}
+			return bf, nil
+		}
+		return nil, fmt.Errorf("expected a string, got a %T", data)
+	}
+}

--- a/internal/cmd/destroycmd.go
+++ b/internal/cmd/destroycmd.go
@@ -85,6 +85,11 @@ func (c *Config) runDestroyCmd(cmd *cobra.Command, args []string, sourceState *c
 				return nil
 			}
 		}
+		if c.backupTarWriter != nil {
+			if err := c.backupPath(destAbsPath); err != nil && !errors.Is(err, fs.ErrNotExist) {
+				return err
+			}
+		}
 		if err := c.destSystem.RemoveAll(destAbsPath); err != nil && !errors.Is(err, fs.ErrNotExist) {
 			return err
 		}

--- a/internal/cmd/editcmd.go
+++ b/internal/cmd/editcmd.go
@@ -64,7 +64,7 @@ func (c *Config) runEditCmd(cmd *cobra.Command, args []string) error {
 				init:         c.Edit.init,
 				recursive:    true,
 				umask:        c.Umask,
-				preApplyFunc: c.defaultPreApplyFunc,
+				preApplyFunc: c.preApplyFunc(),
 			}); err != nil {
 				return err
 			}
@@ -198,7 +198,7 @@ TARGET_REL_PATH:
 				init:         c.Edit.init,
 				recursive:    true,
 				umask:        c.Umask,
-				preApplyFunc: c.defaultPreApplyFunc,
+				preApplyFunc: c.preApplyFunc(),
 			}); err != nil {
 				return err
 			}

--- a/internal/cmd/helps.gen.go
+++ b/internal/cmd/helps.gen.go
@@ -73,6 +73,7 @@ var helps = map[string]*help{
 			"  chezmoi apply --dry-run --verbose\n" +
 			"  chezmoi apply ~/.bashrc",
 		longFlags: chezmoiset.New(
+			"backup",
 			"exclude",
 			"include",
 			"init",
@@ -351,6 +352,7 @@ var helps = map[string]*help{
 			"  chezmoi edit",
 		longFlags: chezmoiset.New(
 			"apply",
+			"backup",
 			"exclude",
 			"hardlink",
 			"include",
@@ -550,6 +552,7 @@ var helps = map[string]*help{
 			"  chezmoi init gitlab.com/user",
 		longFlags: chezmoiset.New(
 			"apply",
+			"backup",
 			"branch",
 			"config-path",
 			"data",
@@ -838,6 +841,7 @@ var helps = map[string]*help{
 			"  chezmoi update",
 		longFlags: chezmoiset.New(
 			"apply",
+			"backup",
 			"exclude",
 			"include",
 			"init",

--- a/internal/cmd/initcmd.go
+++ b/internal/cmd/initcmd.go
@@ -211,7 +211,7 @@ func (c *Config) runInitCmd(cmd *cobra.Command, args []string) error {
 			filter:       c.init.filter,
 			recursive:    false,
 			umask:        c.Umask,
-			preApplyFunc: c.defaultPreApplyFunc,
+			preApplyFunc: c.preApplyFunc(),
 		}); err != nil {
 			return err
 		}

--- a/internal/cmd/testdata/scripts/apply.txtar
+++ b/internal/cmd/testdata/scripts/apply.txtar
@@ -70,3 +70,11 @@ grep -count=2 '# edited' $HOME/.file
 # test that chezmoi apply --source-path fails when called with a targetDirAbsPath
 ! exec chezmoi apply --force --source-path $HOME${/}.file
 [!windows] stderr ${HOME@R}/\.file:\snot\sin\s${CHEZMOISOURCEDIR@R}$
+
+# test that chezmoi apply backups changed files
+edit $HOME/.file
+exec chezmoi apply --force --backup $HOME/backup.tar
+exists $HOME/backup.tar
+tarcontains $HOME/backup.tar .file
+! tarcontains $HOME/backup.tar .empty
+exists $HOME/.file

--- a/internal/cmd/testdata/scripts/edit.txtar
+++ b/internal/cmd/testdata/scripts/edit.txtar
@@ -50,3 +50,10 @@ sourceDir = "~/.local/share/chezmoi/home"
 -- home2/user/.local/share/chezmoi/.git/.keep --
 -- home2/user/.local/share/chezmoi/home/dot_file --
 # contents of .file
+
+# test that chezmoi apply backups changed files
+exec chezmoi edit --backup $HOME/backup.tar $HOME${/}.file
+exists $HOME/backup.tar
+tarcontains $HOME/backup.tar .file
+! tarcontains $HOME/backup.tar .empty
+exists $HOME/.file

--- a/internal/cmd/testdata/scripts/init.txtar
+++ b/internal/cmd/testdata/scripts/init.txtar
@@ -184,3 +184,12 @@ data:
 -- home8/user/.local/share/chezmoi/.chezmoi.toml.tmpl --
 [diff]
 exclude: ["scripts"]
+
+# test that chezmoi init --backup with --apply fetches a git repo and runs chezmoi apply saving replaced in backup.tar
+mkgitconfig
+mkfile $HOME/.file
+exec chezmoi init --backup $HOME/backup.tar --apply --force file://$WORK/home/user/.local/share/chezmoi
+exists $HOME/backup.tar
+tarcontains $HOME/backup.tar .file
+! tarcontains $HOME/backup.tar .empty
+exists $HOME/.file

--- a/internal/cmd/testdata/scripts/update.txtar
+++ b/internal/cmd/testdata/scripts/update.txtar
@@ -57,6 +57,15 @@ exec chezmoi update --init
 exec chezmoi execute-template '{{ .key }}'
 stdout value
 
+# test that chezmoi update --backup with --apply
+edit $HOME/.file
+exec chezmoi update --backup $HOME/backup.tar --apply --force
+exists $HOME/backup.tar
+tarcontains $HOME/backup.tar .file
+! tarcontains $HOME/backup.tar .empty
+exists $HOME/.file
+
+
 -- golden/.chezmoi.toml.tmpl --
 [data]
     key = "value"

--- a/internal/cmd/updatecmd.go
+++ b/internal/cmd/updatecmd.go
@@ -98,7 +98,7 @@ func (c *Config) runUpdateCmd(cmd *cobra.Command, args []string) error {
 			parentDirs:   c.Update.parentDirs,
 			recursive:    c.Update.recursive,
 			umask:        c.Umask,
-			preApplyFunc: c.defaultPreApplyFunc,
+			preApplyFunc: c.preApplyFunc(),
 		}); err != nil {
 			return err
 		}


### PR DESCRIPTION
This change enables a `--backup=file.tar` flag on `edit` `init`, `apply` and `update` (strictly speaking it's a global flag.)

I believe i have covered testing and documentation which were the things I neglected last time.


`make format` gave me this but I don't believe that this is a code issue:

```
$ make format
if [ ! -x bin/golangci-lint ] || ( ./bin/golangci-lint version | grep -Fqv "version 2.1.6" ) ; then \
        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- v2.1.6 ; \
fi
ERRO Can't read config: can't unmarshal config by viper: 1 error(s) decoding:

* 'Version' expected a map, got 'string' 
./bin/golangci-lint fmt
ERRO Can't read config: can't unmarshal config by viper: 1 error(s) decoding:

* 'Version' expected a map, got 'string' 
make: *** [Makefile:130: format] Error 3
```

And lint

```
$ make lint
if [ ! -x bin/actionlint ] || ( ./bin/actionlint --version | grep -Fqv "v1.7.7" ) ; then \
        GOBIN=/home/arran/Documents/Projects/chezmoi/bin go install "github.com/rhysd/actionlint/cmd/actionlint@v1.7.7" ; \
fi
go: downloading github.com/rhysd/actionlint v1.7.7
go: downloading github.com/bmatcuk/doublestar/v4 v4.8.0
go: downloading golang.org/x/sys v0.29.0
go: downloading github.com/mattn/go-shellwords v1.0.12
go: downloading github.com/robfig/cron/v3 v3.0.1
if [ ! -x bin/editorconfig-checker ] || ( ./bin/editorconfig-checker --version | grep -Fqv "v3.3.0" ) ; then \
        curl -sSfL "https://github.com/editorconfig-checker/editorconfig-checker/releases/download/v3.3.0/ec-linux-amd64.tar.gz" | tar -xzf - "bin/ec-linux-amd64" ; \
        mv "bin/ec-linux-amd64" bin/editorconfig-checker ; \
fi
if [ ! -x bin/golangci-lint ] || ( ./bin/golangci-lint version | grep -Fqv "version 2.1.6" ) ; then \
        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- v2.1.6 ; \
fi
ERRO Can't read config: can't unmarshal config by viper: 1 error(s) decoding:

* 'Version' expected a map, got 'string' 
find . -type f -name \*.sh | xargs shellcheck
xargs: shellcheck: No such file or directory
make: *** [Makefile:188: shellcheck] Error 127
```

I am going to rely on CI for that.

Tested in docker too:

```
root@3158c8be9074:~# date >> .zlogin
root@3158c8be9074:~# /workdir/chezmoi update --apply --backup /test.tar 
backing up replaced files to /test.tar
backed up /root/.zlogin to /test.tar
```

But the txtar wrapped internal tests are pretty sophisticated.

