### PR TITLE
fix: Ignore special-use domains when extracting hostname from /etc/hosts

### DIFF
--- a/internal/chezmoi/chezmoi_test.go
+++ b/internal/chezmoi/chezmoi_test.go
@@ -58,7 +58,9 @@ func TestEtcHostsFQDNHostname(t *testing.T) {
 			root: map[string]any{
 				"/etc/hosts": chezmoitest.JoinLines(
 					`127.0.0.1 localhost.localdomain`,
-					`127.0.0.2 host.example.com host`,
+					`127.0.0.2 service.local`,
+					`127.0.0.4 multi.part.domain.example`,
+					`127.0.0.4 host.example.com host`,
 				),
 			},
 			f:        etcHostsFQDNHostname,


### PR DESCRIPTION
Refs #4746. As suggested by @halostatue in https://github.com/twpayne/chezmoi/issues/4746#issuecomment-3476463903.