### PR TITLE
fix: Reverse command check for current user in docker feature

### DIFF
--- a/assets/templates/install-init-shell.sh.tmpl
+++ b/assets/templates/install-init-shell.sh.tmpl
@@ -17,10 +17,10 @@ elif [ -n "${USER}" ]; then
 	username="${USER}"
 elif [ -n "${USERNAME}" ]; then
 	username="${USERNAME}"
-elif is_command logname; then
-	username="$(logname)"
 elif is_command whoami; then
 	username="$(whoami)"
+elif is_command logname; then
+	username="$(logname)"
 else
 	printf "unable to determine username" 1>&2
 	exit 1


### PR DESCRIPTION
The docker feature failed with debian images because, when Chezmoi tries to read the current user, it tried to run `logname`, which fails for root on the base Debian images.

This change tries getting the current user with `whoami` first, which returns 'root' on base Debian images.

# PR prep

I could not find the right place to test this beyond my local manual test. Happy to give this a try if you can point me to the right place.

All current tests pass.

I don't think this requires documentation changes.


--- 
Fixes #4700

<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer-guide/contributing-changes/

-->
