### PR TITLE
fix: Use filepath.Join() to join abspath

### DIFF
--- a/internal/chezmoi/abspath.go
+++ b/internal/chezmoi/abspath.go
@@ -61,7 +61,7 @@ func (p AbsPath) Join(relPaths ...RelPath) AbsPath {
 	for i, relPath := range relPaths {
 		relPathStrs[i+1] = relPath.String()
 	}
-	return NewAbsPath(path.Join(relPathStrs...))
+	return NewAbsPath(filepath.ToSlash(filepath.Join(relPathStrs...)))
 }
 
 // JoinString returns a new AbsPath with ss appended.
@@ -69,7 +69,7 @@ func (p AbsPath) JoinString(ss ...string) AbsPath {
 	strs := make([]string, len(ss)+1)
 	strs[0] = string(p)
 	copy(strs[1:len(ss)+1], ss)
-	return NewAbsPath(path.Join(strs...))
+	return NewAbsPath(filepath.ToSlash(filepath.Join(strs...)))
 }
 
 // Len returns the length of p.


### PR DESCRIPTION
Fixes https://github.com/twpayne/chezmoi/issues/4522

The method `AbsPath.JoinString` eventually calls `path.Join`, which strips the leading `\\` from UNC paths. In this case, `AbsPath.JoinString` is invoked here:

https://github.com/twpayne/chezmoi/blob/5188a2e950a2c36aeb5d1c7ae8059989e2b3e276/internal/chezmoi/system.go#L229