### PR TITLE
Feat: re-add command syncs exact_ directories by adding new files, and removing deleted files from source

### DIFF
--- a/assets/chezmoi.io/docs/reference/commands/add.md
+++ b/assets/chezmoi.io/docs/reference/commands/add.md
@@ -33,6 +33,12 @@ Encrypt files using the defined encryption method.
 
 Set the `exact` attribute on added directories.
 
+!!! warning
+
+    Directories with the `exact` attributes are statefully synced between target and source directories.
+    When running `re-add`, any files deleted from the `exact` target directory will be removed from the source directory.
+    Likewise, any files added to the `exact` target directory, will be added to the source directory
+
 ### `--follow`
 
 If the last part of a target is a symlink, add the target of the symlink

--- a/internal/cmd/readdcmd.go
+++ b/internal/cmd/readdcmd.go
@@ -84,6 +84,9 @@ func (c *Config) runReAddCmd(cmd *cobra.Command, args []string, sourceState *che
 	}
 	slices.SortFunc(targetRelPaths, chezmoi.CompareRelPaths)
 
+	// Track which files were already processed to avoid double-processing with exact directories
+	processedFiles := make(map[chezmoi.RelPath]bool)
+
 TARGET_REL_PATH:
 	for _, targetRelPath := range targetRelPaths {
 		sourceStateFile, ok := sourceStateEntries[targetRelPath].(*chezmoi.SourceStateFile)
@@ -197,6 +200,150 @@ TARGET_REL_PATH:
 			PreAddFunc:      c.defaultPreAddFunc,
 		}); err != nil {
 			return err
+		}
+		// Mark this file as processed
+		processedFiles[targetRelPath] = true
+	}
+
+	// Process exact directories - add new files and remove deleted files
+	return c.processExactDirs(sourceState, sourceStateEntries, processedFiles)
+}
+
+// processExactDirs handles exact directory synchronization during re-add.
+// It adds new files found in exact target directories and removes files from
+// source that no longer exist in exact target directories.
+// processedFiles contains files that were already re-added in the file loop,
+// outside of the exact directory logic, to avoid double-processing them.
+func (c *Config) processExactDirs(
+	sourceState *chezmoi.SourceState,
+	sourceStateEntries map[chezmoi.RelPath]chezmoi.SourceStateEntry,
+	processedFiles map[chezmoi.RelPath]bool,
+) error {
+	// Collect all exact directories from source state that are in scope
+	// An exact directory is in scope if:
+	// 1. It's directly in sourceStateEntries (was explicitly or implicitly targeted)
+	// 2. Any of its children are in sourceStateEntries (parent dir needs sync)
+	exactDirs := make(map[chezmoi.RelPath]*chezmoi.SourceStateDir)
+
+	// First, collect exact directories that are directly in the entries
+	for targetRelPath, entry := range sourceStateEntries {
+		if sourceStateDir, ok := entry.(*chezmoi.SourceStateDir); ok && sourceStateDir.Attr.Exact {
+			exactDirs[targetRelPath] = sourceStateDir
+		}
+	}
+
+	// Then, collect parent exact directories for any entries
+	for targetRelPath := range sourceStateEntries {
+		// Walk up the path to find parent exact directories
+		for parentPath := targetRelPath.Dir(); parentPath != chezmoi.DotRelPath; parentPath = parentPath.Dir() {
+			// Check if this parent is an exact directory in source state
+			parentEntry := sourceState.Get(parentPath)
+			if sourceStateDir, ok := parentEntry.(*chezmoi.SourceStateDir); ok && sourceStateDir.Attr.Exact {
+				// Only add if not already present
+				if _, exists := exactDirs[parentPath]; !exists {
+					exactDirs[parentPath] = sourceStateDir
+				}
+			}
+		}
+	}
+
+	// Process each exact directory
+	for targetRelPath := range exactDirs {
+		targetDirAbsPath := c.DestDirAbsPath.Join(targetRelPath)
+
+		// Read the target directory contents
+		dirEntries, err := c.destSystem.ReadDir(targetDirAbsPath)
+		if err != nil {
+			// If directory doesn't exist in target, skip it
+			continue
+		}
+
+		// Build sets of files in source and target
+		sourceFiles := make(map[string]chezmoi.SourceStateEntry)
+		targetFiles := make(map[string]fs.DirEntry)
+
+		// Collect files from source state that are in this exact directory
+		// Only consider actual files, not removes or other entry types
+		for entryRelPath, entry := range sourceStateEntries {
+			// Check if this entry is a direct child of the exact directory
+			if entryRelPath.Dir() == targetRelPath {
+				// Only count actual files in source, not remove entries
+				if _, ok := entry.(*chezmoi.SourceStateFile); ok {
+					sourceFiles[entryRelPath.Base()] = entry
+				}
+			}
+		}
+
+		// Collect files from target directory
+		for _, dirEntry := range dirEntries {
+			name := dirEntry.Name()
+			if name == "." || name == ".." {
+				continue
+			}
+			targetFiles[name] = dirEntry
+		}
+
+		// Find new files (in target but not in source) and add them
+		destAbsPathInfos := make(map[chezmoi.AbsPath]fs.FileInfo)
+		for name, dirEntry := range targetFiles {
+			entryRelPath := targetRelPath.JoinString(name)
+
+			// Skip files that were already processed in the file re-add loop
+			if processedFiles[entryRelPath] {
+				continue
+			}
+
+			if _, inSource := sourceFiles[name]; !inSource {
+				// Check if ignored
+				if sourceState.Ignore(entryRelPath) {
+					continue
+				}
+
+				// Skip subdirectories that are themselves exact directories
+				// They will be processed separately in their own exact directory processing
+				if dirEntry.IsDir() {
+					childEntry := sourceState.Get(entryRelPath)
+					if childDir, ok := childEntry.(*chezmoi.SourceStateDir); ok && childDir.Attr.Exact {
+						continue
+					}
+				}
+
+				// This is a new file - add it
+				// Get full FileInfo (DirEntry only has partial info)
+				destAbsPath := targetDirAbsPath.JoinString(name)
+				fileInfo, err := dirEntry.Info()
+				if err != nil {
+					return err
+				}
+				destAbsPathInfos[destAbsPath] = fileInfo
+			}
+		}
+
+		// Add new files if any were found
+		if len(destAbsPathInfos) > 0 {
+			if err := sourceState.Add(c.sourceSystem, c.persistentState, c.destSystem, destAbsPathInfos, &chezmoi.AddOptions{
+				Filter:     c.reAdd.filter,
+				PreAddFunc: c.defaultPreAddFunc,
+			}); err != nil {
+				return err
+			}
+		}
+
+		// Find deleted files (in source but not in target) and remove them
+		for name, sourceEntry := range sourceFiles {
+			if _, inTarget := targetFiles[name]; !inTarget {
+				// Check if ignored
+				entryRelPath := targetRelPath.JoinString(name)
+				if sourceState.Ignore(entryRelPath) {
+					continue
+				}
+
+				// This file was deleted from target - remove it from source
+				sourceAbsPath := c.SourceDirAbsPath.Join(sourceEntry.SourceRelPath().RelPath())
+				if err := c.sourceSystem.RemoveAll(sourceAbsPath); err != nil {
+					return err
+				}
+			}
 		}
 	}
 

--- a/internal/cmd/testdata/scripts/re-add.txtar
+++ b/internal/cmd/testdata/scripts/re-add.txtar
@@ -22,10 +22,12 @@ grep -count=1 '# edited' $CHEZMOISOURCEDIR/dot_file
 grep -count=2 '# edited' $CHEZMOISOURCEDIR/dot_dir/file
 grep -count=1 '# edited' $CHEZMOISOURCEDIR/dot_dir/exact_subdir/file
 
-# test that chezmoi re-add --recursive=false does not recurse into subdirectories
+# test that chezmoi re-add --recursive=false does not recurse into subdirectories AND still syncs exact directories
+# Even with --recursive=false, exact directory sync happens because subdir is exact
 exec chezmoi re-add --recursive=false ~/.dir/subdir
-grep -count=1 '# edited' $CHEZMOISOURCEDIR/dot_dir/exact_subdir/file
+grep -count=2 '# edited' $CHEZMOISOURCEDIR/dot_dir/exact_subdir/file
 
 # test that chezmoi re-add is recursive by default
+edit $HOME/.dir/subdir/file
 exec chezmoi re-add ~/.dir/subdir
-grep -count=2 '# edited' $CHEZMOISOURCEDIR/dot_dir/exact_subdir/file
+grep -count=3 '# edited' $CHEZMOISOURCEDIR/dot_dir/exact_subdir/file

--- a/internal/cmd/testdata/scripts/readd-exact.txtar
+++ b/internal/cmd/testdata/scripts/readd-exact.txtar
@@ -1,0 +1,95 @@
+# test that chezmoi re-add adds new files in exact_ directories
+exec chezmoi add --exact $HOME${/}test-dir
+exists $CHEZMOISOURCEDIR/exact_test-dir/test1
+cmp $CHEZMOISOURCEDIR/exact_test-dir/test1 golden/test1
+
+# verify no diff after initial add
+exec chezmoi diff
+! stdout .
+
+# add a new file to the exact directory in target
+cp golden/test2 $HOME/test-dir/test2
+exec chezmoi re-add
+exists $CHEZMOISOURCEDIR/exact_test-dir/test2
+cmp $CHEZMOISOURCEDIR/exact_test-dir/test2 golden/test2
+
+# verify no diff after adding new file
+exec chezmoi diff
+! stdout .
+
+# test that chezmoi re-add removes deleted files from exact_ directories
+rm $HOME/test-dir/test1
+exec chezmoi re-add
+! exists $CHEZMOISOURCEDIR/exact_test-dir/test1
+
+# verify no diff after removing file
+exec chezmoi diff
+! stdout .
+
+# test that chezmoi re-add with explicit exact directory target works
+cp golden/test3 $HOME/test-dir/test3
+exec chezmoi re-add $HOME/test-dir
+exists $CHEZMOISOURCEDIR/exact_test-dir/test3
+cmp $CHEZMOISOURCEDIR/exact_test-dir/test3 golden/test3
+
+# verify no diff after adding file with explicit target
+exec chezmoi diff
+! stdout .
+
+# test nested exact directory with --recursive=false
+exec chezmoi add $HOME/outer-dir
+exec chezmoi add --exact $HOME/outer-dir/exact-inner
+exists $CHEZMOISOURCEDIR/outer-dir/exact_exact-inner/inner1
+
+# add a new file to the nested exact directory in target
+cp golden/inner2 $HOME/outer-dir/exact-inner/inner2
+
+# re-add with --recursive=false should NOT process nested exact directory, and thereforce should not add new file inner2.
+exec chezmoi re-add --recursive=false $HOME/outer-dir
+! exists $CHEZMOISOURCEDIR/outer-dir/exact_exact-inner/inner2
+
+# re-add with recursive (default) SHOULD process nested exact directory
+exec chezmoi re-add $HOME/outer-dir
+exists $CHEZMOISOURCEDIR/outer-dir/exact_exact-inner/inner2
+cmp $CHEZMOISOURCEDIR/outer-dir/exact_exact-inner/inner2 golden/inner2
+
+# verify no diff
+exec chezmoi diff
+! stdout .
+
+# test nested exact directories (both parent and child are exact)
+exec chezmoi add --exact $HOME/exact-outer
+exists $CHEZMOISOURCEDIR/exact_exact-outer/exact_exact-inner/nested1
+
+# add a new file to the nested exact directory
+cp golden/nested2 $HOME/exact-outer/exact-inner/nested2
+
+# re-add should process both exact directories and add the new file
+exec chezmoi re-add
+exists $CHEZMOISOURCEDIR/exact_exact-outer/exact_exact-inner/nested2
+cmp $CHEZMOISOURCEDIR/exact_exact-outer/exact_exact-inner/nested2 golden/nested2
+
+# verify no diff
+exec chezmoi diff
+! stdout .
+
+-- golden/inner2 --
+# contents of inner2
+-- golden/nested2 --
+# contents of nested2
+-- golden/test1 --
+# contents of test1
+-- golden/test2 --
+# contents of test2
+-- golden/test3 --
+# contents of test3
+-- home/user/exact-outer/exact-inner/nested1 --
+# contents of nested1
+-- home/user/exact-outer/outer1 --
+# contents of outer1
+-- home/user/outer-dir/exact-inner/inner1 --
+# contents of inner1
+-- home/user/outer-dir/file1 --
+# contents of outer file1
+-- home/user/test-dir/test1 --
+# contents of test1


### PR DESCRIPTION
<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer-guide/contributing-changes/

-->
Related issue: #2298

As discussed, this PR aims to make exact_ directories more "stateful" when re-adding them.
If an existing exact_ directory has files added or deleted, the source directory will reflect that after running `re-add`

I ran into a few logic edge cases when figuring all of this out, I believe I figured them all out but I would love a second pair of eyes on these choices.

I did have to modify the `re-add.txtar` test to make sure it passes with the new logic.

This has been a doozy to implement and I would not be surprised if I made some dumb mistakes. I'll look through it again with fresh eyes later.