### PR TITLE
feat: Add support for specifying a SHA with git-repo

### DIFF
--- a/assets/chezmoi.io/docs/reference/special-files/chezmoiexternal-format.md
+++ b/assets/chezmoi.io/docs/reference/special-files/chezmoiexternal-format.md
@@ -48,6 +48,7 @@ Entries may have the following fields:
 | `checksum.sha512`            | string   | *none*        | Expected SHA512 checksum of data                                 |
 | `checksum.size`              | int      | *none*        | Expected size of data                                            |
 | `clone.args`                 | []string | *none*        | Extra args to `git clone`                                        |
+| `commit`                     | string   | *none*        | Git commit SHA to checkout for `git-repo` type                   |
 | `filter.command`             | string   | *none*        | Command to filter contents                                       |
 | `filter.args`                | []string | *none*        | Extra args to command to filter contents                         |
 | `pull.args`                  | []string | *none*        | Extra args to `git pull`                                         |

--- a/internal/cmd/testdata/scripts/externalgitrepocommit.txtar
+++ b/internal/cmd/testdata/scripts/externalgitrepocommit.txtar
@@ -1,0 +1,55 @@
+[windows] skip 'UNIX only'
+[!exec:git] skip 'git not found in $PATH'
+
+mkgitconfig
+expandenv $WORK/home/user/.local/share/chezmoi/.chezmoiexternal.toml
+
+# create a git repo with multiple commits
+cd $WORK/repo
+exec git init
+exec git add .
+exec git commit --message 'initial commit'
+edit $WORK/repo/.file
+exec git commit --message 'second commit' .
+# add one more commit to make it clear we're not at HEAD
+exec git commit --allow-empty --message 'third commit'
+cd $WORK
+
+# test that chezmoi apply clones the git repo at specific commit (HEAD~1)
+exec chezmoi apply
+cmp $HOME/.dir/.file golden/.file-edited
+
+# verify that the repo was cloned and we're NOT at the latest commit
+cd $HOME/.dir
+exec git log --oneline
+! stdout 'third commit'
+stdout 'second commit'
+cd $WORK
+
+# test that chezmoi managed lists the directory
+exec chezmoi managed
+stdout ^\.dir$
+
+# test that subsequent apply doesn't change the commit (no pull since commit is specified)
+cd $WORK/repo
+exec git commit --allow-empty --message 'fourth commit'
+cd $WORK
+exec chezmoi apply
+cd $HOME/.dir
+exec git log --oneline
+! stdout 'fourth commit'
+! stdout 'third commit'
+stdout 'second commit'
+
+-- golden/.file --
+# contents of .file
+-- golden/.file-edited --
+# contents of .file
+# edited
+-- home/user/.local/share/chezmoi/.chezmoiexternal.toml --
+[".dir"]
+    type = "git-repo"
+    url = "file://$WORK/repo"
+    commit = "HEAD~1"
+-- repo/.file --
+# contents of .file


### PR DESCRIPTION
I ran into a performance issue while trying to use `.chezmoiexternal.toml`. I wanted to use a tarball at a specific git SHA:

```
[".icons/dracula-icons"]
exact = true
type = "archive"
stripComponents = 1
url = "https://github.com/m4thewz/dracula-icons/archive/de2a8edd94608ba0ac4dcf5a187af0ffaa511ebc.tar.gz"
```

However, I think the `archive` implementation is creating individual `SourceStateFile` entries for every single file in the archive. Then during `chezmoi apply`, each file gets processed individually with its own diff calculation. The tarball above is around 70MB and can take minutes to apply.

The easiest fix was to allow cloning and checking out at a specific git SHA:

```
[".icons/dracula-icons"]
commit = "de2a8edd94608ba0ac4dcf5a187af0ffaa511ebc"
type = "git-repo"
url = "https://github.com/m4thewz/dracula-icons.git"
```

This is implemented in the PR.

Note: I am not particularly familiar with the chezmoi code and wanted to make my change as minimal as possible. As such, I strung `git clone` and `git checkout` commands in a shell. The reliance on `sh` makes it platform-dependent.