### PR TITLE
Better help

### DIFF
--- a/internal/cmd/addcmd.go
+++ b/internal/cmd/addcmd.go
@@ -39,6 +39,7 @@ type addCmdConfig struct {
 
 func (c *Config) newAddCmd() *cobra.Command {
 	addCmd := &cobra.Command{
+		GroupID: groupIDDaily,
 		Use:     "add targets...",
 		Aliases: []string{"manage"},
 		Short:   "Add an existing file, directory, or symlink to the source state",

--- a/internal/cmd/agecmd.go
+++ b/internal/cmd/agecmd.go
@@ -25,9 +25,10 @@ type ageCmdConfig struct {
 
 func (c *Config) newAgeCmd() *cobra.Command {
 	ageCmd := &cobra.Command{
-		Use:   "age",
-		Args:  cobra.NoArgs,
-		Short: "Interact with age",
+		GroupID: groupIDEncryption,
+		Use:     "age",
+		Args:    cobra.NoArgs,
+		Short:   "Interact with age",
 		Annotations: newAnnotations(
 			persistentStateModeReadOnly,
 		),

--- a/internal/cmd/agekeygencmd.go
+++ b/internal/cmd/agekeygencmd.go
@@ -21,6 +21,7 @@ type ageKeygenCmdConfig struct {
 
 func (c *Config) newAgeKeygenCmd() *cobra.Command {
 	ageKeygenCommand := &cobra.Command{
+		GroupID: groupIDEncryption,
 		Use:     "age-keygen",
 		Args:    cobra.MaximumNArgs(1),
 		Short:   "Generate an age identity or convert an age identity to an age recipient",

--- a/internal/cmd/applycmd.go
+++ b/internal/cmd/applycmd.go
@@ -15,6 +15,7 @@ type applyCmdConfig struct {
 
 func (c *Config) newApplyCmd() *cobra.Command {
 	applyCmd := &cobra.Command{
+		GroupID:           groupIDDaily,
 		Use:               "apply [target]...",
 		Short:             "Update the destination directory to match the target state",
 		Long:              mustLongHelp("apply"),

--- a/internal/cmd/archivecmd.go
+++ b/internal/cmd/archivecmd.go
@@ -27,6 +27,7 @@ type archiveCmdConfig struct {
 
 func (c *Config) newArchiveCmd() *cobra.Command {
 	archiveCmd := &cobra.Command{
+		GroupID:           groupIDMigration,
 		Use:               "archive [target]...",
 		Short:             "Generate a tar archive of the target state",
 		Long:              mustLongHelp("archive"),

--- a/internal/cmd/catcmd.go
+++ b/internal/cmd/catcmd.go
@@ -11,6 +11,7 @@ import (
 
 func (c *Config) newCatCmd() *cobra.Command {
 	catCmd := &cobra.Command{
+		GroupID:           groupIDTemplate,
 		Use:               "cat target...",
 		Short:             "Print the target contents of a file, script, or symlink",
 		Long:              mustLongHelp("cat"),

--- a/internal/cmd/catconfigcmd.go
+++ b/internal/cmd/catconfigcmd.go
@@ -4,6 +4,7 @@ import "github.com/spf13/cobra"
 
 func (c *Config) newCatConfigCmd() *cobra.Command {
 	catConfigCmd := &cobra.Command{
+		GroupID:           groupIDInternal,
 		Use:               "cat-config",
 		Short:             "Print the configuration file",
 		Long:              mustLongHelp("cat-config"),

--- a/internal/cmd/cdcmd.go
+++ b/internal/cmd/cdcmd.go
@@ -17,6 +17,7 @@ type cdCmdConfig struct {
 
 func (c *Config) newCDCmd() *cobra.Command {
 	cdCmd := &cobra.Command{
+		GroupID: groupIDAdvanced,
 		Use:     "cd [path]",
 		Short:   "Launch a shell in the source directory",
 		Long:    mustLongHelp("cd"),

--- a/internal/cmd/chattrcmd.go
+++ b/internal/cmd/chattrcmd.go
@@ -75,6 +75,7 @@ type modifier struct {
 
 func (c *Config) newChattrCmd() *cobra.Command {
 	chattrCmd := &cobra.Command{
+		GroupID:           groupIDDaily,
 		Use:               "chattr attributes target...",
 		Short:             "Change the attributes of a target in the source state",
 		Long:              mustLongHelp("chattr"),

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -130,6 +130,14 @@ func mustLongHelp(command string) string {
 	return help.longHelp
 }
 
+// ensureHasGroupID ensures that cmd has a GroupID set, unless it has the
+// explicit "hidden" annotation.
+func ensureHasGroupID(cmd *cobra.Command) {
+	if cmd.GroupID == "" && !cmd.Hidden {
+		panic(cmd.Name() + ": missing group ID")
+	}
+}
+
 // ensureAllFlagsDocumented ensures that all flags are documented, unless
 // ignoreflags=1 is set in the CHEZMOIDEV environment variable.
 func ensureAllFlagsDocumented(cmd *cobra.Command, persistentFlags *pflag.FlagSet) {

--- a/internal/cmd/completioncmd.go
+++ b/internal/cmd/completioncmd.go
@@ -13,6 +13,7 @@ type completionCmdConfig struct {
 
 func (c *Config) newCompletionCmd() *cobra.Command {
 	completionCmd := &cobra.Command{
+		GroupID:   groupIDInternal,
 		Use:       "completion shell",
 		Short:     "Generate shell completion code",
 		Args:      cobra.ExactArgs(1),

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -67,6 +67,28 @@ const (
 	logComponentValueSystem          = "system"
 )
 
+const (
+	groupIDAdvanced      = "advanced"
+	groupIDDaily         = "daily"
+	groupIDDocumentation = "documentation"
+	groupIDEncryption    = "encryption"
+	groupIDInternal      = "internal"
+	groupIDMigration     = "migration"
+	groupIDRemote        = "remote"
+	groupIDTemplate      = "template"
+)
+
+var groups = []*cobra.Group{
+	{ID: groupIDDocumentation, Title: "Documentation commands:"},
+	{ID: groupIDDaily, Title: "Daily commands:"},
+	{ID: groupIDTemplate, Title: "Template commands:"},
+	{ID: groupIDAdvanced, Title: "Advanced commands:"},
+	{ID: groupIDEncryption, Title: "Encryption commands:"},
+	{ID: groupIDRemote, Title: "Remote commands:"},
+	{ID: groupIDMigration, Title: "Migration commands:"},
+	{ID: groupIDInternal, Title: "Internal commands:"},
+}
+
 type doPurgeOptions struct {
 	binary          bool
 	cache           bool
@@ -1791,6 +1813,7 @@ func (c *Config) newRootCmd() (*cobra.Command, error) {
 		SilenceErrors:      true,
 		SilenceUsage:       true,
 	}
+	rootCmd.AddGroup(groups...)
 
 	persistentFlags := rootCmd.PersistentFlags()
 
@@ -1894,6 +1917,7 @@ func (c *Config) newRootCmd() (*cobra.Command, error) {
 		c.newVerifyCmd(),
 	} {
 		if cmd != nil {
+			ensureHasGroupID(cmd)
 			ensureAllFlagsDocumented(cmd, persistentFlags)
 			registerCommonFlagCompletionFuncs(cmd)
 			rootCmd.AddCommand(cmd)

--- a/internal/cmd/datacmd.go
+++ b/internal/cmd/datacmd.go
@@ -14,6 +14,7 @@ type dataCmdConfig struct {
 
 func (c *Config) newDataCmd() *cobra.Command {
 	dataCmd := &cobra.Command{
+		GroupID:           groupIDTemplate,
 		Use:               "data",
 		Short:             "Print the template data",
 		Long:              mustLongHelp("data"),

--- a/internal/cmd/decryptcmd.go
+++ b/internal/cmd/decryptcmd.go
@@ -6,6 +6,7 @@ import (
 
 func (c *Config) newDecryptCommand() *cobra.Command {
 	decryptCmd := &cobra.Command{
+		GroupID: groupIDEncryption,
 		Use:     "decrypt [file...]",
 		Short:   "Decrypt file or standard input",
 		Long:    mustLongHelp("decrypt"),

--- a/internal/cmd/destroycmd.go
+++ b/internal/cmd/destroycmd.go
@@ -16,6 +16,7 @@ type destroyCmdConfig struct {
 
 func (c *Config) newDestroyCmd() *cobra.Command {
 	destroyCmd := &cobra.Command{
+		GroupID:           groupIDMigration,
 		Use:               "destroy target...",
 		Short:             "Permanently delete an entry from the source state, the destination directory, and the state",
 		Long:              mustLongHelp("destroy"),

--- a/internal/cmd/diffcmd.go
+++ b/internal/cmd/diffcmd.go
@@ -22,6 +22,7 @@ type diffCmdConfig struct {
 
 func (c *Config) newDiffCmd() *cobra.Command {
 	diffCmd := &cobra.Command{
+		GroupID:           groupIDDaily,
 		Use:               "diff [target]...",
 		Short:             "Print the diff between the target state and the destination state",
 		Long:              mustLongHelp("diff"),

--- a/internal/cmd/dockercmd.go
+++ b/internal/cmd/dockercmd.go
@@ -24,8 +24,9 @@ type dockerRunCmdConfig struct {
 
 func (c *Config) newDockerCmd() *cobra.Command {
 	commandCmd := &cobra.Command{
-		Use:   "docker",
-		Short: "Use your dotfiles in a Docker container",
+		GroupID: groupIDRemote,
+		Use:     "docker",
+		Short:   "Use your dotfiles in a Docker container",
 		Annotations: newAnnotations(
 			persistentStateModeNone,
 		),

--- a/internal/cmd/doctorcmd.go
+++ b/internal/cmd/doctorcmd.go
@@ -150,6 +150,7 @@ type doctorCmdConfig struct {
 
 func (c *Config) newDoctorCmd() *cobra.Command {
 	doctorCmd := &cobra.Command{
+		GroupID:           groupIDDocumentation,
 		Args:              cobra.NoArgs,
 		ValidArgsFunction: cobra.NoFileCompletions,
 		Use:               "doctor",

--- a/internal/cmd/dumpcmd.go
+++ b/internal/cmd/dumpcmd.go
@@ -18,6 +18,7 @@ type dumpCmdConfig struct {
 
 func (c *Config) newDumpCmd() *cobra.Command {
 	dumpCmd := &cobra.Command{
+		GroupID:           groupIDInternal,
 		Use:               "dump [target]...",
 		Short:             "Generate a dump of the target state",
 		Long:              mustLongHelp("dump"),

--- a/internal/cmd/dumpconfigcmd.go
+++ b/internal/cmd/dumpconfigcmd.go
@@ -12,6 +12,7 @@ type dumpConfigCmdConfig struct {
 
 func (c *Config) newDumpConfigCmd() *cobra.Command {
 	dumpConfigCmd := &cobra.Command{
+		GroupID:           groupIDInternal,
 		Use:               "dump-config",
 		Short:             "Dump the configuration values",
 		Long:              mustLongHelp("dump-config"),

--- a/internal/cmd/editcmd.go
+++ b/internal/cmd/editcmd.go
@@ -27,6 +27,7 @@ type editCmdConfig struct {
 
 func (c *Config) newEditCmd() *cobra.Command {
 	editCmd := &cobra.Command{
+		GroupID:           groupIDDaily,
 		Use:               "edit targets...",
 		Short:             "Edit the source state of a target",
 		Long:              mustLongHelp("edit"),

--- a/internal/cmd/editconfigcmd.go
+++ b/internal/cmd/editconfigcmd.go
@@ -6,6 +6,7 @@ import (
 
 func (c *Config) newEditConfigCmd() *cobra.Command {
 	editConfigCmd := &cobra.Command{
+		GroupID:           groupIDAdvanced,
 		Use:               "edit-config",
 		Short:             "Edit the configuration file",
 		Long:              mustLongHelp("edit-config"),

--- a/internal/cmd/editconfigtemplatecmd.go
+++ b/internal/cmd/editconfigtemplatecmd.go
@@ -11,6 +11,7 @@ import (
 
 func (c *Config) newEditConfigTemplateCmd() *cobra.Command {
 	editConfigCmd := &cobra.Command{
+		GroupID:           groupIDAdvanced,
 		Use:               "edit-config-template",
 		Short:             "Edit the configuration file template",
 		Long:              mustLongHelp("edit-config-template"),

--- a/internal/cmd/encryptcmd.go
+++ b/internal/cmd/encryptcmd.go
@@ -6,6 +6,7 @@ import (
 
 func (c *Config) newEncryptCmd() *cobra.Command {
 	encryptCmd := &cobra.Command{
+		GroupID: groupIDEncryption,
 		Use:     "encrypt [file...]",
 		Short:   "Encrypt file or standard input",
 		Long:    mustLongHelp("encrypt"),

--- a/internal/cmd/executetemplatecmd.go
+++ b/internal/cmd/executetemplatecmd.go
@@ -28,6 +28,7 @@ type executeTemplateCmdConfig struct {
 
 func (c *Config) newExecuteTemplateCmd() *cobra.Command {
 	executeTemplateCmd := &cobra.Command{
+		GroupID: groupIDTemplate,
 		Use:     "execute-template [template]...",
 		Short:   "Execute the given template(s)",
 		Long:    mustLongHelp("execute-template"),

--- a/internal/cmd/forgetcmd.go
+++ b/internal/cmd/forgetcmd.go
@@ -10,6 +10,7 @@ import (
 
 func (c *Config) newForgetCmd() *cobra.Command {
 	forgetCmd := &cobra.Command{
+		GroupID:           groupIDDaily,
 		Use:               "forget target...",
 		Aliases:           []string{"unmanage"},
 		Short:             "Remove a target from the source state",

--- a/internal/cmd/generatecmd.go
+++ b/internal/cmd/generatecmd.go
@@ -22,6 +22,7 @@ type generateInstallInitShellShCmdConfig struct {
 
 func (c *Config) newGenerateCmd() *cobra.Command {
 	generateCmd := &cobra.Command{
+		GroupID: groupIDAdvanced,
 		Use:     "generate file",
 		Short:   "Generate a file for use with chezmoi",
 		Long:    mustLongHelp("generate"),

--- a/internal/cmd/gitcmd.go
+++ b/internal/cmd/gitcmd.go
@@ -16,6 +16,7 @@ type gitCmdConfig struct {
 
 func (c *Config) newGitCmd() *cobra.Command {
 	gitCmd := &cobra.Command{
+		GroupID: groupIDAdvanced,
 		Use:     "git [arg]...",
 		Short:   "Run git in the source directory",
 		Long:    mustLongHelp("git"),

--- a/internal/cmd/helpcmd.go
+++ b/internal/cmd/helpcmd.go
@@ -9,6 +9,7 @@ import (
 
 func (c *Config) newHelpCmd() *cobra.Command {
 	helpCmd := &cobra.Command{
+		GroupID:           groupIDDocumentation,
 		Use:               "help [command]",
 		Short:             "Print help about a command",
 		Long:              mustLongHelp("help"),

--- a/internal/cmd/ignoredcmd.go
+++ b/internal/cmd/ignoredcmd.go
@@ -13,6 +13,7 @@ type ignoredCmdConfig struct {
 
 func (c *Config) newIgnoredCmd() *cobra.Command {
 	ignoredCmd := &cobra.Command{
+		GroupID:           groupIDAdvanced,
 		Use:               "ignored",
 		Short:             "Print ignored targets",
 		Long:              mustLongHelp("ignored"),

--- a/internal/cmd/importcmd.go
+++ b/internal/cmd/importcmd.go
@@ -18,6 +18,7 @@ type importCmdConfig struct {
 
 func (c *Config) newImportCmd() *cobra.Command {
 	importCmd := &cobra.Command{
+		GroupID: groupIDMigration,
 		Use:     "import archive",
 		Short:   "Import an archive into the source state",
 		Long:    mustLongHelp("import"),

--- a/internal/cmd/initcmd.go
+++ b/internal/cmd/initcmd.go
@@ -86,6 +86,7 @@ type gitCloneOptionsLogValuer git.CloneOptions
 
 func (c *Config) newInitCmd() *cobra.Command {
 	initCmd := &cobra.Command{
+		GroupID: groupIDDaily,
 		Args:    cobra.MaximumNArgs(1),
 		Use:     "init [repo]",
 		Short:   "Setup the source directory and update the destination directory to match the target state",

--- a/internal/cmd/licensecmd.go
+++ b/internal/cmd/licensecmd.go
@@ -6,6 +6,7 @@ import (
 
 func (c *Config) newLicenseCmd() *cobra.Command {
 	licenseCmd := &cobra.Command{
+		GroupID:           groupIDDocumentation,
 		Use:               "license",
 		Short:             "Print license",
 		Long:              mustLongHelp("license"),

--- a/internal/cmd/managedcmd.go
+++ b/internal/cmd/managedcmd.go
@@ -19,6 +19,7 @@ type managedCmdConfig struct {
 
 func (c *Config) newManagedCmd() *cobra.Command {
 	managedCmd := &cobra.Command{
+		GroupID: groupIDAdvanced,
 		Use:     "managed [path]...",
 		Aliases: []string{"list"},
 		Short:   "List the managed entries in the destination directory",

--- a/internal/cmd/mergeallcmd.go
+++ b/internal/cmd/mergeallcmd.go
@@ -15,6 +15,7 @@ type mergeAllCmdConfig struct {
 
 func (c *Config) newMergeAllCmd() *cobra.Command {
 	mergeAllCmd := &cobra.Command{
+		GroupID: groupIDDaily,
 		Use:     "merge-all",
 		Short:   "Perform a three-way merge for each modified file",
 		Long:    mustLongHelp("merge-all"),

--- a/internal/cmd/mergecmd.go
+++ b/internal/cmd/mergecmd.go
@@ -20,6 +20,7 @@ type mergeCmdConfig struct {
 
 func (c *Config) newMergeCmd() *cobra.Command {
 	mergeCmd := &cobra.Command{
+		GroupID:           groupIDDaily,
 		Use:               "merge target...",
 		Args:              cobra.MinimumNArgs(1),
 		Short:             "Perform a three-way merge between the destination state, the source state, and the target state",

--- a/internal/cmd/purgecmd.go
+++ b/internal/cmd/purgecmd.go
@@ -19,6 +19,7 @@ type purgeCmdConfig struct {
 
 func (c *Config) newPurgeCmd() *cobra.Command {
 	purgeCmd := &cobra.Command{
+		GroupID:           groupIDMigration,
 		Use:               "purge",
 		Short:             "Purge chezmoi's configuration and data",
 		Long:              mustLongHelp("purge"),

--- a/internal/cmd/readdcmd.go
+++ b/internal/cmd/readdcmd.go
@@ -37,6 +37,7 @@ func (fi *fileInfo) Sys() any           { return nil } // Sys always returns nil
 
 func (c *Config) newReAddCmd() *cobra.Command {
 	reAddCmd := &cobra.Command{
+		GroupID:           groupIDDaily,
 		Use:               "re-add",
 		Short:             "Re-add modified files",
 		Long:              mustLongHelp("re-add"),

--- a/internal/cmd/removecmd.go
+++ b/internal/cmd/removecmd.go
@@ -13,6 +13,7 @@ func (c *Config) newRemoveCmd() *cobra.Command {
 		Aliases:    []string{"rm"},
 		RunE:       c.runRemoveCmd,
 		Long:       mustLongHelp("remove"),
+		Hidden:     true,
 		Annotations: newAnnotations(
 			doesNotRequireValidConfig,
 			persistentStateModeNone,

--- a/internal/cmd/secretcmd.go
+++ b/internal/cmd/secretcmd.go
@@ -8,6 +8,7 @@ type secretCmdConfig struct {
 
 func (c *Config) newSecretCmd() *cobra.Command {
 	secretCmd := &cobra.Command{
+		GroupID: groupIDInternal,
 		Use:     "secret",
 		Args:    cobra.NoArgs,
 		Short:   "Interact with a secret manager",

--- a/internal/cmd/sourcepathcmd.go
+++ b/internal/cmd/sourcepathcmd.go
@@ -9,6 +9,7 @@ import (
 
 func (c *Config) newSourcePathCmd() *cobra.Command {
 	sourcePathCmd := &cobra.Command{
+		GroupID:           groupIDInternal,
 		Use:               "source-path [target]...",
 		Short:             "Print the source path of a target",
 		Long:              mustLongHelp("source-path"),

--- a/internal/cmd/sshcmd.go
+++ b/internal/cmd/sshcmd.go
@@ -13,6 +13,7 @@ type sshCmdConfig struct {
 
 func (c *Config) newSSHCmd() *cobra.Command {
 	sshCmd := &cobra.Command{
+		GroupID: groupIDRemote,
 		Use:     "ssh host",
 		Short:   "SSH to a host and initialize dotfiles",
 		Long:    mustLongHelp("ssh"),

--- a/internal/cmd/statecmd.go
+++ b/internal/cmd/statecmd.go
@@ -56,6 +56,7 @@ type stateSetCmdConfig struct {
 
 func (c *Config) newStateCmd() *cobra.Command {
 	stateCmd := &cobra.Command{
+		GroupID: groupIDInternal,
 		Use:     "state",
 		Short:   "Manipulate the persistent state",
 		Long:    mustLongHelp("state"),

--- a/internal/cmd/statuscmd.go
+++ b/internal/cmd/statuscmd.go
@@ -23,6 +23,7 @@ type statusCmdConfig struct {
 
 func (c *Config) newStatusCmd() *cobra.Command {
 	statusCmd := &cobra.Command{
+		GroupID:           groupIDDaily,
 		Use:               "status [target]...",
 		Short:             "Show the status of targets",
 		Long:              mustLongHelp("status"),

--- a/internal/cmd/targetpathcmd.go
+++ b/internal/cmd/targetpathcmd.go
@@ -10,6 +10,7 @@ import (
 
 func (c *Config) newTargetPathCmd() *cobra.Command {
 	targetPathCmd := &cobra.Command{
+		GroupID: groupIDInternal,
 		Use:     "target-path [source-path]...",
 		Short:   "Print the target path of a source path",
 		Long:    mustLongHelp("target-path"),

--- a/internal/cmd/unmanagedcmd.go
+++ b/internal/cmd/unmanagedcmd.go
@@ -19,6 +19,7 @@ type unmanagedCmdConfig struct {
 
 func (c *Config) newUnmanagedCmd() *cobra.Command {
 	unmanagedCmd := &cobra.Command{
+		GroupID: groupIDAdvanced,
 		Use:     "unmanaged [path]...",
 		Short:   "List the unmanaged files in the destination directory",
 		Long:    mustLongHelp("unmanaged"),

--- a/internal/cmd/updatecmd.go
+++ b/internal/cmd/updatecmd.go
@@ -22,6 +22,7 @@ type updateCmdConfig struct {
 
 func (c *Config) newUpdateCmd() *cobra.Command {
 	updateCmd := &cobra.Command{
+		GroupID:           groupIDDaily,
 		Use:               "update",
 		Short:             "Pull and apply any changes",
 		Long:              mustLongHelp("update"),

--- a/internal/cmd/upgradecmd.go
+++ b/internal/cmd/upgradecmd.go
@@ -48,6 +48,7 @@ type upgradeCmdConfig struct {
 
 func (c *Config) newUpgradeCmd() *cobra.Command {
 	upgradeCmd := &cobra.Command{
+		GroupID:           groupIDMigration,
 		Use:               "upgrade",
 		Short:             "Upgrade chezmoi to the latest released version",
 		Long:              mustLongHelp("upgrade"),

--- a/internal/cmd/verifycmd.go
+++ b/internal/cmd/verifycmd.go
@@ -16,6 +16,7 @@ type verifyCmdConfig struct {
 
 func (c *Config) newVerifyCmd() *cobra.Command {
 	verifyCmd := &cobra.Command{
+		GroupID:           groupIDAdvanced,
 		Use:               "verify [target]...",
 		Short:             "Exit with success if the destination state matches the target state, fail otherwise",
 		Long:              mustLongHelp("verify"),


### PR DESCRIPTION
This groups the commands in the output of `chezmoi help` to emphasize popular commands.

After this PR the output of `chezmoi help` looks like:

```
...

Documentation commands:
  doctor               Check your system for potential problems
  help                 Print help about a command
  license              Print license

Daily commands:
  add                  Add an existing file, directory, or symlink to the source state
  apply                Update the destination directory to match the target state
  chattr               Change the attributes of a target in the source state
  diff                 Print the diff between the target state and the destination state
  edit                 Edit the source state of a target
  forget               Remove a target from the source state
  init                 Setup the source directory and update the destination directory to match the target state
  merge                Perform a three-way merge between the destination state, the source state, and the target state
  merge-all            Perform a three-way merge for each modified file
  re-add               Re-add modified files
  status               Show the status of targets
  update               Pull and apply any changes

Template commands:
  cat                  Print the target contents of a file, script, or symlink
  data                 Print the template data
  execute-template     Execute the given template(s)

Advanced commands:
  cd                   Launch a shell in the source directory
  edit-config          Edit the configuration file
  edit-config-template Edit the configuration file template
  generate             Generate a file for use with chezmoi
  git                  Run git in the source directory
  ignored              Print ignored targets
  managed              List the managed entries in the destination directory
  unmanaged            List the unmanaged files in the destination directory
  verify               Exit with success if the destination state matches the target state, fail otherwise

Encryption commands:
  age                  Interact with age
  age-keygen           Generate an age identity or convert an age identity to an age recipient
  decrypt              Decrypt file or standard input
  encrypt              Encrypt file or standard input

Remote commands:
  docker               Use your dotfiles in a Docker container
  ssh                  SSH to a host and initialize dotfiles

Migration commands:
  archive              Generate a tar archive of the target state
  destroy              Permanently delete an entry from the source state, the destination directory, and the state
  import               Import an archive into the source state
  purge                Purge chezmoi's configuration and data
  upgrade              Upgrade chezmoi to the latest released version

Internal commands:
  cat-config           Print the configuration file
  completion           Generate shell completion code
  dump                 Generate a dump of the target state
  dump-config          Dump the configuration values
  secret               Interact with a secret manager
  source-path          Print the source path of a target
  state                Manipulate the persistent state
  target-path          Print the target path of a source path

Flags:
...
```