### PR TITLE
fix: Don't overwrite config file in init --dry-run

### DIFF
--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -883,10 +883,10 @@ func (c *Config) createAndReloadConfigFile(cmd *cobra.Command) error {
 			configPath = c.customConfigFileAbsPath
 		}
 	}
-	if err := chezmoi.MkdirAll(c.baseSystem, configPath.Dir(), fs.ModePerm); err != nil {
+	if err := chezmoi.MkdirAll(c.destSystem, configPath.Dir(), fs.ModePerm); err != nil {
 		return err
 	}
-	if err := c.baseSystem.WriteFile(configPath, configFileContents, 0o600); err != nil {
+	if err := c.destSystem.WriteFile(configPath, configFileContents, 0o600); err != nil {
 		return err
 	}
 

--- a/internal/cmd/testdata/scripts/issue4703.txtar
+++ b/internal/cmd/testdata/scripts/issue4703.txtar
@@ -1,0 +1,10 @@
+# test that chezmoi init --dry-run does not overwrite the config file
+exec chezmoi init --dry-run
+cmp $CHEZMOICONFIGDIR/chezmoi.toml golden/chezmoi.toml
+
+-- golden/chezmoi.toml --
+# current contents of .config/chezmoi/chezmoi.toml
+-- home/user/.config/chezmoi/chezmoi.toml --
+# current contents of .config/chezmoi/chezmoi.toml
+-- home/user/.local/share/chezmoi/.chezmoi.toml.tmpl --
+# new contents of .config/chezmoi/chezmoi.toml


### PR DESCRIPTION
Fixes #4703.