### PR TITLE
fix: adjusted grep to filename anchor

### DIFF
--- a/get
+++ b/get
@@ -316,7 +316,7 @@ hash_sha256_verify() {
 	checksums="${2}"
 	basename="${target##*/}"
 
-	want="$(grep "${basename}" "${checksums}" 2>/dev/null | tr '\t' ' ' | cut -d ' ' -f 1)"
+	want="$(grep "${basename}\$" "${checksums}" 2>/dev/null | tr '\t' ' ' | cut -d ' ' -f 1)"
 	if [ -z "${want}" ]; then
 		log_err "hash_sha256_verify unable to find checksum for ${target} in ${checksums}"
 		return 1


### PR DESCRIPTION
the latest build included filenames that had the same prefix (chezmoi_2.66.1_linux_glibc_amd64.tar.gz and chezmoi_2.66.1_linux_glibc_amd64.tar.gz.sbom.json). it seems like the .sbom.json sorts ahead of the actual tarbal, causing checksum mismatch errors. this patch should ensure that filenames match properly.

<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer-guide/contributing-changes/

-->
