### PR TITLE
fix: Docs in "User guide -> tools -> merge -> use vscode as the merge tool" don't work for paths with spaces in them

### DIFF
--- a/assets/chezmoi.io/docs/user-guide/tools/merge.md
+++ b/assets/chezmoi.io/docs/user-guide/tools/merge.md
@@ -67,7 +67,7 @@ To use [VSCode][vscode] as the merge tool, add the following to your config:
     command = "bash"
     args = [
         "-c",
-        "cp {{ .Target }} {{ .Target }}.base && code --new-window --wait --merge {{ .Destination }} {{ .Target }} {{ .Target }}.base {{ .Source }}",
+        "cp \"{{ .Target }}\" \"{{ .Target }}.base\" && code --new-window --wait --merge \"{{ .Destination }}\" \"{{ .Target }}\" \"{{ .Target }}.base\" \"{{ .Source }}\"",
     ]
     ```
 
@@ -78,7 +78,7 @@ To use [VSCode][vscode] as the merge tool, add the following to your config:
       command: "bash"
       args:
       - "-c"
-      - "cp {{ .Target }} {{ .Target }}.base && code --new-window --wait --merge {{ .Destination }} {{ .Target }} {{ .Target }}.base {{ .Source }}"
+      - "cp \"{{ .Target }}\" \"{{ .Target }}.base\" && code --new-window --wait --merge \"{{ .Destination }}\" \"{{ .Target }}\" \"{{ .Target }}.base\" \"{{ .Source }}\""
     ```
 
 [bcomp]: https://www.scootersoftware.com/


### PR DESCRIPTION
Solves #4730 

<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer-guide/contributing-changes/

-->
