### PR TITLE
fix: input prompt line wrapping (#3583)

### DIFF
--- a/internal/chezmoibubbles/boolinputmodel.go
+++ b/internal/chezmoibubbles/boolinputmodel.go
@@ -17,7 +17,7 @@ type BoolInputModel struct {
 
 func NewBoolInputModel(prompt string, defaultValue *bool) BoolInputModel {
 	textInput := textinput.New()
-	textInput.Prompt = prompt + "? "
+	textInput.Prompt = prompt
 	textInput.Placeholder = "bool"
 	if defaultValue != nil {
 		textInput.Placeholder += ", default " + strconv.FormatBool(*defaultValue)

--- a/internal/chezmoibubbles/choiceinputmodel.go
+++ b/internal/chezmoibubbles/choiceinputmodel.go
@@ -20,7 +20,7 @@ type ChoiceInputModel struct {
 
 func NewChoiceInputModel(prompt string, choices []string, defaultValue *string) ChoiceInputModel {
 	textInput := textinput.New()
-	textInput.Prompt = prompt + "? "
+	textInput.Prompt = prompt
 	textInput.Placeholder = strings.Join(choices, "/")
 	if defaultValue != nil {
 		textInput.Placeholder += ", default " + *defaultValue

--- a/internal/chezmoibubbles/intinputmodel.go
+++ b/internal/chezmoibubbles/intinputmodel.go
@@ -15,7 +15,7 @@ type IntInputModel struct {
 
 func NewIntInputModel(prompt string, defaultValue *int64) IntInputModel {
 	textInput := textinput.New()
-	textInput.Prompt = prompt + "? "
+	textInput.Prompt = prompt
 	textInput.Placeholder = "int"
 	if defaultValue != nil {
 		textInput.Placeholder += ", default " + strconv.FormatInt(*defaultValue, 10)

--- a/internal/chezmoibubbles/stringinputmodel.go
+++ b/internal/chezmoibubbles/stringinputmodel.go
@@ -13,7 +13,7 @@ type StringInputModel struct {
 
 func NewStringInputModel(prompt string, defaultValue *string) StringInputModel {
 	textInput := textinput.New()
-	textInput.Prompt = prompt + "? "
+	textInput.Prompt = prompt
 	textInput.Placeholder = "string"
 	if defaultValue != nil {
 		textInput.Placeholder += ", default " + *defaultValue

--- a/internal/cmd/prompt.go
+++ b/internal/cmd/prompt.go
@@ -36,7 +36,11 @@ func (c *Config) readBool(prompt string, defaultValue *bool) (bool, error) {
 			}
 		}
 	default:
-		initModel := chezmoibubbles.NewBoolInputModel(prompt, defaultValue)
+		_, err := c.stdout.Write([]byte(prompt + "?\n"))
+		if err != nil {
+			return false, err
+		}
+		initModel := chezmoibubbles.NewBoolInputModel("> ", defaultValue)
 		finalModel, err := runCancelableModel(initModel)
 		if err != nil {
 			return false, err
@@ -68,7 +72,11 @@ func (c *Config) readChoice(prompt string, choices []string, defaultValue *strin
 			}
 		}
 	default:
-		initModel := chezmoibubbles.NewChoiceInputModel(prompt, choices, defaultValue)
+		_, err := c.stdout.Write([]byte(prompt + "?\n"))
+		if err != nil {
+			return "", err
+		}
+		initModel := chezmoibubbles.NewChoiceInputModel("> ", choices, defaultValue)
 		finalModel, err := runCancelableModel(initModel)
 		if err != nil {
 			return "", err
@@ -99,7 +107,11 @@ func (c *Config) readInt(prompt string, defaultValue *int64) (int64, error) {
 			}
 		}
 	default:
-		initModel := chezmoibubbles.NewIntInputModel(prompt, defaultValue)
+		_, err := c.stdout.Write([]byte(prompt + "?\n"))
+		if err != nil {
+			return 0, err
+		}
+		initModel := chezmoibubbles.NewIntInputModel("> ", defaultValue)
 		finalModel, err := runCancelableModel(initModel)
 		if err != nil {
 			return 0, err
@@ -181,7 +193,11 @@ func (c *Config) readMultichoice(prompt string, choices []string, defaultValue *
 		return result, nil
 
 	default:
-		initModel := chezmoibubbles.NewMultichoiceInputModel(prompt, choices, defaultValue)
+		_, err := c.stdout.Write([]byte(prompt + "?\n"))
+		if err != nil {
+			return []string{}, err
+		}
+		initModel := chezmoibubbles.NewMultichoiceInputModel("> ", choices, defaultValue)
 		finalModel, err := tea.NewProgram(initModel, tea.WithOutput(os.Stderr)).Run()
 		if err != nil {
 			return []string{}, err
@@ -226,7 +242,11 @@ func (c *Config) readString(prompt string, defaultValue *string) (string, error)
 		}
 		return value, nil
 	default:
-		initModel := chezmoibubbles.NewStringInputModel(prompt, defaultValue)
+		_, err := c.stdout.Write([]byte(prompt + "?\n"))
+		if err != nil {
+			return "", err
+		}
+		initModel := chezmoibubbles.NewStringInputModel("> ", defaultValue)
 		finalModel, err := runCancelableModel(initModel)
 		if err != nil {
 			return "", err


### PR DESCRIPTION
When prompting for input, write prompt text to stdout with a newline, then call bubbles for user input. Bubbles does not wrap prompt text if it is longer than the terminal width, printing to stdout does.

Resolves #3583

![WindowsTerminal_j1cIAei2QJ](https://github.com/user-attachments/assets/440422e7-230d-4f70-a07d-fe84aab44d5a)
