### PR TITLE
chore: Add `onchange` to chattr command reference

### DIFF
--- a/assets/chezmoi.io/docs/reference/commands/chattr.md
+++ b/assets/chezmoi.io/docs/reference/commands/chattr.md
@@ -18,6 +18,7 @@ modifiers and their abbreviations are:
 | `executable`       | `x`          |
 | `external`         | *none*       |
 | `once`             | `o`          |
+| `onchange`         | *none*       |
 | `private`          | `p`          |
 | `readonly`         | `r`          |
 | `remove`           | *none*       |

--- a/internal/cmd/helps.gen.go
+++ b/internal/cmd/helps.gen.go
@@ -177,6 +177,7 @@ var helps = map[string]*help{
 			"   executable                          | x\n" +
 			"   external                            | none\n" +
 			"   once                                | o\n" +
+			"   onchange                            | none\n" +
 			"   private                             | p\n" +
 			"   readonly                            | r\n" +
 			"   remove                              | none\n" +


### PR DESCRIPTION
The `onchange` attribute was missing from the `chattr --help` text.