### PR TITLE
docs: Fix minor error in example hook

### DIFF
--- a/assets/chezmoi.io/docs/user-guide/advanced/install-your-password-manager-on-init.md
+++ b/assets/chezmoi.io/docs/user-guide/advanced/install-your-password-manager-on-init.md
@@ -51,5 +51,5 @@ the source state:
 
 ```toml title=".config/chezmoi/chezmoi.toml"
 [hooks.read-source-state.pre]
-    command = ".local/share/chezmoi/.install-password-manager.sh"
+    script = ".local/share/chezmoi/.install-password-manager.sh"
 ```


### PR DESCRIPTION
I think the example hook is incorrect. Since it's a script, not a command, the config should use `script`.