### PR TITLE
chore: Specify commit message requirements in developer guide

### DIFF
--- a/assets/chezmoi.io/docs/developer-guide/contributing-changes.md
+++ b/assets/chezmoi.io/docs/developer-guide/contributing-changes.md
@@ -35,15 +35,27 @@ that:
 * The code passes [`golangci-lint`][golangci-lint]. You can ensure this by
   running `make lint`.
 
-* The commit messages follow the [conventional commits specification][commits].
-  chezmoi's release notes are generated directly from the commit messages. The
-  following criteria can be used to determine the commit type:
+* The commit messages adhere to the [conventional commits specification][commits],
+  with the following additional requirements:
 
-      * Small changes, such as fixing a typo or correcting grammar: `chore`
-      * Bug fixes: `fix`
-      * Extending an existing feature, or adding a new feature: `feat`
-      * Adding to, or updating, the documentation: `docs`
-      * Anything not covered by the above: `chore`
+      * The first character of the commit message is uppercase, e.g:
+
+          ```text
+          chore: Fix typo in test
+          ```
+
+        The purpose of this is to maintain consistency in chezmoi's release
+        notes, which are generated directly from the commit messages.
+
+      * The commits do not have scopes (e.g. `chore(scope): Message` is invalid).
+
+    The following criteria can be used to determine the commit type:
+
+      * `fix`: bug fixes in chezmoi code
+      * `feat`: extending an existing feature or adding a new feature
+      * `docs`: adding to or updating the documentation
+      * `chore`: small changes, such as fixing a typo, correcting grammar
+        (including in documentation), or anything not covered by the above
 
     Examples can be found in the [commit history][history].
 


### PR DESCRIPTION
Given that it was ultimately decided to stick with the existing requirements in https://github.com/twpayne/chezmoi/pull/4467, and the fact that they differ from the Conventional Commits specification, we should document this.