### PR TITLE
feat: Add `podman` and `ssh` commands

### DIFF
--- a/assets/chezmoi.io/docs/reference/commands/generate.md
+++ b/assets/chezmoi.io/docs/reference/commands/generate.md
@@ -2,14 +2,16 @@
 
 Generates *output* for use with chezmoi. The currently supported *output*s are:
 
-| Output               | Description                                                           |
-| -------------------- | --------------------------------------------------------------------- |
-| `git-commit-message` | A git commit message, describing the changes to the source directory. |
-| `install.sh`         | An install script, suitable for use with GitHub Codespaces            |
+| Output                  | Description                                                                   |
+| ----------------------- | ----------------------------------------------------------------------------- |
+| `git-commit-message`    | A git commit message, describing the changes to the source directory.         |
+| `install.sh`            | An install script, suitable for use with GitHub Codespaces                    |
+| `install-init-shell.sh` | A script which installs chezmoi, runs `chezmoi init`, and executes your shell |
 
 ## Examples
 
 ```sh
 chezmoi generate install.sh > install.sh
 chezmoi git commit -m "$(chezmoi generate git-commit-message)"
+chezmoi generate install-init-shell.sh $GITHUB_USERNAME
 ```

--- a/assets/chezmoi.io/docs/reference/commands/podman.md
+++ b/assets/chezmoi.io/docs/reference/commands/podman.md
@@ -1,0 +1,50 @@
+# `podman`
+
+!!! Warning
+
+    `podman` is an experimental command.
+
+Install chezmoi, run `chezmoi init --apply`, and optionally execute your shell
+in podman containers.
+
+## Subcommands
+
+### `exec` *container-id* *init-args*...
+
+Install chezmoi, run `chezmoi init --apply *init-args*`, and execute your shell
+in the existing podman container *container-id*.
+
+#### Flags
+
+#### `-i`, `--interactive`
+
+Keep stdin open even if not attached.
+
+#### `-p`, `--package`
+
+Install chezmoi using the distribution's package manager, if possible.
+Otherwise, fall back to `curl` or `wget` installation. If neither `curl` nor
+`wget` are installed then install them with the distribution's package manager.
+
+#### `-s`, `--shell`
+
+After installing chezmoi, initializing your dotfiles, execute your shell. This
+is the default.
+
+### `run` *image-id* *init-args*...
+
+Create a new podman container using *image-id*, and in it, install chezmoit, run
+`chezmoi init --apply *init-args*`, and execute your shell.
+
+#### `-p`, `--package`
+
+Install chezmoi using the distribution's package manager, if possible.
+Otherwise, fall back to `curl` or `wget` installation. If neither `curl` nor
+`wget` are installed then install them with the distribution's package manager.
+
+## Examples
+
+```sh
+chezmoi podman exec $CONTAINER_ID $GITHUB_USERNAME
+chezmoi podman run alpine:latest $GITHUB_USERNAME
+```

--- a/assets/chezmoi.io/docs/reference/commands/ssh.md
+++ b/assets/chezmoi.io/docs/reference/commands/ssh.md
@@ -1,0 +1,28 @@
+# `ssh` *host* *init-args*...
+
+!!! Warning
+
+    `ssh` is an experimental, potentially destructive, command.
+
+SSH to *host*, install chezmoi, run `chezmoi init --apply *init-args*`, and
+executes your shell.
+
+## Flags
+
+### `-p`, `--package`
+
+Install chezmoi using the distribution's package manager, if possible.
+Otherwise, fall back to `curl` or `wget` installation. If neither `curl` nor
+`wget` are installed then install them with the distribution's package manager.
+
+### `-s`, `--shell`
+
+After installing chezmoi, initializing your dotfiles, execute your shell. This
+is the default.
+
+## Examples
+
+```sh
+chezmoi ssh $HOSTNAME $GITHUB_USERNAME
+chezmoi ssh $HOSTNAME -- --one-shot $GITHUB_USERNAME
+```

--- a/assets/chezmoi.io/mkdocs.yml
+++ b/assets/chezmoi.io/mkdocs.yml
@@ -178,6 +178,7 @@ nav:
     - managed: reference/commands/managed.md
     - merge: reference/commands/merge.md
     - merge-all: reference/commands/merge-all.md
