### PR TITLE
docs: Update link to star chezmoi

### DIFF
--- a/assets/chezmoi.io/docs/index.md.tmpl
+++ b/assets/chezmoi.io/docs/index.md.tmpl
@@ -97,7 +97,7 @@ to a charity or cause of your choice.
 [reference]: /reference/index.md
 [repos]: /links/dotfile-repos.md
 [share]: /links/social-media.md
-[star]: https://github.com/twpayne/chezmoi/stargazers
+[star]: https://github.com/twpayne/chezmoi
 [support]: https://github.com/twpayne/chezmoi/issues/new?assignees=&labels=support&projects=&template=01_support_request.md&title=.
 [tag]: /links/dotfile-repos.md
 [videos]: /links/videos.md


### PR DESCRIPTION
There is not a button to star on `/stargazers` page, so I changed it to go to homepage.

<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer-guide/contributing-changes/

-->
