### PR TITLE
chore: Better internal docs

### DIFF
--- a/internal/chezmoi/actualstateentry.go
+++ b/internal/chezmoi/actualstateentry.go
@@ -80,7 +80,7 @@ func NewActualStateEntry(system System, absPath AbsPath, fileInfo fs.FileInfo, e
 			}),
 		}, nil
 	default:
-		return nil, &unsupportedFileTypeError{
+		return nil, &UnsupportedFileTypeError{
 			absPath: absPath,
 			mode:    fileInfo.Mode(),
 		}

--- a/internal/chezmoi/archive.go
+++ b/internal/chezmoi/archive.go
@@ -139,18 +139,18 @@ func implicitTarDirHeader(dir string, modTime time.Time) *tar.Header {
 	}
 }
 
-// A rarFileInfo wraps a *rardecode.FileHeader so that it implements
+// A RARFileInfo wraps a *rardecode.FileHeader so that it implements
 // fs.FileInfo.
-type rarFileInfo struct {
+type RARFileInfo struct {
 	*rardecode.FileHeader
 }
 
-func (i rarFileInfo) Name() string       { return i.FileHeader.Name }
-func (i rarFileInfo) Size() int64        { return i.UnPackedSize }
-func (i rarFileInfo) Mode() fs.FileMode  { return i.FileHeader.Mode() }
-func (i rarFileInfo) ModTime() time.Time { return i.ModificationTime }
-func (i rarFileInfo) IsDir() bool        { return i.FileHeader.IsDir }
-func (i rarFileInfo) Sys() any           { return nil }
+func (i RARFileInfo) Name() string       { return i.FileHeader.Name }
+func (i RARFileInfo) Size() int64        { return i.UnPackedSize }
+func (i RARFileInfo) Mode() fs.FileMode  { return i.FileHeader.Mode() }
+func (i RARFileInfo) ModTime() time.Time { return i.ModificationTime }
+func (i RARFileInfo) IsDir() bool        { return i.FileHeader.IsDir }
+func (i RARFileInfo) Sys() any           { return nil }
 
 // walkArchiveRar walks over all the entries in a rar archive.
 func walkArchiveRar(r io.Reader, f WalkArchiveFunc) error {
@@ -171,7 +171,7 @@ func walkArchiveRar(r io.Reader, f WalkArchiveFunc) error {
 		}
 		seenDirs.Add(dir)
 		name := strings.TrimSuffix(header.Name, "/")
-		switch err := f(name, rarFileInfo{FileHeader: header}, rarReader, ""); {
+		switch err := f(name, RARFileInfo{FileHeader: header}, rarReader, ""); {
 		case errors.Is(err, fs.SkipDir):
 			skippedDirPrefixes = append(skippedDirPrefixes, header.Name)
 		case err != nil:

--- a/internal/chezmoi/archivereadersystem.go
+++ b/internal/chezmoi/archivereadersystem.go
@@ -10,8 +10,8 @@ import (
 
 // A ArchiveReaderSystem a system constructed from reading an archive.
 type ArchiveReaderSystem struct {
-	emptySystemMixin
-	noUpdateSystemMixin
+	EmptySystemMixin
+	NoUpdateSystemMixin
 
 	fileInfos map[AbsPath]fs.FileInfo
 	contents  map[AbsPath][]byte

--- a/internal/chezmoi/compression.go
+++ b/internal/chezmoi/compression.go
@@ -11,37 +11,37 @@ import (
 	"github.com/ulikunitz/xz"
 )
 
-// A compressionFormat is a compression format.
-type compressionFormat string
+// A CompressionFormat is a compression format.
+type CompressionFormat string
 
 // Compression formats.
 const (
-	compressionFormatNone  compressionFormat = ""
-	compressionFormatBzip2 compressionFormat = "bzip2"
-	compressionFormatGzip  compressionFormat = "gzip"
-	compressionFormatXz    compressionFormat = "xz"
-	compressionFormatZstd  compressionFormat = "zstd"
+	CompressionFormatNone  CompressionFormat = ""
+	CompressionFormatBzip2 CompressionFormat = "bzip2"
+	CompressionFormatGzip  CompressionFormat = "gzip"
+	CompressionFormatXz    CompressionFormat = "xz"
+	CompressionFormatZstd  CompressionFormat = "zstd"
 )
 
-func decompress(compressionFormat compressionFormat, data []byte) ([]byte, error) {
+func decompress(compressionFormat CompressionFormat, data []byte) ([]byte, error) {
 	switch compressionFormat {
-	case compressionFormatNone:
+	case CompressionFormatNone:
 		return data, nil
-	case compressionFormatBzip2:
+	case CompressionFormatBzip2:
 		return io.ReadAll(bzip2.NewReader(bytes.NewReader(data)))
-	case compressionFormatGzip:
+	case CompressionFormatGzip:
 		gzipReader, err := gzip.NewReader(bytes.NewReader(data))
 		if err != nil {
 			return nil, err
 		}
 		return io.ReadAll(gzipReader)
-	case compressionFormatXz:
+	case CompressionFormatXz:
 		xzReader, err := xz.NewReader(bytes.NewReader(data))
 		if err != nil {
 			return nil, err
 		}
 		return io.ReadAll(xzReader)
-	case compressionFormatZstd:
+	case CompressionFormatZstd:
 		zstdReader, err := zstd.NewReader(bytes.NewReader(data))
 		if err != nil {
 			return nil, err

--- a/internal/chezmoi/diff.go
+++ b/internal/chezmoi/diff.go
@@ -18,49 +18,49 @@ var gitDiffOperation = map[diffmatchpatch.Operation]diff.Operation{
 	diffmatchpatch.DiffInsert: diff.Add,
 }
 
-// A gitDiffChunk implements the
+// A GitDiffChunk implements the
 // github.com/go-git/go-git/v5/plumbing/format/diff.Chunk interface.
-type gitDiffChunk struct {
+type GitDiffChunk struct {
 	content   string
 	operation diff.Operation
 }
 
-func (c *gitDiffChunk) Content() string      { return c.content }
-func (c *gitDiffChunk) Type() diff.Operation { return c.operation }
+func (c *GitDiffChunk) Content() string      { return c.content }
+func (c *GitDiffChunk) Type() diff.Operation { return c.operation }
 
-// A gitDiffFile implements the
+// A GitDiffFile implements the
 // github.com/go-git/go-git/v5/plumbing/format/diff.File interface.
-type gitDiffFile struct {
+type GitDiffFile struct {
 	hash     plumbing.Hash
 	fileMode filemode.FileMode
 	relPath  RelPath
 }
 
-func (f *gitDiffFile) Hash() plumbing.Hash     { return f.hash }
-func (f *gitDiffFile) Mode() filemode.FileMode { return f.fileMode }
-func (f *gitDiffFile) Path() string            { return f.relPath.String() }
+func (f *GitDiffFile) Hash() plumbing.Hash     { return f.hash }
+func (f *GitDiffFile) Mode() filemode.FileMode { return f.fileMode }
+func (f *GitDiffFile) Path() string            { return f.relPath.String() }
 
-// A gitDiffFilePatch implements the
+// A GitDiffFilePatch implements the
 // github.com/go-git/go-git/v5/plumbing/format/diff.FilePatch interface.
-type gitDiffFilePatch struct {
-	isBinary bool
+type GitDiffFilePatch struct {
+	binary   bool
 	from, to diff.File
 	chunks   []diff.Chunk
 }
 
-func (fp *gitDiffFilePatch) IsBinary() bool              { return fp.isBinary }
-func (fp *gitDiffFilePatch) Files() (from, to diff.File) { return fp.from, fp.to }
-func (fp *gitDiffFilePatch) Chunks() []diff.Chunk        { return fp.chunks }
+func (fp *GitDiffFilePatch) IsBinary() bool              { return fp.binary }
+func (fp *GitDiffFilePatch) Files() (from, to diff.File) { return fp.from, fp.to }
+func (fp *GitDiffFilePatch) Chunks() []diff.Chunk        { return fp.chunks }
 
-// A gitDiffPatch implements the
+// A GitDiffPatch implements the
 // github.com/go-git/go-git/v5/plumbing/format/diff.Patch interface.
-type gitDiffPatch struct {
+type GitDiffPatch struct {
 	filePatches []diff.FilePatch
 	message     string
 }
 
-func (p *gitDiffPatch) FilePatches() []diff.FilePatch { return p.filePatches }
-func (p *gitDiffPatch) Message() string               { return p.message }
+func (p *GitDiffPatch) FilePatches() []diff.FilePatch { return p.filePatches }
+func (p *GitDiffPatch) Message() string               { return p.message }
 
 // DiffPatch returns a github.com/go-git/go-git/plumbing/format/diff.Patch for
 // path from the given data and mode to the given data and mode.
@@ -73,7 +73,7 @@ func DiffPatch(path RelPath, fromData []byte, fromMode fs.FileMode, toData []byt
 		if err != nil {
 			return nil, err
 		}
-		from = &gitDiffFile{
+		from = &GitDiffFile{
 			fileMode: fromFileMode,
 			relPath:  path,
 			hash:     plumbing.ComputeHash(plumbing.BlobObject, fromData),
@@ -86,7 +86,7 @@ func DiffPatch(path RelPath, fromData []byte, fromMode fs.FileMode, toData []byt
 		if err != nil {
 			return nil, err
 		}
-		to = &gitDiffFile{
+		to = &GitDiffFile{
 			fileMode: toFileMode,
 			relPath:  path,
 			hash:     plumbing.ComputeHash(plumbing.BlobObject, toData),
@@ -98,13 +98,13 @@ func DiffPatch(path RelPath, fromData []byte, fromMode fs.FileMode, toData []byt
 		chunks = diffChunks(string(fromData), string(toData))
 	}
 
-	return &gitDiffPatch{
+	return &GitDiffPatch{
 		filePatches: []diff.FilePatch{
-			&gitDiffFilePatch{
-				isBinary: isBinary,
-				from:     from,
-				to:       to,
-				chunks:   chunks,
+			&GitDiffFilePatch{
+				binary: isBinary,
+				from:   from,
+				to:     to,
+				chunks: chunks,
 			},
 		},
 	}, nil
@@ -120,7 +120,7 @@ func diffChunks(from, to string) []diff.Chunk {
 	diffs := dmp.DiffCharsToLines(dmp.DiffMainRunes(fromRunes, toRunes, false), runesToLines)
 	chunks := make([]diff.Chunk, len(diffs))
 	for i, d := range diffs {
-		chunk := &gitDiffChunk{
+		chunk := &GitDiffChunk{
 			content:   d.Text,
 			operation: gitDiffOperation[d.Type],
 		}

--- a/internal/chezmoi/dumpsystem.go
+++ b/internal/chezmoi/dumpsystem.go
@@ -7,16 +7,16 @@ import (
 	vfs "github.com/twpayne/go-vfs/v5"
 )
 
-// A dataType is a data type.
-type dataType string
+// A DumpSystemDataType is a data type in a dump system.
+type DumpSystemDataType string
 
-// dataTypes.
+// Dump system data types.
 const (
-	dataTypeCommand dataType = "command"
-	dataTypeDir     dataType = "dir"
-	dataTypeFile    dataType = "file"
-	dataTypeScript  dataType = "script"
-	dataTypeSymlink dataType = "symlink"
+	DumpSystemDataTypeCommand DumpSystemDataType = "command"
+	DumpSystemDataTypeDir     DumpSystemDataType = "dir"
+	DumpSystemDataTypeFile    DumpSystemDataType = "file"
+	DumpSystemDataTypeScript  DumpSystemDataType = "script"
+	DumpSystemDataTypeSymlink DumpSystemDataType = "symlink"
 )
 
 // A DumpSystem is a System that writes to a data file.
@@ -24,63 +24,58 @@ type DumpSystem struct {
 	emptySystemMixin
 	noUpdateSystemMixin
 
-	data map[string]any
+	Data map[string]any
 }
 
-// A commandData contains data about a command.
-type commandData struct {
-	Type dataType `json:"type" yaml:"type"`
-	Path string   `json:"path" yaml:"path"`
-	Args []string `json:"args" yaml:"args"`
+// A DumpSystemCommandData contains data about a command.
+type DumpSystemCommandData struct {
+	Type DumpSystemDataType `json:"type" yaml:"type"`
+	Path string             `json:"path" yaml:"path"`
+	Args []string           `json:"args" yaml:"args"`
 }
 
-// A dirData contains data about a directory.
-type dirData struct {
-	Type dataType    `json:"type" yaml:"type"`
-	Name AbsPath     `json:"name" yaml:"name"`
-	Perm fs.FileMode `json:"perm" yaml:"perm"`
+// A DumpSystemDirData contains data about a directory.
+type DumpSystemDirData struct {
+	Type DumpSystemDataType `json:"type" yaml:"type"`
+	Name AbsPath            `json:"name" yaml:"name"`
+	Perm fs.FileMode        `json:"perm" yaml:"perm"`
 }
 
-// A fileData contains data about a file.
-type fileData struct {
-	Type     dataType    `json:"type"     yaml:"type"`
-	Name     AbsPath     `json:"name"     yaml:"name"`
-	Contents string      `json:"contents" yaml:"contents"`
-	Perm     fs.FileMode `json:"perm"     yaml:"perm"`
+// A DumpSystemFileData contains data about a file.
+type DumpSystemFileData struct {
+	Type     DumpSystemDataType `json:"type"     yaml:"type"`
+	Name     AbsPath            `json:"name"     yaml:"name"`
+	Contents string             `json:"contents" yaml:"contents"`
+	Perm     fs.FileMode        `json:"perm"     yaml:"perm"`
 }
 
-// A scriptData contains data about a script.
-type scriptData struct {
-	Type        dataType     `json:"type"                  yaml:"type"`
-	Name        AbsPath      `json:"name"                  yaml:"name"`
-	Contents    string       `json:"contents"              yaml:"contents"`
-	Condition   string       `json:"condition"             yaml:"condition"`
-	Interpreter *Interpreter `json:"interpreter,omitempty" yaml:"interpreter,omitempty"`
+// A DumpSystemScriptData contains data about a script.
+type DumpSystemScriptData struct {
+	Type        DumpSystemDataType `json:"type"                  yaml:"type"`
+	Name        AbsPath            `json:"name"                  yaml:"name"`
+	Contents    string             `json:"contents"              yaml:"contents"`
+	Condition   string             `json:"condition"             yaml:"condition"`
+	Interpreter *Interpreter       `json:"interpreter,omitempty" yaml:"interpreter,omitempty"`
 }
 
-// A symlinkData contains data about a symlink.
-type symlinkData struct {
-	Type     dataType `json:"type"     yaml:"type"`
-	Name     AbsPath  `json:"name"     yaml:"name"`
-	Linkname string   `json:"linkname" yaml:"linkname"`
+// A DumpSystemSymlinkData contains data about a symlink.
+type DumpSystemSymlinkData struct {
+	Type     DumpSystemDataType `json:"type"     yaml:"type"`
+	Name     AbsPath            `json:"name"     yaml:"name"`
+	Linkname string             `json:"linkname" yaml:"linkname"`
 }
 
 // NewDumpSystem returns a new DumpSystem that accumulates data.
 func NewDumpSystem() *DumpSystem {
 	return &DumpSystem{
-		data: make(map[string]any),
+		Data: make(map[string]any),
 	}
-}
-
-// Data returns s's data.
-func (s *DumpSystem) Data() any {
-	return s.data
 }
 
 // Mkdir implements System.Mkdir.
 func (s *DumpSystem) Mkdir(dirname AbsPath, perm fs.FileMode) error {
-	return s.setData(dirname.String(), &dirData{
-		Type: dataTypeDir,
+	return s.setData(dirname.String(), &DumpSystemDirData{
+		Type: DumpSystemDataTypeDir,
 		Name: dirname,
 		Perm: perm,
 	})
@@ -91,8 +86,8 @@ func (s *DumpSystem) RunCmd(cmd *exec.Cmd) error {
 	if cmd.Dir == "" {
 		return nil
 	}
-	return s.setData(cmd.Dir, &commandData{
-		Type: dataTypeCommand,
+	return s.setData(cmd.Dir, &DumpSystemCommandData{
+		Type: DumpSystemDataTypeCommand,
 		Path: cmd.Path,
 		Args: cmd.Args,
 	})
@@ -101,8 +96,8 @@ func (s *DumpSystem) RunCmd(cmd *exec.Cmd) error {
 // RunScript implements System.RunScript.
 func (s *DumpSystem) RunScript(scriptName RelPath, dir AbsPath, data []byte, options RunScriptOptions) error {
 	scriptNameStr := scriptName.String()
-	scriptData := &scriptData{
-		Type:     dataTypeScript,
+	scriptData := &DumpSystemScriptData{
+		Type:     DumpSystemDataTypeScript,
 		Name:     NewAbsPath(scriptNameStr),
 		Contents: string(data),
 	}
@@ -122,8 +117,8 @@ func (s *DumpSystem) UnderlyingFS() vfs.FS {
 
 // WriteFile implements System.WriteFile.
 func (s *DumpSystem) WriteFile(filename AbsPath, data []byte, perm fs.FileMode) error {
-	return s.setData(filename.String(), &fileData{
-		Type:     dataTypeFile,
+	return s.setData(filename.String(), &DumpSystemFileData{
+		Type:     DumpSystemDataTypeFile,
 		Name:     filename,
 		Contents: string(data),
 		Perm:     perm,
@@ -132,17 +127,17 @@ func (s *DumpSystem) WriteFile(filename AbsPath, data []byte, perm fs.FileMode) 
 
 // WriteSymlink implements System.WriteSymlink.
 func (s *DumpSystem) WriteSymlink(oldName string, newName AbsPath) error {
-	return s.setData(newName.String(), &symlinkData{
-		Type:     dataTypeSymlink,
+	return s.setData(newName.String(), &DumpSystemSymlinkData{
+		Type:     DumpSystemDataTypeSymlink,
 		Name:     newName,
 		Linkname: oldName,
 	})
 }
 
 func (s *DumpSystem) setData(key string, value any) error {
-	if _, ok := s.data[key]; ok {
+	if _, ok := s.Data[key]; ok {
 		return fs.ErrExist
 	}
-	s.data[key] = value
+	s.Data[key] = value
 	return nil
 }

--- a/internal/chezmoi/dumpsystem.go
+++ b/internal/chezmoi/dumpsystem.go
@@ -21,8 +21,8 @@ const (
 
 // A DumpSystem is a System that writes to a data file.
 type DumpSystem struct {
-	emptySystemMixin
-	noUpdateSystemMixin
+	EmptySystemMixin
+	NoUpdateSystemMixin
 
 	Data map[string]any
 }

--- a/internal/chezmoi/dumpsystem_test.go
+++ b/internal/chezmoi/dumpsystem_test.go
@@ -53,30 +53,29 @@ func TestDumpSystem(t *testing.T) {
 		})
 		assert.NoError(t, err)
 		expectedData := map[string]any{
-			".dir": &dirData{
-				Type: dataTypeDir,
+			".dir": &DumpSystemDirData{
+				Type: DumpSystemDataTypeDir,
 				Name: NewAbsPath(".dir"),
 				Perm: fs.ModePerm &^ chezmoitest.Umask,
 			},
-			".dir/file": &fileData{
-				Type:     dataTypeFile,
+			".dir/file": &DumpSystemFileData{
+				Type:     DumpSystemDataTypeFile,
 				Name:     NewAbsPath(".dir/file"),
 				Contents: "# contents of .dir/file\n",
 				Perm:     0o666 &^ chezmoitest.Umask,
 			},
-			"script": &scriptData{
-				Type:      dataTypeScript,
+			"script": &DumpSystemScriptData{
+				Type:      DumpSystemDataTypeScript,
 				Name:      NewAbsPath("script"),
 				Contents:  "# contents of script\n",
 				Condition: "always",
 			},
-			"symlink": &symlinkData{
-				Type:     dataTypeSymlink,
+			"symlink": &DumpSystemSymlinkData{
+				Type:     DumpSystemDataTypeSymlink,
 				Name:     NewAbsPath("symlink"),
 				Linkname: ".dir/subdir/file",
 			},
 		}
-		actualData := dumpSystem.Data()
-		assert.Equal(t, expectedData, actualData.(map[string]any))
+		assert.Equal(t, expectedData, dumpSystem.Data)
 	})
 }

--- a/internal/chezmoi/errors.go
+++ b/internal/chezmoi/errors.go
@@ -28,12 +28,12 @@ func (e *TooOldError) Error() string {
 	return fmt.Sprintf(format, e.Need, e.Have)
 }
 
-type inconsistentStateError struct {
+type InconsistentStateError struct {
 	targetRelPath RelPath
 	origins       []string
 }
 
-func (e *inconsistentStateError) Error() string {
+func (e *InconsistentStateError) Error() string {
 	format := "%s: inconsistent state (%s)"
 	return fmt.Sprintf(format, e.targetRelPath, strings.Join(e.origins, ", "))
 }
@@ -47,20 +47,20 @@ func (e *NotInAbsDirError) Error() string {
 	return fmt.Sprintf("%s: not in %s", e.pathAbsPath, e.dirAbsPath)
 }
 
-type notInRelDirError struct {
+type NotInRelDirError struct {
 	pathRelPath RelPath
 	dirRelPath  RelPath
 }
 
-func (e *notInRelDirError) Error() string {
+func (e *NotInRelDirError) Error() string {
 	return fmt.Sprintf("%s: not in %s", e.pathRelPath, e.dirRelPath)
 }
 
-type unsupportedFileTypeError struct {
+type UnsupportedFileTypeError struct {
 	absPath AbsPath
 	mode    fs.FileMode
 }
 
-func (e *unsupportedFileTypeError) Error() string {
+func (e *UnsupportedFileTypeError) Error() string {
 	return fmt.Sprintf("%s: unsupported file type %s", e.absPath, modeTypeName(e.mode))
 }

--- a/internal/chezmoi/gitdiffsystem.go
+++ b/internal/chezmoi/gitdiffsystem.go
@@ -230,15 +230,15 @@ func (s *GitDiffSystem) Rename(oldPath, newPath AbsPath) error {
 		if s.reverse {
 			fromPath, toPath = toPath, fromPath
 		}
-		if err := s.unifiedEncoder.Encode(&gitDiffPatch{
+		if err := s.unifiedEncoder.Encode(&GitDiffPatch{
 			filePatches: []diff.FilePatch{
-				&gitDiffFilePatch{
-					from: &gitDiffFile{
+				&GitDiffFilePatch{
+					from: &GitDiffFile{
 						fileMode: fileMode,
 						relPath:  fromPath,
 						hash:     hash,
 					},
-					to: &gitDiffFile{
+					to: &GitDiffFile{
 						fileMode: fileMode,
 						relPath:  toPath,
 						hash:     hash,

--- a/internal/chezmoi/gitdiffsystem_test.go
+++ b/internal/chezmoi/gitdiffsystem_test.go
@@ -6,8 +6,8 @@ import (
 
 var (
 	_ System         = &GitDiffSystem{}
-	_ diff.Chunk     = &gitDiffChunk{}
-	_ diff.File      = &gitDiffFile{}
-	_ diff.FilePatch = &gitDiffFilePatch{}
-	_ diff.Patch     = &gitDiffPatch{}
+	_ diff.Chunk     = &GitDiffChunk{}
+	_ diff.File      = &GitDiffFile{}
+	_ diff.FilePatch = &GitDiffFilePatch{}
+	_ diff.Patch     = &GitDiffPatch{}
 )

--- a/internal/chezmoi/glob.go
+++ b/internal/chezmoi/glob.go
@@ -7,28 +7,28 @@ import (
 	vfs "github.com/twpayne/go-vfs/v5"
 )
 
-// A lstatFS implements io/fs.StatFS but uses Lstat instead of Stat.
-type lstatFS struct {
-	wrapped interface {
+// A LstatFS implements io/fs.StatFS but uses Lstat instead of Stat.
+type LstatFS struct {
+	Wrapped interface {
 		fs.FS
 		Lstat(name string) (fs.FileInfo, error)
 	}
 }
 
 // Open implements io/fs.StatFS.Open.
-func (s lstatFS) Open(name string) (fs.File, error) {
-	return s.wrapped.Open(name)
+func (s LstatFS) Open(name string) (fs.File, error) {
+	return s.Wrapped.Open(name)
 }
 
 // Stat implements io/fs.StatFS.Stat.
-func (s lstatFS) Stat(name string) (fs.FileInfo, error) {
-	return s.wrapped.Lstat(name)
+func (s LstatFS) Stat(name string) (fs.FileInfo, error) {
+	return s.Wrapped.Lstat(name)
 }
 
 // Glob is like github.com/bmatcuk/doublestar/v4.Glob except that it does not
 // follow symlinks.
 func Glob(fileSystem vfs.FS, prefix string) ([]string, error) {
-	fsys := lstatFS{wrapped: fileSystem}
+	fsys := LstatFS{Wrapped: fileSystem}
 	opts := []doublestar.GlobOption{
 		doublestar.WithFailOnIOErrors(),
 		doublestar.WithNoFollow(),

--- a/internal/chezmoi/mode.go
+++ b/internal/chezmoi/mode.go
@@ -10,9 +10,9 @@ const (
 	ModeSymlink Mode = "symlink"
 )
 
-type invalidModeError string
+type InvalidModeError string
 
-func (e invalidModeError) Error() string {
+func (e InvalidModeError) Error() string {
 	return "invalid mode: " + string(e)
 }
 
@@ -32,7 +32,7 @@ func (m *Mode) Set(s string) error {
 		*m = ModeSymlink
 		return nil
 	default:
-		return invalidModeError(Mode(s))
+		return InvalidModeError(Mode(s))
 	}
 }
 

--- a/internal/chezmoi/nullsystem.go
+++ b/internal/chezmoi/nullsystem.go
@@ -1,6 +1,6 @@
 package chezmoi
 
 type NullSystem struct {
-	emptySystemMixin
-	noUpdateSystemMixin
+	EmptySystemMixin
+	NoUpdateSystemMixin
 }

--- a/internal/chezmoi/patternset_test.go
+++ b/internal/chezmoi/patternset_test.go
@@ -12,64 +12,64 @@ import (
 func TestPatternSet(t *testing.T) {
 	for _, tc := range []struct {
 		name          string
-		ps            *patternSet
-		expectMatches map[string]patternSetMatchType
+		ps            *PatternSet
+		expectMatches map[string]PatternSetMatchType
 	}{
 		{
 			name: "empty",
-			ps:   newPatternSet(),
-			expectMatches: map[string]patternSetMatchType{
-				"foo": patternSetMatchUnknown,
+			ps:   NewPatternSet(),
+			expectMatches: map[string]PatternSetMatchType{
+				"foo": PatternSetMatchUnknown,
 			},
 		},
 		{
 			name: "exact",
-			ps: mustNewPatternSet(t, map[string]patternSetIncludeType{
-				"foo": patternSetInclude,
+			ps: mustNewPatternSet(t, map[string]PatternSetIncludeType{
+				"foo": PatternSetInclude,
 			}),
-			expectMatches: map[string]patternSetMatchType{
-				"foo": patternSetMatchInclude,
-				"bar": patternSetMatchExclude,
+			expectMatches: map[string]PatternSetMatchType{
+				"foo": PatternSetMatchInclude,
+				"bar": PatternSetMatchExclude,
 			},
 		},
 		{
 			name: "wildcard",
-			ps: mustNewPatternSet(t, map[string]patternSetIncludeType{
-				"b*": patternSetInclude,
+			ps: mustNewPatternSet(t, map[string]PatternSetIncludeType{
+				"b*": PatternSetInclude,
 			}),
-			expectMatches: map[string]patternSetMatchType{
-				"foo": patternSetMatchExclude,
-				"bar": patternSetMatchInclude,
-				"baz": patternSetMatchInclude,
+			expectMatches: map[string]PatternSetMatchType{
+				"foo": PatternSetMatchExclude,
+				"bar": PatternSetMatchInclude,
+				"baz": PatternSetMatchInclude,
 			},
 		},
 		{
 			name: "exclude",
-			ps: mustNewPatternSet(t, map[string]patternSetIncludeType{
-				"b*":  patternSetInclude,
-				"baz": patternSetExclude,
+			ps: mustNewPatternSet(t, map[string]PatternSetIncludeType{
+				"b*":  PatternSetInclude,
+				"baz": PatternSetExclude,
 			}),
-			expectMatches: map[string]patternSetMatchType{
-				"foo": patternSetMatchUnknown,
-				"bar": patternSetMatchInclude,
-				"baz": patternSetMatchExclude,
+			expectMatches: map[string]PatternSetMatchType{
+				"foo": PatternSetMatchUnknown,
+				"bar": PatternSetMatchInclude,
+				"baz": PatternSetMatchExclude,
 			},
 		},
 		{
 			name: "doublestar",
-			ps: mustNewPatternSet(t, map[string]patternSetIncludeType{
-				"**/foo": patternSetInclude,
+			ps: mustNewPatternSet(t, map[string]PatternSetIncludeType{
+				"**/foo": PatternSetInclude,
 			}),
-			expectMatches: map[string]patternSetMatchType{
-				"foo":         patternSetMatchInclude,
-				"bar/foo":     patternSetMatchInclude,
-				"baz/bar/foo": patternSetMatchInclude,
+			expectMatches: map[string]PatternSetMatchType{
+				"foo":         PatternSetMatchInclude,
+				"bar/foo":     PatternSetMatchInclude,
+				"baz/bar/foo": PatternSetMatchInclude,
 			},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			for s, expectMatch := range tc.expectMatches {
-				assert.Equal(t, expectMatch, tc.ps.match(s))
+				assert.Equal(t, expectMatch, tc.ps.Match(s))
 			}
 		})
 	}
@@ -78,20 +78,20 @@ func TestPatternSet(t *testing.T) {
 func TestPatternSetGlob(t *testing.T) {
 	for _, tc := range []struct {
 		name            string
-		ps              *patternSet
+		ps              *PatternSet
 		root            any
 		expectedMatches []string
 	}{
 		{
 			name:            "empty",
-			ps:              newPatternSet(),
+			ps:              NewPatternSet(),
 			root:            nil,
 			expectedMatches: []string{},
 		},
 		{
 			name: "simple",
-			ps: mustNewPatternSet(t, map[string]patternSetIncludeType{
-				"/f*": patternSetInclude,
+			ps: mustNewPatternSet(t, map[string]PatternSetIncludeType{
+				"/f*": PatternSetInclude,
 			}),
 			root: map[string]any{
 				"foo": "",
@@ -102,9 +102,9 @@ func TestPatternSetGlob(t *testing.T) {
 		},
 		{
 			name: "include_exclude",
-			ps: mustNewPatternSet(t, map[string]patternSetIncludeType{
-				"/b*": patternSetInclude,
-				"/*z": patternSetExclude,
+			ps: mustNewPatternSet(t, map[string]PatternSetIncludeType{
+				"/b*": PatternSetInclude,
+				"/*z": PatternSetExclude,
 			}),
 			root: map[string]any{
 				"bar": "",
@@ -116,8 +116,8 @@ func TestPatternSetGlob(t *testing.T) {
 		},
 		{
 			name: "doublestar",
-			ps: mustNewPatternSet(t, map[string]patternSetIncludeType{
-				"/**/f*": patternSetInclude,
+			ps: mustNewPatternSet(t, map[string]PatternSetIncludeType{
+				"/**/f*": PatternSetInclude,
 			}),
 			root: map[string]any{
 				"dir1/dir2/foo": "",
@@ -129,7 +129,7 @@ func TestPatternSetGlob(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			chezmoitest.WithTestFS(t, tc.root, func(fileSystem vfs.FS) {
-				actualMatches, err := tc.ps.glob(fileSystem, "/")
+				actualMatches, err := tc.ps.Glob(fileSystem, "/")
 				assert.NoError(t, err)
 				assert.Equal(t, tc.expectedMatches, actualMatches)
 			})
@@ -137,11 +137,11 @@ func TestPatternSetGlob(t *testing.T) {
 	}
 }
 
-func mustNewPatternSet(t *testing.T, patterns map[string]patternSetIncludeType) *patternSet {
+func mustNewPatternSet(t *testing.T, patterns map[string]PatternSetIncludeType) *PatternSet {
 	t.Helper()
-	ps := newPatternSet()
+	ps := NewPatternSet()
 	for pattern, include := range patterns {
-		assert.NoError(t, ps.add(pattern, include))
+		assert.NoError(t, ps.Add(pattern, include))
 	}
 	return ps
 }

--- a/internal/chezmoi/readonlysystem.go
+++ b/internal/chezmoi/readonlysystem.go
@@ -8,7 +8,7 @@ import (
 
 // A ReadOnlySystem is a system that may only be read from.
 type ReadOnlySystem struct {
-	noUpdateSystemMixin
+	NoUpdateSystemMixin
 
 	system System
 }

--- a/internal/chezmoi/relpath.go
+++ b/internal/chezmoi/relpath.go
@@ -121,7 +121,7 @@ func (p RelPath) String() string {
 // TrimDirPrefix trims prefix from p.
 func (p RelPath) TrimDirPrefix(dirPrefix RelPath) (RelPath, error) {
 	if !p.HasDirPrefix(dirPrefix) {
-		return EmptyRelPath, &notInRelDirError{
+		return EmptyRelPath, &NotInRelDirError{
 			pathRelPath: p,
 			dirRelPath:  dirPrefix,
 		}

--- a/internal/chezmoi/sourcestate.go
+++ b/internal/chezmoi/sourcestate.go
@@ -1067,7 +1067,7 @@ func (s *SourceState) Read(ctx context.Context, options *ReadOptions) error {
 			addSourceStateEntries(targetRelPath, sourceStateEntry)
 			return nil
 		default:
-			return &unsupportedFileTypeError{
+			return &UnsupportedFileTypeError{
 				absPath: sourceAbsPath,
 				mode:    fileInfo.Mode(),
 			}
@@ -1284,7 +1284,7 @@ func (s *SourceState) Read(ctx context.Context, options *ReadOptions) error {
 			origins[i] = sourceStateEntry.Origin().OriginString()
 		}
 		slices.Sort(origins)
-		errs = append(errs, &inconsistentStateError{
+		errs = append(errs, &InconsistentStateError{
 			targetRelPath: targetRelPath,
 			origins:       origins,
 		})
@@ -1409,7 +1409,7 @@ func (s *SourceState) addExternalDir(ctx context.Context, externalsDirAbsPath Ab
 		case fileInfo.IsDir():
 			return nil
 		default:
-			return &unsupportedFileTypeError{
+			return &UnsupportedFileTypeError{
 				absPath: externalAbsPath,
 				mode:    fileInfo.Mode(),
 			}
@@ -1499,7 +1499,7 @@ func (s *SourceState) addTemplateDataDir(sourceAbsPath AbsPath, fileInfo fs.File
 		case fileInfo.IsDir():
 			return nil
 		default:
-			return &unsupportedFileTypeError{
+			return &UnsupportedFileTypeError{
 				absPath: dataAbsPath,
 				mode:    fileInfo.Mode(),
 			}
@@ -1549,7 +1549,7 @@ func (s *SourceState) addTemplatesDir(ctx context.Context, templatesDirAbsPath A
 		case fileInfo.IsDir():
 			return nil
 		default:
-			return &unsupportedFileTypeError{
+			return &UnsupportedFileTypeError{
 				absPath: templateAbsPath,
 				mode:    fileInfo.Mode(),
 			}
@@ -2878,7 +2878,7 @@ func (s *SourceState) readScriptsDir(ctx context.Context, scriptsDirAbsPath AbsP
 			addSourceStateEntry(targetRelPath, sourceStateEntry)
 			return nil
 		default:
-			return &unsupportedFileTypeError{
+			return &UnsupportedFileTypeError{
 				absPath: sourceAbsPath,
 				mode:    fileInfo.Mode(),
 			}

--- a/internal/chezmoi/sourcestate.go
+++ b/internal/chezmoi/sourcestate.go
@@ -302,9 +302,9 @@ func WithWarnFunc(warnFunc WarnFunc) SourceStateOption {
 	}
 }
 
-// A targetStateEntryFunc returns a TargetStateEntry based on reading an AbsPath
+// A TargetStateEntryFunc returns a TargetStateEntry based on reading an AbsPath
 // on a System.
-type targetStateEntryFunc func(System, AbsPath) (TargetStateEntry, error)
+type TargetStateEntryFunc func(System, AbsPath) (TargetStateEntry, error)
 
 // NewSourceState creates a new source state with the given options.
 func NewSourceState(options ...SourceStateOption) *SourceState {
@@ -1820,7 +1820,7 @@ func (s *SourceState) newCreateTargetStateEntryFunc(
 	sourceRelPath SourceRelPath,
 	fileAttr FileAttr,
 	sourceContentsFunc func() ([]byte, error),
-) targetStateEntryFunc {
+) TargetStateEntryFunc {
 	return func(destSystem System, destAbsPath AbsPath) (TargetStateEntry, error) {
 		var contentsFunc func() ([]byte, error)
 		switch contents, err := destSystem.ReadFile(destAbsPath); {
@@ -1866,7 +1866,7 @@ func (s *SourceState) newFileTargetStateEntryFunc(
 	sourceRelPath SourceRelPath,
 	fileAttr FileAttr,
 	sourceContentsFunc func() ([]byte, error),
-) targetStateEntryFunc {
+) TargetStateEntryFunc {
 	return func(destSystem System, destAbsPath AbsPath) (TargetStateEntry, error) {
 		if s.mode == ModeSymlink && !fileAttr.Encrypted && !fileAttr.Executable && !fileAttr.Private && !fileAttr.Template {
 			switch contents, err := sourceContentsFunc(); {
@@ -1921,7 +1921,7 @@ func (s *SourceState) newModifyTargetStateEntryFunc(
 	fileAttr FileAttr,
 	contentsFunc func() ([]byte, error),
 	interpreter *Interpreter,
-) targetStateEntryFunc {
+) TargetStateEntryFunc {
 	return func(destSystem System, destAbsPath AbsPath) (TargetStateEntry, error) {
 		contentsFunc := sync.OnceValues(func() (contents []byte, err error) {
 			// FIXME this should share code with RealSystem.RunScript
@@ -2029,7 +2029,7 @@ func (s *SourceState) newModifyTargetStateEntryFunc(
 
 // newRemoveTargetStateEntryFunc returns a targetStateEntryFunc that removes a
 // target.
-func (s *SourceState) newRemoveTargetStateEntryFunc() targetStateEntryFunc {
+func (s *SourceState) newRemoveTargetStateEntryFunc() TargetStateEntryFunc {
 	return func(destSystem System, destAbsPath AbsPath) (TargetStateEntry, error) {
 		return &TargetStateRemove{}, nil
 	}
@@ -2043,7 +2043,7 @@ func (s *SourceState) newScriptTargetStateEntryFunc(
 	targetRelPath RelPath,
 	sourceContentsFunc func() ([]byte, error),
 	interpreter *Interpreter,
-) targetStateEntryFunc {
+) TargetStateEntryFunc {
 	return func(destSystem System, destAbsPath AbsPath) (TargetStateEntry, error) {
 		contentsFunc := sync.OnceValues(func() ([]byte, error) {
 			contents, err := sourceContentsFunc()
@@ -2082,7 +2082,7 @@ func (s *SourceState) newSymlinkTargetStateEntryFunc(
 	sourceRelPath SourceRelPath,
 	fileAttr FileAttr,
 	contentsFunc func() ([]byte, error),
-) targetStateEntryFunc {
+) TargetStateEntryFunc {
 	return func(destSystem System, destAbsPath AbsPath) (TargetStateEntry, error) {
 		linknameFunc := func() (string, error) {
 			linknameBytes, err := contentsFunc()
@@ -2130,7 +2130,7 @@ func (s *SourceState) newSourceStateFile(
 		return contents, nil
 	})
 
-	var targetStateEntryFunc targetStateEntryFunc
+	var targetStateEntryFunc TargetStateEntryFunc
 	switch fileAttr.Type {
 	case SourceFileTypeCreate:
 		targetStateEntryFunc = s.newCreateTargetStateEntryFunc(sourceRelPath, fileAttr, contentsFunc)

--- a/internal/chezmoi/sourcestate.go
+++ b/internal/chezmoi/sourcestate.go
@@ -60,11 +60,11 @@ var (
 	appleDoubleContentsPrefix = []byte{0x00, 0x05, 0x16, 0x07, 0x00, 0x02, 0x00, 0x00}
 )
 
-type externalArchive struct {
+type ExternalArchive struct {
 	ExtractAppleDoubleFiles bool `json:"extractAppleDoubleFiles" toml:"extractAppleDoubleFiles" yaml:"extractAppleDoubleFiles"`
 }
 
-type externalChecksum struct {
+type ExternalChecksum struct {
 	MD5       HexBytes `json:"md5"       toml:"md5"       yaml:"md5"`
 	RIPEMD160 HexBytes `json:"ripemd160" toml:"ripemd160" yaml:"ripemd160"`
 	SHA1      HexBytes `json:"sha1"      toml:"sha1"      yaml:"sha1"`
@@ -74,16 +74,16 @@ type externalChecksum struct {
 	Size      int      `json:"size"      toml:"size"      yaml:"size"`
 }
 
-type externalClone struct {
+type ExternalClone struct {
 	Args []string `json:"args" toml:"args" yaml:"args"`
 }
 
-type externalFilter struct {
+type ExternalFilter struct {
 	Command string   `json:"command" toml:"command" yaml:"command"`
 	Args    []string `json:"args"    toml:"args"    yaml:"args"`
 }
 
-type externalPull struct {
+type ExternalPull struct {
 	Args []string `json:"args" toml:"args" yaml:"args"`
 }
 
@@ -98,16 +98,16 @@ type External struct {
 	Executable      bool              `json:"executable"      toml:"executable"      yaml:"executable"`
 	Private         bool              `json:"private"         toml:"private"         yaml:"private"`
 	ReadOnly        bool              `json:"readonly"        toml:"readonly"        yaml:"readonly"`
-	Checksum        externalChecksum  `json:"checksum"        toml:"checksum"        yaml:"checksum"`
-	Clone           externalClone     `json:"clone"           toml:"clone"           yaml:"clone"`
+	Checksum        ExternalChecksum  `json:"checksum"        toml:"checksum"        yaml:"checksum"`
+	Clone           ExternalClone     `json:"clone"           toml:"clone"           yaml:"clone"`
 	Decompress      CompressionFormat `json:"decompress"      toml:"decompress"      yaml:"decompress"`
 	Exclude         []string          `json:"exclude"         toml:"exclude"         yaml:"exclude"`
-	Filter          externalFilter    `json:"filter"          toml:"filter"          yaml:"filter"`
+	Filter          ExternalFilter    `json:"filter"          toml:"filter"          yaml:"filter"`
 	Format          ArchiveFormat     `json:"format"          toml:"format"          yaml:"format"`
-	Archive         externalArchive   `json:"archive"         toml:"archive"         yaml:"archive"`
+	Archive         ExternalArchive   `json:"archive"         toml:"archive"         yaml:"archive"`
 	Include         []string          `json:"include"         toml:"include"         yaml:"include"`
 	ArchivePath     string            `json:"path"            toml:"path"            yaml:"path"`
-	Pull            externalPull      `json:"pull"            toml:"pull"            yaml:"pull"`
+	Pull            ExternalPull      `json:"pull"            toml:"pull"            yaml:"pull"`
 	RefreshPeriod   Duration          `json:"refreshPeriod"   toml:"refreshPeriod"   yaml:"refreshPeriod"`
 	StripComponents int               `json:"stripComponents" toml:"stripComponents" yaml:"stripComponents"`
 	URL             string            `json:"url"             toml:"url"             yaml:"url"`

--- a/internal/chezmoi/sourcestate.go
+++ b/internal/chezmoi/sourcestate.go
@@ -100,7 +100,7 @@ type External struct {
 	ReadOnly        bool              `json:"readonly"        toml:"readonly"        yaml:"readonly"`
 	Checksum        externalChecksum  `json:"checksum"        toml:"checksum"        yaml:"checksum"`
 	Clone           externalClone     `json:"clone"           toml:"clone"           yaml:"clone"`
-	Decompress      compressionFormat `json:"decompress"      toml:"decompress"      yaml:"decompress"`
+	Decompress      CompressionFormat `json:"decompress"      toml:"decompress"      yaml:"decompress"`
 	Exclude         []string          `json:"exclude"         toml:"exclude"         yaml:"exclude"`
 	Filter          externalFilter    `json:"filter"          toml:"filter"          yaml:"filter"`
 	Format          ArchiveFormat     `json:"format"          toml:"format"          yaml:"format"`

--- a/internal/chezmoi/sourcestate_test.go
+++ b/internal/chezmoi/sourcestate_test.go
@@ -1149,8 +1149,8 @@ func TestSourceStateRead(t *testing.T) {
 			},
 			expectedSourceState: NewSourceState(
 				withIgnore(
-					mustNewPatternSet(t, map[string]patternSetIncludeType{
-						"README.md": patternSetInclude,
+					mustNewPatternSet(t, map[string]PatternSetIncludeType{
+						"README.md": PatternSetInclude,
 					}),
 				),
 			),
@@ -1165,8 +1165,8 @@ func TestSourceStateRead(t *testing.T) {
 			},
 			expectedSourceState: NewSourceState(
 				withIgnore(
-					mustNewPatternSet(t, map[string]patternSetIncludeType{
-						"README.md": patternSetInclude,
+					mustNewPatternSet(t, map[string]PatternSetIncludeType{
+						"README.md": PatternSetInclude,
 					}),
 				),
 				withIgnoredRelPathStrs(
@@ -1184,8 +1184,8 @@ func TestSourceStateRead(t *testing.T) {
 			},
 			expectedSourceState: NewSourceState(
 				withIgnore(
-					mustNewPatternSet(t, map[string]patternSetIncludeType{
-						"README.md#": patternSetInclude,
+					mustNewPatternSet(t, map[string]PatternSetIncludeType{
+						"README.md#": PatternSetInclude,
 					}),
 				),
 				withIgnoredRelPathStrs(
@@ -1243,8 +1243,8 @@ func TestSourceStateRead(t *testing.T) {
 					},
 				}),
 				withIgnore(
-					mustNewPatternSet(t, map[string]patternSetIncludeType{
-						"dir/file3": patternSetInclude,
+					mustNewPatternSet(t, map[string]PatternSetIncludeType{
+						"dir/file3": PatternSetInclude,
 					}),
 				),
 				withIgnoredRelPathStrs(
@@ -1269,8 +1269,8 @@ func TestSourceStateRead(t *testing.T) {
 					},
 				}),
 				withRemove(
-					mustNewPatternSet(t, map[string]patternSetIncludeType{
-						"file": patternSetInclude,
+					mustNewPatternSet(t, map[string]PatternSetIncludeType{
+						"file": PatternSetInclude,
 					}),
 				),
 			),
@@ -1296,16 +1296,16 @@ func TestSourceStateRead(t *testing.T) {
 					},
 				}),
 				withIgnore(
-					mustNewPatternSet(t, map[string]patternSetIncludeType{
-						"file2": patternSetInclude,
+					mustNewPatternSet(t, map[string]PatternSetIncludeType{
+						"file2": PatternSetInclude,
 					}),
 				),
 				withIgnoredRelPathStrs(
 					"file2",
 				),
 				withRemove(
-					mustNewPatternSet(t, map[string]patternSetIncludeType{
-						"file*": patternSetInclude,
+					mustNewPatternSet(t, map[string]PatternSetIncludeType{
+						"file*": PatternSetInclude,
 					}),
 				),
 			),
@@ -1343,16 +1343,16 @@ func TestSourceStateRead(t *testing.T) {
 					},
 				}),
 				withIgnore(
-					mustNewPatternSet(t, map[string]patternSetIncludeType{
-						"dir/file2": patternSetInclude,
+					mustNewPatternSet(t, map[string]PatternSetIncludeType{
+						"dir/file2": PatternSetInclude,
 					}),
 				),
 				withIgnoredRelPathStrs(
 					"dir/file2",
 				),
 				withRemove(
-					mustNewPatternSet(t, map[string]patternSetIncludeType{
-						"dir/file*": patternSetInclude,
+					mustNewPatternSet(t, map[string]PatternSetIncludeType{
+						"dir/file*": PatternSetInclude,
 					}),
 				),
 			),
@@ -2177,7 +2177,7 @@ func withEntries(sourceEntries map[RelPath]SourceStateEntry) SourceStateOption {
 	}
 }
 
-func withIgnore(ignore *patternSet) SourceStateOption {
+func withIgnore(ignore *PatternSet) SourceStateOption {
 	return func(s *SourceState) {
 		s.ignore = ignore
 	}
@@ -2191,7 +2191,7 @@ func withIgnoredRelPathStrs(relPathStrs ...string) SourceStateOption {
 	}
 }
 
-func withRemove(remove *patternSet) SourceStateOption {
+func withRemove(remove *PatternSet) SourceStateOption {
 	return func(s *SourceState) {
 		s.remove = remove
 	}

--- a/internal/chezmoi/sourcestate_test.go
+++ b/internal/chezmoi/sourcestate_test.go
@@ -2136,7 +2136,7 @@ func (s *SourceState) applyAll(
 // without error.
 func requireEvaluateAll(t *testing.T, s *SourceState, destSystem System) {
 	t.Helper()
-	err := s.root.forEach(EmptyRelPath, func(targetRelPath RelPath, sourceStateEntry SourceStateEntry) error {
+	err := s.root.ForEach(EmptyRelPath, func(targetRelPath RelPath, sourceStateEntry SourceStateEntry) error {
 		assert.NoError(t, sourceStateEntry.Evaluate())
 		if sourceStateFile, ok := sourceStateEntry.(*SourceStateFile); ok {
 			contents, err := sourceStateFile.Contents()
@@ -2170,9 +2170,9 @@ func requireEvaluateAll(t *testing.T, s *SourceState, destSystem System) {
 
 func withEntries(sourceEntries map[RelPath]SourceStateEntry) SourceStateOption {
 	return func(s *SourceState) {
-		s.root = sourceStateEntryTreeNode{}
+		s.root = SourceStateEntryTreeNode{}
 		for targetRelPath, sourceStateEntry := range sourceEntries {
-			s.root.set(targetRelPath, sourceStateEntry)
+			s.root.Set(targetRelPath, sourceStateEntry)
 		}
 	}
 }

--- a/internal/chezmoi/sourcestateentry.go
+++ b/internal/chezmoi/sourcestateentry.go
@@ -59,7 +59,7 @@ type SourceStateFile struct {
 	contentsSHA256Func   func() ([32]byte, error)
 	origin               SourceStateOrigin
 	sourceRelPath        SourceRelPath
-	targetStateEntryFunc targetStateEntryFunc
+	targetStateEntryFunc TargetStateEntryFunc
 	targetStateEntry     TargetStateEntry
 	targetStateEntryErr  error
 }

--- a/internal/chezmoi/sourcestatetreenode_test.go
+++ b/internal/chezmoi/sourcestatetreenode_test.go
@@ -8,20 +8,20 @@ import (
 )
 
 func TestSourceStateEntryTreeNodeEmpty(t *testing.T) {
-	n := newSourceStateTreeNode()
-	assert.Equal(t, nil, n.get(EmptyRelPath))
-	assert.Equal(t, []*sourceStateEntryTreeNode{n}, n.getNodes(EmptyRelPath))
-	assert.NoError(t, n.forEach(EmptyRelPath, func(RelPath, SourceStateEntry) error {
+	n := NewSourceStateEntryTreeNode()
+	assert.Equal(t, nil, n.Get(EmptyRelPath))
+	assert.Equal(t, []*SourceStateEntryTreeNode{n}, n.GetNodes(EmptyRelPath))
+	assert.NoError(t, n.ForEach(EmptyRelPath, func(RelPath, SourceStateEntry) error {
 		return errors.New("should not be called")
 	}))
 }
 
 func TestSourceStateEntryTreeNodeSingle(t *testing.T) {
-	n := newSourceStateTreeNode()
+	n := NewSourceStateEntryTreeNode()
 	sourceStateFile := &SourceStateFile{}
-	n.set(NewRelPath("file"), sourceStateFile)
-	assert.Equal(t, sourceStateFile, n.get(NewRelPath("file")).(*SourceStateFile))
-	err := n.forEach(EmptyRelPath, func(targetRelPath RelPath, sourceStateEntry SourceStateEntry) error {
+	n.Set(NewRelPath("file"), sourceStateFile)
+	assert.Equal(t, sourceStateFile, n.Get(NewRelPath("file")).(*SourceStateFile))
+	err := n.ForEach(EmptyRelPath, func(targetRelPath RelPath, sourceStateEntry SourceStateEntry) error {
 		assert.Equal(t, NewRelPath("file"), targetRelPath)
 		assert.Equal(t, sourceStateFile, sourceStateEntry.(*SourceStateFile))
 		return nil
@@ -38,13 +38,13 @@ func TestSourceStateEntryTreeNodeMultiple(t *testing.T) {
 		NewRelPath("dir/a_file"): &SourceStateFile{},
 		NewRelPath("dir/b_file"): &SourceStateFile{},
 	}
-	n := newSourceStateTreeNode()
+	n := NewSourceStateEntryTreeNode()
 	for targetRelPath, sourceStateEntry := range entries {
-		n.set(targetRelPath, sourceStateEntry)
+		n.Set(targetRelPath, sourceStateEntry)
 	}
 
 	var targetRelPaths []RelPath
-	err := n.forEach(EmptyRelPath, func(targetRelPath RelPath, sourceStateEntry SourceStateEntry) error {
+	err := n.ForEach(EmptyRelPath, func(targetRelPath RelPath, sourceStateEntry SourceStateEntry) error {
 		assert.Equal(t, entries[targetRelPath], sourceStateEntry)
 		targetRelPaths = append(targetRelPaths, targetRelPath)
 		return nil
@@ -59,5 +59,5 @@ func TestSourceStateEntryTreeNodeMultiple(t *testing.T) {
 		NewRelPath("dir/b_file"),
 	}, targetRelPaths)
 
-	assert.Equal(t, entries, n.getMap())
+	assert.Equal(t, entries, n.GetMap())
 }

--- a/internal/chezmoi/system.go
+++ b/internal/chezmoi/system.go
@@ -44,62 +44,62 @@ type System interface { //nolint:interfacebloat
 	WriteSymlink(oldName string, newName AbsPath) error
 }
 
-// A emptySystemMixin simulates an empty system.
-type emptySystemMixin struct{}
+// A EmptySystemMixin simulates an empty system.
+type EmptySystemMixin struct{}
 
-func (emptySystemMixin) Glob(pattern string) ([]string, error)       { return nil, nil }
-func (emptySystemMixin) Lstat(name AbsPath) (fs.FileInfo, error)     { return nil, fs.ErrNotExist }
-func (emptySystemMixin) RawPath(path AbsPath) (AbsPath, error)       { return path, nil }
-func (emptySystemMixin) ReadDir(name AbsPath) ([]fs.DirEntry, error) { return nil, fs.ErrNotExist }
-func (emptySystemMixin) ReadFile(name AbsPath) ([]byte, error)       { return nil, fs.ErrNotExist }
-func (emptySystemMixin) Readlink(name AbsPath) (string, error)       { return "", fs.ErrNotExist }
-func (emptySystemMixin) Stat(name AbsPath) (fs.FileInfo, error)      { return nil, fs.ErrNotExist }
-func (emptySystemMixin) UnderlyingFS() vfs.FS                        { return nil }
+func (EmptySystemMixin) Glob(pattern string) ([]string, error)       { return nil, nil }
+func (EmptySystemMixin) Lstat(name AbsPath) (fs.FileInfo, error)     { return nil, fs.ErrNotExist }
+func (EmptySystemMixin) RawPath(path AbsPath) (AbsPath, error)       { return path, nil }
+func (EmptySystemMixin) ReadDir(name AbsPath) ([]fs.DirEntry, error) { return nil, fs.ErrNotExist }
+func (EmptySystemMixin) ReadFile(name AbsPath) ([]byte, error)       { return nil, fs.ErrNotExist }
+func (EmptySystemMixin) Readlink(name AbsPath) (string, error)       { return "", fs.ErrNotExist }
+func (EmptySystemMixin) Stat(name AbsPath) (fs.FileInfo, error)      { return nil, fs.ErrNotExist }
+func (EmptySystemMixin) UnderlyingFS() vfs.FS                        { return nil }
 
-// A noUpdateSystemMixin panics on any update.
-type noUpdateSystemMixin struct{}
+// A NoUpdateSystemMixin panics on any update.
+type NoUpdateSystemMixin struct{}
 
-func (noUpdateSystemMixin) Chmod(name AbsPath, perm fs.FileMode) error {
+func (NoUpdateSystemMixin) Chmod(name AbsPath, perm fs.FileMode) error {
 	panic("update to no update system")
 }
 
-func (noUpdateSystemMixin) Chtimes(name AbsPath, atime, mtime time.Time) error {
+func (NoUpdateSystemMixin) Chtimes(name AbsPath, atime, mtime time.Time) error {
 	panic("update to no update system")
 }
 
-func (noUpdateSystemMixin) Link(oldName, newName AbsPath) error {
+func (NoUpdateSystemMixin) Link(oldName, newName AbsPath) error {
 	panic("update to no update system")
 }
 
-func (noUpdateSystemMixin) Mkdir(name AbsPath, perm fs.FileMode) error {
+func (NoUpdateSystemMixin) Mkdir(name AbsPath, perm fs.FileMode) error {
 	panic("update to no update system")
 }
 
-func (noUpdateSystemMixin) Remove(name AbsPath) error {
+func (NoUpdateSystemMixin) Remove(name AbsPath) error {
 	panic("update to no update system")
 }
 
-func (noUpdateSystemMixin) RemoveAll(name AbsPath) error {
+func (NoUpdateSystemMixin) RemoveAll(name AbsPath) error {
 	panic("update to no update system")
 }
 
-func (noUpdateSystemMixin) Rename(oldPath, newPath AbsPath) error {
+func (NoUpdateSystemMixin) Rename(oldPath, newPath AbsPath) error {
 	panic("update to no update system")
 }
 
-func (noUpdateSystemMixin) RunCmd(cmd *exec.Cmd) error {
+func (NoUpdateSystemMixin) RunCmd(cmd *exec.Cmd) error {
 	panic("update to no update system")
 }
 
-func (noUpdateSystemMixin) RunScript(scriptName RelPath, dir AbsPath, data []byte, options RunScriptOptions) error {
+func (NoUpdateSystemMixin) RunScript(scriptName RelPath, dir AbsPath, data []byte, options RunScriptOptions) error {
 	panic("update to no update system")
 }
 
-func (noUpdateSystemMixin) WriteFile(filename AbsPath, data []byte, perm fs.FileMode) error {
+func (NoUpdateSystemMixin) WriteFile(filename AbsPath, data []byte, perm fs.FileMode) error {
 	panic("update to no update system")
 }
 
-func (noUpdateSystemMixin) WriteSymlink(oldName string, newName AbsPath) error {
+func (NoUpdateSystemMixin) WriteSymlink(oldName string, newName AbsPath) error {
 	panic("update to no update system")
 }
 

--- a/internal/chezmoi/system.go
+++ b/internal/chezmoi/system.go
@@ -160,9 +160,9 @@ func Walk(system System, rootAbsPath AbsPath, walkFunc WalkFunc) error {
 	return vfs.Walk(system.UnderlyingFS(), rootAbsPath.String(), outerWalkFunc)
 }
 
-// A concurrentWalkSourceDirFunc is a function called concurrently for every
+// A ConcurrentWalkSourceDirFunc is a function called concurrently for every
 // entry in a source directory.
-type concurrentWalkSourceDirFunc func(ctx context.Context, absPath AbsPath, fileInfo fs.FileInfo, err error) error
+type ConcurrentWalkSourceDirFunc func(ctx context.Context, absPath AbsPath, fileInfo fs.FileInfo, err error) error
 
 // WalkSourceDir walks the source directory rooted at sourceDirAbsPath in
 // system, calling walkFunc for each file or directory in the tree, including
@@ -240,7 +240,7 @@ func concurrentWalkSourceDir(
 	ctx context.Context,
 	system System,
 	dirAbsPath AbsPath,
-	walkFunc concurrentWalkSourceDirFunc,
+	walkFunc ConcurrentWalkSourceDirFunc,
 ) error {
 	dirEntries, err := system.ReadDir(dirAbsPath)
 	if err != nil {

--- a/internal/chezmoi/targetstateentry.go
+++ b/internal/chezmoi/targetstateentry.go
@@ -69,15 +69,15 @@ type TargetStateSymlink struct {
 	sourceAttr   SourceAttr
 }
 
-// A modifyDirWithCmdState records the state of a directory modified by a
+// A ModifyDirWithCmdState records the state of a directory modified by a
 // command.
-type modifyDirWithCmdState struct {
+type ModifyDirWithCmdState struct {
 	Name  AbsPath   `json:"name"  yaml:"name"`
 	RunAt time.Time `json:"runAt" yaml:"runAt"`
 }
 
-// A scriptState records the state of a script that has been run.
-type scriptState struct {
+// A ScriptState records the state of a script that has been run.
+type ScriptState struct {
 	Name  RelPath   `json:"name"  yaml:"name"`
 	RunAt time.Time `json:"runAt" yaml:"runAt"`
 }
@@ -101,7 +101,7 @@ func (t *TargetStateModifyDirWithCmd) Apply(
 
 	modifyDirWithCmdStateKey := []byte(actualStateEntry.Path().String())
 	if err := PersistentStateSet(
-		persistentState, GitRepoExternalStateBucket, modifyDirWithCmdStateKey, &modifyDirWithCmdState{
+		persistentState, GitRepoExternalStateBucket, modifyDirWithCmdStateKey, &ModifyDirWithCmdState{
 			Name:  actualStateEntry.Path(),
 			RunAt: runAt,
 		}); err != nil {
@@ -136,7 +136,7 @@ func (t *TargetStateModifyDirWithCmd) SkipApply(persistentState PersistentState,
 	case modifyDirWithCmdStateBytes == nil:
 		return false, nil
 	default:
-		var modifyDirWithCmdState modifyDirWithCmdState
+		var modifyDirWithCmdState ModifyDirWithCmdState
 		if err := stateFormat.Unmarshal(modifyDirWithCmdStateBytes, &modifyDirWithCmdState); err != nil {
 			return false, err
 		}
@@ -363,7 +363,7 @@ func (t *TargetStateScript) Apply(
 	}
 
 	scriptStateKey := []byte(hex.EncodeToString(contentsSHA256[:]))
-	if err := PersistentStateSet(persistentState, ScriptStateBucket, scriptStateKey, &scriptState{
+	if err := PersistentStateSet(persistentState, ScriptStateBucket, scriptStateKey, &ScriptState{
 		Name:  t.name,
 		RunAt: runAt,
 	}); err != nil {

--- a/internal/chezmoi/tarwritersystem.go
+++ b/internal/chezmoi/tarwritersystem.go
@@ -9,8 +9,8 @@ import (
 
 // A TarWriterSystem is a System that writes to a tar archive.
 type TarWriterSystem struct {
-	emptySystemMixin
-	noUpdateSystemMixin
+	EmptySystemMixin
+	NoUpdateSystemMixin
 
 	tarWriter      *tar.Writer
 	headerTemplate tar.Header

--- a/internal/chezmoi/zipwritersystem.go
+++ b/internal/chezmoi/zipwritersystem.go
@@ -11,8 +11,8 @@ import (
 
 // A ZIPWriterSystem is a System that writes to a ZIP archive.
 type ZIPWriterSystem struct {
-	emptySystemMixin
-	noUpdateSystemMixin
+	EmptySystemMixin
+	NoUpdateSystemMixin
 
 	zipWriter *zip.Writer
 	modified  time.Time

--- a/internal/cmd/dumpcmd.go
+++ b/internal/cmd/dumpcmd.go
@@ -54,5 +54,5 @@ func (c *Config) runDumpCmd(cmd *cobra.Command, args []string) error {
 	}); err != nil {
 		return err
 	}
-	return c.marshal(cmp.Or(c.dump.format.String(), c.Format.String()), dumpSystem.Data())
+	return c.marshal(cmp.Or(c.dump.format.String(), c.Format.String()), dumpSystem.Data)
 }


### PR DESCRIPTION
Refs #4628.

The goal of this PR is to make https://pkg.go.dev/chezmoi.io/chezmoi/internal/chezmoi more complete.

There are no functional changes. Only internal changes.

chezmoi has a bunch of internal packages that cannot be imported outside chezmoi. These internal packages currently have non-exported types and functions, but there is no point in not exporting these when the package is internal.

This PR exports several types and methods, which means that they will be now be documented on https://pkg.go.dev/chezmoi.io/chezmoi/internal/chezmoi, while still remaining internal to the project.