### PR TITLE
fix: Properly handle comments after filenames

### DIFF
--- a/internal/chezmoi/sourcestate.go
+++ b/internal/chezmoi/sourcestate.go
@@ -49,7 +49,7 @@ const (
 )
 
 var (
-	commentRx                       = regexp.MustCompile(`(?:\A|\s+)#.*$`)
+	commentRx                       = regexp.MustCompile(`(?:\A|\s+)#.*(?:\r?\n)?$`)
 	lineEndingRx                    = regexp.MustCompile(`(?m)(?:\r\n|\r|\n)`)
 	modifyTemplateRx                = regexp.MustCompile(`(?m)^.*chezmoi:modify-template.*$(?:\r?\n)?`)
 	templateDirectiveRx             = regexp.MustCompile(`(?m)^.*?chezmoi:template:(.*)$(?:\r?\n)?`)

--- a/internal/cmd/testdata/scripts/ignored.txtar
+++ b/internal/cmd/testdata/scripts/ignored.txtar
@@ -10,7 +10,7 @@ cmp stdout golden/ignored
 .readonly
 .template
 -- home/user/.local/share/chezmoi/.chezmoiignore --
-.dir/subdir
+.dir/subdir # Comment following pattern
 .read*
 **/file
 .template


### PR DESCRIPTION
Comments in #4559 suggested that there might be a problem with ignore
patterns that have a trailing comment. Experimental testing shows that
this is the case.

The `commentRx` pattern was not properly seeing the end of the string
because of a newline present.
