### PR TITLE
feat: Add support for Sprout template functions

### DIFF
--- a/internal/chezmoi/sourcestate.go
+++ b/internal/chezmoi/sourcestate.go
@@ -145,7 +145,8 @@ type SourceState struct {
 	userTemplateData        map[string]any
 	priorityTemplateData    map[string]any
 	templateData            map[string]any
-	templateFuncs           template.FuncMap
+	sprigTemplateFuncs      template.FuncMap
+	sproutTemplateFuncs     template.FuncMap
 	templateOptions         []string
 	templates               map[string]*Template
 	externals               map[RelPath][]*External
@@ -268,10 +269,17 @@ func WithTemplateDataOnly(templateDataOnly bool) SourceStateOption {
 	}
 }
 
-// WithTemplateFuncs sets the template functions.
-func WithTemplateFuncs(templateFuncs template.FuncMap) SourceStateOption {
+// WithSprigTemplateFuncs sets the Sprig template functions.
+func WithSprigTemplateFuncs(sprigTemplateFuncs template.FuncMap) SourceStateOption {
 	return func(s *SourceState) {
-		s.templateFuncs = templateFuncs
+		s.sprigTemplateFuncs = sprigTemplateFuncs
+	}
+}
+
+// WithSproutTemplateFuncs sets the Sprout template functions.
+func WithSproutTemplateFuncs(sproutTemplateFuncs template.FuncMap) SourceStateOption {
+	return func(s *SourceState) {
+		s.sproutTemplateFuncs = sproutTemplateFuncs
 	}
 }
 
@@ -846,7 +854,8 @@ type ExecuteTemplateDataOptions struct {
 // ExecuteTemplateData returns the result of executing template data.
 func (s *SourceState) ExecuteTemplateData(options ExecuteTemplateDataOptions) ([]byte, error) {
 	templateOptions := options.TemplateOptions
-	templateOptions.Funcs = s.templateFuncs
+	templateOptions.SprigFuncs = s.sprigTemplateFuncs
+	templateOptions.SproutFuncs = s.sproutTemplateFuncs
 	templateOptions.Options = slices.Clone(s.templateOptions)
 
 	tmpl, err := ParseTemplate(options.NameRelPath.String(), options.Data, templateOptions)
@@ -1601,8 +1610,9 @@ func (s *SourceState) addTemplatesDir(ctx context.Context, templatesDirAbsPath A
 			name := templateRelPath.String()
 
 			tmpl, err := ParseTemplate(name, contents, TemplateOptions{
-				Funcs:   s.templateFuncs,
-				Options: slices.Clone(s.templateOptions),
+				SprigFuncs:  s.sprigTemplateFuncs,
+				SproutFuncs: s.sproutTemplateFuncs,
+				Options:     slices.Clone(s.templateOptions),
 			})
 			if err != nil {
 				return err
@@ -2028,8 +2038,9 @@ func (s *SourceState) newModifyTargetStateEntryFunc(
 				templateContents := removeMatches(modifierContents, matches)
 				var tmpl *Template
 				tmpl, err = ParseTemplate(sourceFile, templateContents, TemplateOptions{
-					Funcs:   s.templateFuncs,
-					Options: slices.Clone(s.templateOptions),
+					SprigFuncs:  s.sprigTemplateFuncs,
+					SproutFuncs: s.sproutTemplateFuncs,
+					Options:     slices.Clone(s.templateOptions),
 				})
 				if err != nil {
 					return nil, err

--- a/internal/cmd/config_test.go
+++ b/internal/cmd/config_test.go
@@ -88,7 +88,8 @@ func TestConfigFileFormatRoundTrip(t *testing.T) {
 				},
 				ScriptEnv: map[string]string{},
 				Template: templateConfig{
-					Options: []string{},
+					FunctionsStr: defaultSentinel,
+					Options:      []string{},
 				},
 				TextConv:      []*textConvElement{},
 				UseBuiltinAge: autoBool{value: false},

--- a/internal/cmd/executetemplatecmd.go
+++ b/internal/cmd/executetemplatecmd.go
@@ -257,7 +257,7 @@ func (c *Config) runExecuteTemplateCmd(cmd *cobra.Command, args []string) error 
 			"writeToStdout":         c.writeToStdout,
 		}
 
-		chezmoi.RecursiveMerge(c.templateFuncs, initTemplateFuncs)
+		chezmoi.RecursiveMerge(c.sprigTemplateFuncs, initTemplateFuncs)
 	}
 
 	if len(args) == 0 {

--- a/internal/cmd/mergecmd.go
+++ b/internal/cmd/mergecmd.go
@@ -148,8 +148,10 @@ func (c *Config) doMerge(targetRelPath chezmoi.RelPath, sourceStateEntry chezmoi
 	anyTemplateArgs := false
 	for i, arg := range c.Merge.Args {
 		tmpl, err := chezmoi.ParseTemplate("merge.args["+strconv.Itoa(i)+"]", []byte(arg), chezmoi.TemplateOptions{
-			Funcs:   c.templateFuncs,
-			Options: c.Template.Options,
+			Functions:   c.Template.functions,
+			SprigFuncs:  c.sprigTemplateFuncs,
+			SproutFuncs: c.sproutTemplateFuncs,
+			Options:     c.Template.Options,
 		})
 		if err != nil {
 			return err

--- a/internal/cmd/templatefuncs.go
+++ b/internal/cmd/templatefuncs.go
@@ -264,8 +264,10 @@ func (c *Config) includeTemplateTemplateFunc(filename string, args ...any) strin
 	contents := mustValue(c.readFile(filename, searchDirAbsPaths))
 
 	tmpl := mustValue(chezmoi.ParseTemplate(filename, contents, chezmoi.TemplateOptions{
-		Funcs:   c.templateFuncs,
-		Options: slices.Clone(c.Template.Options),
+		Functions:   c.Template.functions,
+		SprigFuncs:  c.sprigTemplateFuncs,
+		SproutFuncs: c.sproutTemplateFuncs,
+		Options:     slices.Clone(c.Template.Options),
 	}))
 
 	return string(mustValue(tmpl.Execute(data)))


### PR DESCRIPTION
Fixes #2668.

This PR is not ready for review yet. At the time of writing, it adds some of the infrastructure for switching between Sprig and Sprout template functions both globally and locally, but there's much more work to be done including importing the Sprout template functions, refining the switches between Sprig and Sprout, testing, and a re-structure of the documentation.