### PR TITLE
fix: Fix fromIni | toIni template func round trip with quoted strings

### DIFF
--- a/internal/cmd/templatefuncs.go
+++ b/internal/cmd/templatefuncs.go
@@ -173,7 +173,9 @@ func (c *Config) findOneExecutableTemplateFunc(fileList, pathList any) string {
 }
 
 func (c *Config) fromIniTemplateFunc(s string) map[string]any {
-	return iniFileToMap(mustValue(ini.Load([]byte(s))))
+	return iniFileToMap(mustValue(ini.LoadSources(ini.LoadOptions{
+		UnescapeValueDoubleQuotes: true,
+	}, []byte(s))))
 }
 
 // fromJsonTemplateFunc parses s as JSON and returns the result. In contrast to

--- a/internal/cmd/testdata/scripts/issue4727.txtar
+++ b/internal/cmd/testdata/scripts/issue4727.txtar
@@ -1,0 +1,6 @@
+# test that fromIni | toIni does not mangle strings
+exec chezmoi execute-template '{{ "a = \"\\\"\"" | fromIni | toIni | fromIni | toIni }}'
+cmp stdout golden/stdout
+
+-- golden/stdout --
+a = "\""


### PR DESCRIPTION
Fixes #4727.