+    - podman: reference/commands/podman.md
     - purge: reference/commands/purge.md
     - re-add: reference/commands/re-add.md
     - remove: reference/commands/remove.md

--- a/assets/chezmoi.io/mkdocs.yml
+++ b/assets/chezmoi.io/mkdocs.yml
@@ -185,6 +185,7 @@ nav:
     - rm: reference/commands/rm.md
     - secret: reference/commands/secret.md
     - source-path: reference/commands/source-path.md
+    - ssh: reference/commands/ssh.md
     - state: reference/commands/state.md
     - status: reference/commands/status.md
     - target-path: reference/commands/target-path.md

--- a/assets/scripts/install-local-bin.sh
+++ b/assets/scripts/install-local-bin.sh
@@ -179,7 +179,7 @@ check_goos_goarch() {
 	windows/386) return 0 ;;
 	windows/amd64) return 0 ;;
 	*)
-		printf '%s: unsupported platform\n' "${1}" 1>&2
+		log_crit '%s: unsupported platform\n' "${1}" 1>&2
 		return 1
 		;;
 	esac

--- a/assets/scripts/install.sh
+++ b/assets/scripts/install.sh
@@ -178,7 +178,7 @@ check_goos_goarch() {
 	windows/386) return 0 ;;
 	windows/amd64) return 0 ;;
 	*)
-		printf '%s: unsupported platform\n' "${1}" 1>&2
+		log_crit '%s: unsupported platform\n' "${1}" 1>&2
 		return 1
 		;;
 	esac

--- a/assets/templates/install-init-shell.sh.tmpl
+++ b/assets/templates/install-init-shell.sh.tmpl
@@ -1,0 +1,89 @@
+#!/bin/sh
+
+# FIXME inline install.sh here instead of using curl | sh
+# FIXME consider using packages to install chezmoi on deb and rpm-based systems
+
+set -e
+
+cd "${HOME}"
+
+is_command() {
+	type "${1}" >/dev/null 2>&1
+}
+
+if [ -n "${LOGNAME}" ]; then
+	username="${LOGNAME}"
+elif [ -n "${USER}" ]; then
+	username="${USER}"
+elif [ -n "${USERNAME}" ]; then
+	username="${USERNAME}"
+elif is_command logname; then
+	username="$(logname)"
+elif is_command whoami; then
+	username="$(whoami)"
+else
+	printf "unable to determine username" 1>&2
+	exit 1
+fi
+
+sudo=
+if [ "${username}" != "root" ]; then
+	sudo="sudo "
+fi
+
+chezmoi=chezmoi
+if ! (is_command chezmoi); then
+	if is_command "${HOME}/.local/bin/chezmoi"; then
+		chezmoi="${HOME}/.local/bin/chezmoi"
+	elif is_command "${HOME}/bin/chezmoi"; then
+		chezmoi="${HOME}/bin/chezmoi"
+{{- if .package }}
+	elif is_command apk; then
+		${sudo}apk add chezmoi
+	elif is_command brew; then
+		${sudo}brew install chezmoi
+	elif is_command pacman; then
+		${sudo}pacman -S chezmoi
+	elif is_command port; then
+		${sudo}port install chezmoi
+	elif is_command nix-env; then
+		${sudo}nix-env -i chezmoi
+	elif is_command snap; then
+		${sudo}snap install chezmoi --classic
+	elif is_command zypper; then
+		${sudo}zypper install chezmoi
+	elif is_command pkg; then
+		${sudo}pkg install chezmoi
+	elif is_command xbps-install; then
+		${sudo}xbps-install -S chezmoi
+{{- end }}
+	elif is_command curl; then
+		sh -c "$(curl -fsSL get.chezmoi.io/lb)"
+		chezmoi="$HOME/.local/bin/chezmoi"
+	elif is_command wget; then
+		sh -c "$(wget -qO- get.chezmoi.io/lb)"
+		chezmoi="$HOME/.local/bin/chezmoi"
+{{- if .package }}
+	elif is_command apt-get; then
+		export DEBIAN_FRONTEND=noninteractive
+		${sudo}apt-get update
+		${sudo}apt-get install --yes curl
+		sh -c "$(curl -fsSL get.chezmoi.io/lb)"
+		chezmoi="$HOME/.local/bin/chezmoi"
+	elif is_command dnf; then
+		${sudo}dnf install curl
+		sh -c "$(curl -fsSL get.chezmoi.io/lb)"
+		chezmoi="$HOME/.local/bin/chezmoi"
+{{- end }}
+	else
+		echo "unable to install chezmoi" 1>&2
+		exit 1
+	fi
+fi
+
+${chezmoi} init --apply {{ .args | quoteList | join " " }}
+{{- if .shell }}
+
+shell="$(awk -F : "\$1 == \"${username}\" { print \$7 }" /etc/passwd)"
+exec "${shell}"
+{{- end }}

