### PR TITLE
Watch hardlink dependency

### DIFF
--- a/assets/chezmoi.io/docs/reference/commands/edit.md
+++ b/assets/chezmoi.io/docs/reference/commands/edit.md
@@ -35,6 +35,13 @@ Invoke the editor with a hard link to the source file with a name matching the
 target filename. This can help the editor determine the type of the file
 correctly. This is the default.
 
+
+!!! hint
+
+    Creating hardlinks is not possible between different filesystems. Hence,
+    if your [`tempDir`][tempdir] resides on a different filesystem (e.g. a
+    [tmpfs][tmpfs], which is sometimes used for `/tmp`), this will not work.
+
 ### `--watch`
 
 > Configuration: `edit.watch`
@@ -47,6 +54,7 @@ Automatically apply changes when files are saved, with the following limitations
 * Only the edited files are watched, not any dependent files (e.g.
   `.chezmoitemplates` and `include`d files in templates are not watched).
 * Only works on operating systems supported by [fsnotify][fsnotify].
+* Only works if `edit.hardlink` is enabled and works.
 
 ## Common flags
 
@@ -72,3 +80,5 @@ Automatically apply changes when files are saved, with the following limitations
 
 [fsnotify]: https://github.com/fsnotify/fsnotify
 [modelines]: https://vimhelp.org/options.txt.html#auto-setting
+[tempdir]: /reference/configuration-file/variables.md#tempdir
+[tmpfs]: https://en.wikipedia.org/wiki/Tmpfs

--- a/internal/cmd/doctorcmd.go
+++ b/internal/cmd/doctorcmd.go
@@ -219,6 +219,7 @@ func (c *Config) runDoctorCmd(cmd *cobra.Command, args []string) error {
 			name:    "dest-dir",
 			dirname: c.DestDirAbsPath,
 		},
+		hardlinkCheck{},
 		umaskCheck{},
 		&binaryCheck{
 			name:       "cd-command",

--- a/internal/cmd/doctorcmd_unix.go
+++ b/internal/cmd/doctorcmd_unix.go
@@ -4,6 +4,7 @@ package cmd
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -15,10 +16,56 @@ import (
 )
 
 type (
+	// Check if hardlinks work between tempDir and sourceDir.
+	hardlinkCheck   struct{}
 	systeminfoCheck struct{ omittedCheck }
 	umaskCheck      struct{}
 	unameCheck      struct{}
 )
+
+func (hardlinkCheck) Name() string {
+	return "hardlink"
+}
+
+func (hardlinkCheck) Run(config *Config) (checkResult, string) {
+	if !config.Edit.Hardlink {
+		return checkResultInfo, "edit.hardlink disabled"
+	}
+
+	testFileName := ".chezmoi-doctor-hardlink-test"
+
+	tempDirAbsPath, err := config.tempDir("chezmoi-doctor")
+	if err != nil {
+		return checkResultFailed, err.Error()
+	}
+
+	hardlinkAbsPath := tempDirAbsPath.JoinString(testFileName)
+	sourceAbsPath := config.SourceDirAbsPath.JoinString(testFileName)
+
+	if err := config.baseSystem.WriteFile(sourceAbsPath, []byte(""), 0o700); err != nil {
+		return checkResultFailed, err.Error()
+	}
+
+	if err := os.MkdirAll(hardlinkAbsPath.Dir().String(), 0o700); err != nil {
+		return checkResultFailed, err.Error()
+	}
+
+	if err := config.baseSystem.Link(config.SourceDirAbsPath.JoinString(testFileName), hardlinkAbsPath); err != nil {
+		errCleanUp := config.baseSystem.Remove(sourceAbsPath)
+		return checkResultError, fmt.Sprintf(
+			"Failed creating hardlink %s -> %s: %s",
+			config.SourceDirAbsPath,
+			config.TempDir,
+			errors.Join(err, errCleanUp),
+		)
+	}
+
+	if err := config.baseSystem.Remove(sourceAbsPath); err != nil {
+		return checkResultFailed, err.Error()
+	}
+
+	return checkResultOK, fmt.Sprintf("Can create hardlinks %s -> %s", config.SourceDirAbsPath, config.TempDir)
+}
 
 func (umaskCheck) Name() string {
 	return "umask"

--- a/internal/cmd/doctorcmd_windows.go
+++ b/internal/cmd/doctorcmd_windows.go
@@ -10,6 +10,7 @@ import (
 )
 
 type (
+	hardlinkCheck   struct{ omittedCheck }
 	systeminfoCheck struct{}
 	umaskCheck      struct{ omittedCheck }
 	unameCheck      struct{ omittedCheck }


### PR DESCRIPTION
This fixes #4587 

I had a look at adding test scripts, but the setup is pretty complicated:
 - You need a tmpfs filesystem to set tempDir to.
 - It needs to be a different tmpfs from the one the source dir potentially is in (the testscripts seem to create temporary home dirs in /tmp so you cannot use /tmp)
 - Creating tmpfs needs root rights (`mount -t tmpfs tmpfs <PATH_TO_MOUNT_POINT>`), so we cannot do that ad-hoc

For my system, I can just set `tempDir` to `/run/user/1000` and test it that way, but that is very my-system-specific. There is also not really a way to check this and skip the test if you don't have a tmpfs at hand -> I don't feel comfortable just creating a test that works for me.