### PR TITLE
fix: Fix bad skip instruction in test script issue4479 

### DIFF
--- a/internal/cmd/testdata/scripts/issue4479.txtar
+++ b/internal/cmd/testdata/scripts/issue4479.txtar
@@ -1,4 +1,4 @@
-[!exec:git] 'skip git not found in $PATH'
+[!exec:git] skip 'git not found in $PATH'
 
 mkgitconfig
 


### PR DESCRIPTION
If Git is not found in `$PATH`, the test looks like it should be skipped with the message 'git not found in $PATH'. Instead, the test fails with:

```go
[   45s]         testscript.go:584: > [!exec:git] 'skip git not found in $PATH'
[   45s]             FAIL: testdata/scripts/issue4479.txtar:1: unknown command "skip git not found in $PATH"
```