--- a/assets/templates/templates.go
+++ b/assets/templates/templates.go
@@ -7,4 +7,7 @@ import _ "embed"
 var CommitMessageTmpl string
 
 //go:embed install.sh
-var InstallSH []byte
+var InstallSh []byte
+
+//go:embed install-init-shell.sh.tmpl
+var InstallInitShellShTmpl []byte

--- a/internal/chezmoi/sourcestate.go
+++ b/internal/chezmoi/sourcestate.go
@@ -796,6 +796,7 @@ type ExecuteTemplateDataOptions struct {
 	Destination     string
 	Data            []byte
 	TemplateOptions TemplateOptions
+	ExtraData       map[string]any
 }
 
 // ExecuteTemplateData returns the result of executing template data.
@@ -822,6 +823,7 @@ func (s *SourceState) ExecuteTemplateData(options ExecuteTemplateDataOptions) ([
 		chezmoiTemplateData["sourceFile"] = options.Name
 		chezmoiTemplateData["targetFile"] = options.Destination
 	}
+	RecursiveMerge(templateData, options.ExtraData)
 
 	result, err := tmpl.Execute(templateData)
 	if errors.Is(err, errReturnEmpty) {

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -209,6 +209,7 @@ type Config struct {
 	managed         managedCmdConfig
 	mergeAll        mergeAllCmdConfig
 	podman          podmanCmdConfig
+	ssh             sshCmdConfig
 	purge           purgeCmdConfig
 	reAdd           reAddCmdConfig
 	secret          secretCmdConfig
@@ -405,6 +406,9 @@ func newConfig(options ...configOption) (*Config, error) {
 				interactive: true,
 				shell:       true,
 			},
+		},
+		ssh: sshCmdConfig{
+			shell: true,
 		},
 		state: stateCmdConfig{
 			data: stateDataCmdConfig{
@@ -1884,6 +1888,7 @@ func (c *Config) newRootCmd() (*cobra.Command, error) {
 		c.newPurgeCmd(),
 		c.newReAddCmd(),
 		c.newRemoveCmd(),
+		c.newSSHCmd(),
 		c.newSecretCmd(),
 		c.newSourcePathCmd(),
 		c.newStateCmd(),

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -208,6 +208,7 @@ type Config struct {
 	init            initCmdConfig
 	managed         managedCmdConfig
 	mergeAll        mergeAllCmdConfig
+	podman          podmanCmdConfig
 	purge           purgeCmdConfig
 	reAdd           reAddCmdConfig
 	secret          secretCmdConfig
@@ -398,6 +399,12 @@ func newConfig(options ...configOption) (*Config, error) {
 		reAdd: reAddCmdConfig{
 			filter:    chezmoi.NewEntryTypeFilter(chezmoi.EntryTypesAll, chezmoi.EntryTypesNone),
 			recursive: true,
+		},
+		podman: podmanCmdConfig{
+			exec: podmanExecCmdConfig{
+				interactive: true,
+				shell:       true,
+			},
 		},
 		state: stateCmdConfig{
 			data: stateDataCmdConfig{
@@ -1873,6 +1880,7 @@ func (c *Config) newRootCmd() (*cobra.Command, error) {
 		c.newManagedCmd(),
 		c.newMergeCmd(),
 		c.newMergeAllCmd(),
+		c.newPodmanCmd(),
 		c.newPurgeCmd(),
 		c.newReAddCmd(),
 		c.newRemoveCmd(),

--- a/internal/cmd/generatecmd.go
+++ b/internal/cmd/generatecmd.go
@@ -1,59 +1,117 @@
 package cmd
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/twpayne/chezmoi/assets/templates"
+	"github.com/twpayne/chezmoi/internal/chezmoi"
 	"github.com/twpayne/chezmoi/internal/chezmoigit"
 )
 
+type generateCmdConfig struct {
+	installInitShellSh generateInstallInitShellShCmdConfig
+}
+
+type generateInstallInitShellShCmdConfig struct {
+	interactive bool
+	_package    bool
+	shell       bool
+}
+
 func (c *Config) newGenerateCmd() *cobra.Command {
 	generateCmd := &cobra.Command{
-		Use:       "generate file",
-		Short:     "Generate a file for use with chezmoi",
-		Long:      mustLongHelp("generate"),
-		Example:   example("generate"),
-		Args:      cobra.ExactArgs(1),
-		ValidArgs: []string{"install.sh"},
-		RunE:      c.runGenerateCmd,
+		Use:     "generate file",
+		Short:   "Generate a file for use with chezmoi",
+		Long:    mustLongHelp("generate"),
+		Example: example("generate"),
+		Annotations: newAnnotations(
+			persistentStateModeNone,
+		),
+	}
+
+	generateGitCommitMessageCmd := &cobra.Command{
+		Use:   "git-commit-message",
+		Short: "Generate a git commit message",
+		Args:  cobra.NoArgs,
+		RunE:  c.runGenerateGitCommitMessageCmd,
+		Annotations: newAnnotations(
+			persistentStateModeNone,
+		),
+	}
+	generateCmd.AddCommand(generateGitCommitMessageCmd)
+
+	generateInstallShCmd := &cobra.Command{
+		Use:   "install.sh",
+		Short: "Generate an install script",
+		Args:  cobra.NoArgs,
+		RunE:  c.runGenerateInstallShCmd,
 		Annotations: newAnnotations(
 			doesNotRequireValidConfig,
 			persistentStateModeNone,
 		),
 	}
+	generateCmd.AddCommand(generateInstallShCmd)
+
+	generateInstallInitShellShCmd := &cobra.Command{
+		Use:   "install-init-shell.sh",
+		Short: "Generate an install script that also executes a shell",
+		Args:  cobra.MinimumNArgs(1),
+		RunE:  c.makeRunEWithSourceState(c.runGenerateInstallInitShellShCmd),
+		Annotations: newAnnotations(
+			persistentStateModeReadWrite,
+		),
+	}
+	generateInstallInitShellShCmd.Flags().
+		BoolVarP(&c.generate.installInitShellSh.interactive, "interactive", "i", c.generate.installInitShellSh.interactive, "Set interactive")
+	generateInstallInitShellShCmd.Flags().
+		BoolVarP(&c.generate.installInitShellSh.shell, "package", "p", c.generate.installInitShellSh._package, "Install with package")
+	generateInstallInitShellShCmd.Flags().
+		BoolVarP(&c.generate.installInitShellSh.shell, "shell", "s", c.generate.installInitShellSh.shell, "Set shell")
+	generateCmd.AddCommand(generateInstallInitShellShCmd)
 
 	return generateCmd
 }
 
-func (c *Config) runGenerateCmd(cmd *cobra.Command, args []string) error {
+func (c *Config) runGenerateGitCommitMessageCmd(cmd *cobra.Command, args []string) error {
 	builder := strings.Builder{}
 	builder.Grow(16384)
-	switch args[0] {
-	case "git-commit-message":
-		output, err := c.cmdOutput(c.WorkingTreeAbsPath, c.Git.Command, []string{"status", "--porcelain=v2"})
-		if err != nil {
-			return err
-		}
-		status, err := chezmoigit.ParseStatusPorcelainV2(output)
-		if err != nil {
-			return err
-		}
-		data, err := c.gitCommitMessage(cmd, status)
-		if err != nil {
-			return err
-		}
-		if _, err := builder.Write(data); err != nil {
-			return err
-		}
-	case "install.sh":
-		if _, err := builder.Write(templates.InstallSH); err != nil {
-			return err
-		}
-	default:
-		return fmt.Errorf("%s: unsupported file", args[0])
+	output, err := c.cmdOutput(c.WorkingTreeAbsPath, c.Git.Command, []string{"status", "--porcelain=v2"})
+	if err != nil {
+		return err
+	}
+	status, err := chezmoigit.ParseStatusPorcelainV2(output)
+	if err != nil {
+		return err
+	}
+	data, err := c.gitCommitMessage(cmd, status)
+	if err != nil {
+		return err
+	}
+	if _, err := builder.Write(data); err != nil {
+		return err
 	}
 	return c.writeOutputString(builder.String(), 0o666)
+}
+
+func (c *Config) runGenerateInstallShCmd(cmd *cobra.Command, args []string) error {
+	return c.writeOutput(templates.InstallSh, 0o777)
+}
+
+func (c *Config) runGenerateInstallInitShellShCmd(cmd *cobra.Command, args []string, sourceState *chezmoi.SourceState) error {
+	script, err := sourceState.ExecuteTemplateData(chezmoi.ExecuteTemplateDataOptions{
+		Name: "install-init-shell.sh.tmpl",
+		Data: templates.InstallInitShellShTmpl,
+		ExtraData: map[string]any{
+			"args":        args,
+			"interactive": c.generate.installInitShellSh.interactive,
+			"package":     c.generate.installInitShellSh._package,
+			"shell":       c.generate.installInitShellSh.shell,
+		},
+	})
+	if err != nil {
+		return err
+	}
+	return c.writeOutput(script, 0o777)
 }

--- a/internal/cmd/helps.gen.go
+++ b/internal/cmd/helps.gen.go
@@ -685,6 +685,14 @@ var helps = map[string]*help{
 			"r",
 		),
 	},
+	"podman": {
+		longHelp: "" +
+			"Description:\n" +
+			"",
+		example: "" +
+			"  chezmoi podman exec $CONTAINER_ID $GITHUB_USERNAME\n" +
+			"  chezmoi podman run alpine:latest $GITHUB_USERNAME",
+	},
 	"purge": {
 		longHelp: "" +
 			"Description:\n" +

--- a/internal/cmd/helps.gen.go
+++ b/internal/cmd/helps.gen.go
@@ -446,15 +446,18 @@ var helps = map[string]*help{
 			"Description:\n" +
 			"  Generates output for use with chezmoi. The currently supported outputs are:\n" +
 			"\n" +
-			"   Output             | Description\n" +
-			"  --------------------|-----------------------------------------------------\n" +
-			"   git-commit-message | A git commit message, describing the changes to the\n" +
-			"                      | source directory.\n" +
-			"   install.sh         | An install script, suitable for use with GitHub\n" +
-			"                      | Codespaces",
+			"   Output                | Description\n" +
+			"  -----------------------|--------------------------------------------------\n" +
+			"   git-commit-message    | A git commit message, describing the changes to\n" +
+			"                         | the source directory.\n" +
+			"   install.sh            | An install script, suitable for use with GitHub\n" +
+			"                         | Codespaces\n" +
+			"   install-init-shell.sh | A script which installs chezmoi, runs chezmoi\n" +
+			"                         | init, and executes your shell",
 		example: "" +
 			"  chezmoi generate install.sh > install.sh\n" +
-			"  chezmoi git commit -m \"$(chezmoi generate git-commit-message)\"",
+			"  chezmoi git commit -m \"$(chezmoi generate git-commit-message)\"\n" +
+			"  chezmoi generate install-init-shell.sh $GITHUB_USERNAME",
 	},
 	"git": {
 		longHelp: "" +

--- a/internal/cmd/helps.gen.go
+++ b/internal/cmd/helps.gen.go
@@ -766,6 +766,22 @@ var helps = map[string]*help{
 			"  chezmoi source-path\n" +
 			"  chezmoi source-path ~/.bashrc",
 	},
+	"ssh": {
+		longHelp: "" +
+			"Description:\n" +
+			"",
+		example: "" +
+			"  chezmoi ssh $HOSTNAME $GITHUB_USERNAME\n" +
+			"  chezmoi ssh $HOSTNAME -- --one-shot $GITHUB_USERNAME",
+		longFlags: chezmoiset.New(
+			"package",
+			"shell",
+		),
+		shortFlags: chezmoiset.New(
+			"p",
+			"s",
+		),
+	},
 	"state": {
 		longHelp: "" +
 			"Description:\n" +

--- a/internal/cmd/podmancmd.go
+++ b/internal/cmd/podmancmd.go
@@ -1,0 +1,93 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/twpayne/chezmoi/internal/chezmoi"
+)
+
+type podmanCmdConfig struct {
+	exec podmanExecCmdConfig
+	run  podmanRunCmdConfig
+}
+
+type podmanExecCmdConfig struct {
+	interactive bool
+	_package    bool
+	shell       bool
+}
+
+type podmanRunCmdConfig struct {
+	_package bool
+}
+
+func (c *Config) newPodmanCmd() *cobra.Command {
+	podmanCmd := &cobra.Command{
+		Use:   "podman",
+		Short: "Install chezmoi and your dotfiles in a podman container",
+		Annotations: newAnnotations(
+			persistentStateModeNone,
+		),
+	}
+
+	podmanExecCmd := &cobra.Command{
+		Use:   "exec container-id [args...]",
+		Short: "Install chezmoi and your dotfiles in an existing podman container",
+		Args:  cobra.MinimumNArgs(1),
+		RunE:  c.makeRunEWithSourceState(c.runPodmanExecCmd),
+		Annotations: newAnnotations(
+			persistentStateModeReadWrite,
+		),
+	}
+	podmanExecCmd.Flags().
+		BoolVarP(&c.podman.exec.interactive, "interactive", "i", c.podman.exec.interactive, "Run interactively")
+	podmanExecCmd.Flags().BoolVarP(&c.podman.exec._package, "package", "p", c.podman.exec._package, "Install with package")
+	podmanExecCmd.Flags().BoolVarP(&c.podman.exec.shell, "shell", "s", c.podman.exec.shell, "Execute shell afterwards")
+	podmanCmd.AddCommand(podmanExecCmd)
+
+	podmanRunCmd := &cobra.Command{
+		Use:   "run image-id [args...]",
+		Short: "Install chezmoi and your dotfiles in a new podman container",
+		Args:  cobra.MinimumNArgs(1),
+		RunE:  c.makeRunEWithSourceState(c.runPodmanRun),
+		Annotations: newAnnotations(
+			persistentStateModeReadWrite,
+		),
+	}
+	podmanRunCmd.Flags().BoolVarP(&c.podman.run._package, "package", "p", c.podman.run._package, "Install with package")
+	podmanCmd.AddCommand(podmanRunCmd)
+
+	return podmanCmd
+}
+
+func (c *Config) runPodmanExecCmd(cmd *cobra.Command, args []string, sourceState *chezmoi.SourceState) error {
+	podmanArgs := []string{"exec"}
+	if c.podman.exec.interactive {
+		podmanArgs = append(podmanArgs,
+			"--interactive",
+			"--tty",
+		)
+	}
+	podmanArgs = append(podmanArgs, args[0])
+	return c.runInstallInitShellSh(sourceState,
+		"podman", podmanArgs,
+		runInstallInitShellOptions{
+			args:        args[1:],
+			interactive: c.podman.exec.interactive,
+			_package:    c.podman.exec._package,
+			shell:       c.podman.exec.shell,
+		},
+	)
+}
+
+func (c *Config) runPodmanRun(cmd *cobra.Command, args []string, sourceState *chezmoi.SourceState) error {
+	return c.runInstallInitShellSh(sourceState,
+		"podman", []string{"run", "--interactive", "--tty", args[0]},
+		runInstallInitShellOptions{
+			args:        args[1:],
+			interactive: true,
+			_package:    c.podman.run._package,
+			shell:       true,
+		},
+	)
+}

--- a/internal/cmd/sshcmd.go
+++ b/internal/cmd/sshcmd.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/twpayne/chezmoi/internal/chezmoi"
+)
+
+type sshCmdConfig struct {
+	_package bool
+	shell    bool
+}
+
+func (c *Config) newSSHCmd() *cobra.Command {
+	sshCmd := &cobra.Command{
+		Use:     "ssh host",
+		Short:   "ssh to a host and initialize dotfiles",
+		Long:    mustLongHelp("ssh"),
+		Example: example("ssh"),
+		Args:    cobra.MinimumNArgs(1),
+		RunE:    c.makeRunEWithSourceState(c.runSSHCmd),
+		Annotations: newAnnotations(
+			persistentStateModeReadWrite,
+		),
+	}
+	sshCmd.Flags().BoolVarP(&c.ssh._package, "package", "p", c.ssh._package, "Install with package")
+	sshCmd.Flags().BoolVarP(&c.ssh.shell, "shell", "s", c.ssh.shell, "Execute shell afterwards")
+
+	return sshCmd
+}
+
+func (c *Config) runSSHCmd(cmd *cobra.Command, args []string, sourceState *chezmoi.SourceState) error {
+	return c.runInstallInitShellSh(sourceState,
+		"ssh", []string{args[0]},
+		runInstallInitShellOptions{
+			args:        args[1:],
+			interactive: true,
+			_package:    c.ssh._package,
+			shell:       c.ssh.shell,
+		},
+	)
+}

--- a/internal/cmd/templatefuncs.go
+++ b/internal/cmd/templatefuncs.go
@@ -384,9 +384,13 @@ func (c *Config) squoteTemplateFunc(list ...any) string {
 	return strings.Join(ss, " ")
 }
 
-func (c *Config) quoteListTemplateFunc(list []any) []string {
-	result := make([]string, len(list))
-	for i, elem := range list {
+func (c *Config) quoteListTemplateFunc(list any) []string {
+	stringSlice, err := anyToStringSlice(list)
+	if err != nil {
+		panic(err)
+	}
+	result := make([]string, len(stringSlice))
+	for i, elem := range stringSlice {
 		result[i] = strconv.Quote(anyToString(elem))
 	}
 	return result

--- a/internal/cmds/generate-install.sh/install.sh.tmpl
+++ b/internal/cmds/generate-install.sh/install.sh.tmpl
@@ -163,7 +163,7 @@ check_goos_goarch() {
 	{{ .GOOS }}/{{ .GOARCH }}) return 0 ;;
 {{- end }}
 	*)
-		printf '%s: unsupported platform\n' "${1}" 1>&2
+		log_crit '%s: unsupported platform\n' "${1}" 1>&2
 		return 1
 		;;
 	esac


### PR DESCRIPTION
Fixes #1410.
Fixes #3676.

This is a draft PR, but basically allows you to connect to a remote machine or container and get your shell with your dotfiles installed all in a single command:

```bash
# start a new container from $IMAGE_ID, install chezmoi,
# run chezmoi init --apply $GITHUB_USERNAME, and exec your shell
chezmoi podman run $IMAGE_ID $GITHUB_USERNAME

# start a new shell in an existing container, install chezmoi,
# run chezmoi init --apply $GITHUB_USERNAME, and exec your shell
chezmoi podman exec $CONTAINER_ID $GITHUB_USERNAME

# ssh into $HOSTNAME, install chezmoi,
# run chezmoi init --apply $GITHUB_USERNAME, and exec your shell
chezmoi ssh $HOSTNAME $GITHUB_USERNAME
```

This means, that, for example, I can test my dotfiles in a new, Ubuntu container with:

```bash
chezmoi podman run ubuntu:latest twpayne
```

Or, if I want to login to some host and have my shell and my dotfiles, I can do:

```bash
chezmoi ssh hostname twpayne
```

**Please be really careful with the `chezmoi ssh` command**. This will overwrite your dotfiles in the machine you SSH into, and may do other damage to the target machine. Please, only use it on machines that you don't mind destroying!

Credit to @cdown's https://github.com/cdown/sshrc (originally authored by @Russell91) for the idea of running a shell script to install your dotfiles on the remote machine. The major difference with sshrc is that sshrc only handles a few static files, whereas the `chezmoi ssh` and `chezmoi podman` give you the full power of chezmoi.

This PR is ready for testing, but still needs a few more things completed before it's ready to merge:

* [ ] Testing on more UNIX-y distributions (I've only really test Ubuntu and Alpine in podman containers so far)
* [x] Complete documentation
* [ ] Add a `chezmoi docker` command, equivalent to `chezmoi podman`, except using Docker

All feedback welcome!