### PR TITLE
chore: update snap base

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -288,6 +288,7 @@ snapcrafts:
   grade: stable
   confinement: classic
   license: MIT
+  base: bare
   apps:
     chezmoi:
       command: chezmoi


### PR DESCRIPTION
remove snap dependency on obsolete core base

Using the `bare` base for this Works On My Machine. I don't know enough about go builds to know if that's sufficient. `core24` would be a more conservative choice.

See https://documentation.ubuntu.com/snapcraft/stable/reference/bases/#base-snap-reference

Fixes #4671


