### PR TITLE
fix: Fix panic in execute-template --override-data with no template data

### DIFF
--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -3087,6 +3087,7 @@ func newConfigFile(bds *xdg.BaseDirectorySpecification) ConfigFile {
 		Color: autoBool{
 			auto: true,
 		},
+		Data:         make(map[string]any),
 		Interpreters: defaultInterpreters,
 		Mode:         chezmoi.ModeFile,
 		Pager:        os.Getenv("PAGER"),

--- a/internal/cmd/testdata/scripts/issue4796.txtar
+++ b/internal/cmd/testdata/scripts/issue4796.txtar
@@ -1,0 +1,3 @@
+# test that chezmoi execute-template --override-data does not panic when there is no template data
+exec chezmoi execute-template --override-data '{"foo":"baz"}' '{{ .foo }}'
+stdout baz


### PR DESCRIPTION
Fixes #4796.