### PR TITLE
docs: add Fedora and RHEL install commands

### DIFF
--- a/assets/chezmoi.io/docs/install.md.tmpl
+++ b/assets/chezmoi.io/docs/install.md.tmpl
@@ -23,6 +23,12 @@ Install chezmoi with your package manager with a single command:
         pacman -S chezmoi
         ```
 
+    === "Fedora"
+
+        ```sh
+        dnf install chezmoi
+        ```
+
     === "NixOS"
 
         ```sh
@@ -33,6 +39,12 @@ Install chezmoi with your package manager with a single command:
 
         ```sh
         zypper install chezmoi
+        ```
+
+    === "RHEL (EPEL)"
+
+        ```sh
+        dnf install epel-release && dnf install chezmoi
         ```
 
     === "Termux"


### PR DESCRIPTION
Packages have been built for all current Fedora releases and EPEL9 & EPEL10, they will land in stable in a few days: https://bodhi.fedoraproject.org/updates/?packages=chezmoi
