### PR TITLE
chore: use doc links to point at stdlib symbols

### DIFF
--- a/internal/chezmoi/abspath.go
+++ b/internal/chezmoi/abspath.go
@@ -124,7 +124,7 @@ func (p AbsPath) String() string {
 	return string(p)
 }
 
-// ToSlash calls filepath.ToSlash on p.
+// ToSlash calls [filepath.ToSlash] on p.
 func (p AbsPath) ToSlash() AbsPath {
 	return NewAbsPath(filepath.ToSlash(string(p)))
 }

--- a/internal/chezmoi/archive.go
+++ b/internal/chezmoi/archive.go
@@ -140,7 +140,7 @@ func implicitTarDirHeader(dir string, modTime time.Time) *tar.Header {
 }
 
 // A RARFileInfo wraps a *rardecode.FileHeader so that it implements
-// fs.FileInfo.
+// [fs.FileInfo].
 type RARFileInfo struct {
 	*rardecode.FileHeader
 }

--- a/internal/chezmoi/chezmoi.go
+++ b/internal/chezmoi/chezmoi.go
@@ -192,8 +192,8 @@ func FlagCompletionFunc(allCompletions []string) func(*cobra.Command, []string, 
 	}
 }
 
-// ParseBool is like strconv.ParseBool but also accepts on, ON, y, Y, yes, YES,
-// n, N, no, NO, off, and OFF.
+// ParseBool is like [strconv.ParseBool] but also accepts on, ON, y, Y, yes,
+// YES, n, N, no, NO, off, and OFF.
 func ParseBool(str string) (bool, error) {
 	switch strings.ToLower(strings.TrimSpace(str)) {
 	case "n", "no", "off":

--- a/internal/chezmoi/chezmoi_unix.go
+++ b/internal/chezmoi/chezmoi_unix.go
@@ -27,7 +27,7 @@ func IsExecutable(fileInfo fs.FileInfo) bool {
 	return fileInfo.Mode().Perm()&0o111 != 0
 }
 
-// UserHomeDir on UNIX returns the value of os.UserHomeDir.
+// UserHomeDir on UNIX returns the value of [os.UserHomeDir].
 func UserHomeDir() (string, error) {
 	return os.UserHomeDir()
 }

--- a/internal/chezmoi/diff.go
+++ b/internal/chezmoi/diff.go
@@ -147,7 +147,7 @@ func diffChunks(from, to string) []diff.Chunk {
 	return chunks
 }
 
-// diffFileMode converts an io/fs.FileMode into a
+// diffFileMode converts an [io/fs.FileMode] into a
 // github.com/go-git/go-git/v5/plumbing/format/diff.FileMode.
 func diffFileMode(mode fs.FileMode) (filemode.FileMode, error) {
 	fileMode, err := filemode.NewFromOSFileMode(mode)

--- a/internal/chezmoi/duration.go
+++ b/internal/chezmoi/duration.go
@@ -2,7 +2,7 @@ package chezmoi
 
 import "time"
 
-// A Duration is a time.Duration that implements encoding.TextUnmarshaler.
+// A Duration is a [time.Duration] that implements [encoding.TextUnmarshaler].
 type Duration time.Duration
 
 func (d *Duration) UnmarshalText(data []byte) error {

--- a/internal/chezmoi/glob.go
+++ b/internal/chezmoi/glob.go
@@ -7,7 +7,7 @@ import (
 	vfs "github.com/twpayne/go-vfs/v5"
 )
 
-// A LstatFS implements io/fs.StatFS but uses Lstat instead of Stat.
+// A LstatFS implements [io/fs.StatFS] but uses Lstat instead of Stat.
 type LstatFS struct {
 	Wrapped interface {
 		fs.FS

--- a/internal/chezmoi/interpreter.go
+++ b/internal/chezmoi/interpreter.go
@@ -11,7 +11,7 @@ type Interpreter struct {
 	Args    []string `json:"args"    mapstructure:"args"    yaml:"args"`
 }
 
-// ExecCommand returns the *exec.Cmd to interpret name.
+// ExecCommand returns the [*exec.Cmd] to interpret name.
 func (i *Interpreter) ExecCommand(name string) *exec.Cmd {
 	if i.None() {
 		return exec.Command(name)

--- a/internal/chezmoi/lookpath.go
+++ b/internal/chezmoi/lookpath.go
@@ -10,7 +10,7 @@ var (
 	lookPathCache      = make(map[string]string)
 )
 
-// LookPath is like os/exec.LookPath except that the first positive result is
+// LookPath is like [os/exec.LookPath] except that the first positive result is
 // cached.
 func LookPath(file string) (string, error) {
 	lookPathCacheMutex.Lock()

--- a/internal/chezmoi/realsystem_unix.go
+++ b/internal/chezmoi/realsystem_unix.go
@@ -119,8 +119,8 @@ func (s *RealSystem) WriteSymlink(oldName string, newName AbsPath) error {
 	return s.fileSystem.Symlink(oldName, newName.String())
 }
 
-// writeFile is like os.WriteFile but always sets perm before writing data.
-// os.WriteFile only sets the permissions when creating a new file. We need to
+// writeFile is like [os.WriteFile] but always sets perm before writing data.
+// [os.WriteFile] only sets the permissions when creating a new file. We need to
 // ensure permissions, so we use our own implementation.
 func writeFile(fileSystem vfs.FS, filename AbsPath, data []byte, perm fs.FileMode) (err error) {
 	// Create a new file, or truncate any existing one.

--- a/internal/chezmoi/sourcestate.go
+++ b/internal/chezmoi/sourcestate.go
@@ -683,7 +683,7 @@ DEST_ABS_PATH:
 	return nil
 }
 
-// AddDestAbsPathInfos adds an fs.FileInfo to destAbsPathInfos for destAbsPath
+// AddDestAbsPathInfos adds an [fs.FileInfo] to destAbsPathInfos for destAbsPath
 // and any of its parents which are not already known.
 func (s *SourceState) AddDestAbsPathInfos(
 	destAbsPathInfos map[AbsPath]fs.FileInfo,

--- a/internal/chezmoi/system.go
+++ b/internal/chezmoi/system.go
@@ -103,7 +103,7 @@ func (noUpdateSystemMixin) WriteSymlink(oldName string, newName AbsPath) error {
 	panic("update to no update system")
 }
 
-// MkdirAll is the equivalent of os.MkdirAll but operates on system.
+// MkdirAll is the equivalent of [os.MkdirAll] but operates on system.
 func MkdirAll(system System, absPath AbsPath, perm fs.FileMode) error {
 	switch err := system.Mkdir(absPath, perm); {
 	case err == nil:

--- a/internal/chezmoi/template.go
+++ b/internal/chezmoi/template.go
@@ -17,7 +17,7 @@ import (
 	"golang.org/x/text/encoding/unicode"
 )
 
-// A Template extends text/template.Template with support for directives.
+// A Template extends [text/template.Template] with support for directives.
 type Template struct {
 	name     string
 	template *template.Template

--- a/internal/chezmoierrors/chezmoierrors.go
+++ b/internal/chezmoierrors/chezmoierrors.go
@@ -7,7 +7,7 @@ import "errors"
 // Combine combines all non-nil errors in errs into one. If there are no non-nil
 // errors, it returns nil. If there is exactly one non-nil error then it returns
 // that error. Otherwise, it returns the non-nil errors combined with
-// errors.Join.
+// [errors.Join].
 func Combine(errs ...error) error {
 	nonNilErrs := make([]error, 0, len(errs))
 	for _, err := range errs {

--- a/internal/chezmoilog/chezmoilog.go
+++ b/internal/chezmoilog/chezmoilog.go
@@ -15,20 +15,20 @@ import (
 
 const few = 64
 
-// An OSExecCmdLogValuer wraps an *os/exec.Cmd and adds log/slog.LogValuer
+// An OSExecCmdLogValuer wraps an [*os/exec.Cmd] and adds [log/slog.LogValuer]
 // functionality.
 type OSExecCmdLogValuer struct {
 	*exec.Cmd
 }
 
-// An OSExecExitLogValuerError wraps an *os/exec.ExitError and adds
-// log/slog.LogValuer.
+// An OSExecExitLogValuerError wraps an [*os/exec.ExitError] and adds
+// [log/slog.LogValuer].
 type OSExecExitLogValuerError struct {
 	*exec.ExitError
 }
 
-// An OSProcessStateLogValuer wraps an *os.ProcessState and adds
-// log/slog.LogValuer functionality.
+// An OSProcessStateLogValuer wraps an [*os.ProcessState] and adds
+// [log/slog.LogValuer] functionality.
 type OSProcessStateLogValuer struct {
 	*os.ProcessState
 }
@@ -106,12 +106,12 @@ func AppendExitErrorAttrs(attrs []slog.Attr, err error) []slog.Attr {
 	return attrs
 }
 
-// Bytes returns an slog.Attr with the value data.
+// Bytes returns an [slog.Attr] with the value data.
 func Bytes(key string, data []byte) slog.Attr {
 	return slog.String(key, string(data))
 }
 
-// FirstFewBytes returns an slog.Attr with the value of the first few bytes of
+// FirstFewBytes returns an [slog.Attr] with the value of the first few bytes of
 // data.
 func FirstFewBytes(key string, data []byte) slog.Attr {
 	return slog.String(key, string(firstFewBytesHelper(data)))
@@ -230,7 +230,7 @@ func InfoOrErrorContext(ctx context.Context, logger *slog.Logger, msg string, er
 	logger.Log(ctx, level, msg, args...)
 }
 
-// Stringer returns an slog.Attr with value.
+// Stringer returns an [slog.Attr] with value.
 func Stringer(key string, value fmt.Stringer) slog.Attr {
 	return slog.String(key, value.String())
 }

--- a/internal/chezmoilog/nullhandler.go
+++ b/internal/chezmoilog/nullhandler.go
@@ -5,7 +5,7 @@ import (
 	"log/slog"
 )
 
-// A NullHandler implements log/slog.Handler and drops all output.
+// A NullHandler implements [log/slog.Handler] and drops all output.
 type NullHandler struct{}
 
 func (NullHandler) Enabled(context.Context, slog.Level) bool  { return false }

--- a/internal/chezmoitest/chezmoitest.go
+++ b/internal/chezmoitest/chezmoitest.go
@@ -71,7 +71,7 @@ func JoinLines(lines ...string) string {
 	return strings.Join(lines, "\n") + "\n"
 }
 
-// SkipUnlessGOOS calls t.Skip() if name does not match runtime.GOOS.
+// SkipUnlessGOOS calls t.Skip() if name does not match [runtime.GOOS].
 func SkipUnlessGOOS(t *testing.T, name string) {
 	t.Helper()
 	switch {
@@ -91,7 +91,7 @@ func WithTestFS(t *testing.T, root any, f func(vfs.FS)) {
 	f(fileSystem)
 }
 
-// mustParseFileMode parses s as a fs.FileMode and panics on any error.
+// mustParseFileMode parses s as a [fs.FileMode] and panics on any error.
 func mustParseFileMode(s string) fs.FileMode {
 	u, err := strconv.ParseUint(s, 0, 32)
 	if err != nil {

--- a/internal/cmd/archivecmd.go
+++ b/internal/cmd/archivecmd.go
@@ -114,7 +114,7 @@ func (c *Config) runArchiveCmd(cmd *cobra.Command, args []string) error {
 	return c.writeOutputString(gzippedArchive.String(), 0o666)
 }
 
-// tarHeaderTemplate returns a tar.Header template populated with the current
+// tarHeaderTemplate returns a [tar.Header] template populated with the current
 // user and time.
 func tarHeaderTemplate() tar.Header {
 	// Attempt to lookup the current user. Ignore errors because the default

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -1589,11 +1589,11 @@ func (c *Config) getGitleaksDetector() (*detect.Detector, error) {
 	return c.gitleaksDetector, c.gitleaksDetectorErr
 }
 
-// A modifyHTTPRequestFunc is a function that modifies a net/http.Request before
-// it is sent.
+// A modifyHTTPRequestFunc is a function that modifies a [net/http.Request]
+// before it is sent.
 type modifyHTTPRequestFunc func(*http.Request) (*http.Request, error)
 
-// A modifyHTTPRequestRoundTripper is a net/http.Transport that modifies the
+// A modifyHTTPRequestRoundTripper is a [net/http.Transport] that modifies the
 // request before it is sent.
 type modifyHTTPRequestRoundTripper struct {
 	modifyHTTPRequestFunc modifyHTTPRequestFunc
@@ -1607,7 +1607,7 @@ func newModifyHTTPRequestRoundTripper(f modifyHTTPRequestFunc, t http.RoundTripp
 	}
 }
 
-// RoundTrip implements net/http.Transport.RoundTrip.
+// RoundTrip implements [net/http.Transport.RoundTrip].
 func (m modifyHTTPRequestRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	modifiedRequest, err := m.modifyHTTPRequestFunc(req)
 	if err != nil {

--- a/internal/cmd/doctorcmd.go
+++ b/internal/cmd/doctorcmd.go
@@ -122,7 +122,7 @@ type latestVersionCheck struct {
 	version       semver.Version
 }
 
-// An osArchCheck checks that runtime.GOOS and runtime.GOARCH are supported.
+// An osArchCheck checks that [runtime.GOOS] and [runtime.GOARCH] are supported.
 type osArchCheck struct{}
 
 // A omittedCheck is a check that is omitted.

--- a/internal/cmd/initcmd.go
+++ b/internal/cmd/initcmd.go
@@ -81,7 +81,7 @@ var repoGuesses = []struct {
 }
 
 // A gitCloneOptionsLogValuer is a git.CloneOptions that implements
-// log/slog.LogValuer.
+// [log/slog.LogValuer].
 type gitCloneOptionsLogValuer git.CloneOptions
 
 func (c *Config) newInitCmd() *cobra.Command {

--- a/internal/cmd/readdcmd.go
+++ b/internal/cmd/readdcmd.go
@@ -19,7 +19,7 @@ type reAddCmdConfig struct {
 	recursive bool
 }
 
-// A fileInfo is a simple struct that implements the io/fs.FileInfo interface
+// A fileInfo is a simple struct that implements the [io/fs.FileInfo] interface
 // for the purpose of overriding the mode on Windows.
 type fileInfo struct {
 	name    string


### PR DESCRIPTION
Fixes #4856

Tested with a local build of Golangci-lint, cloned from latest `main`.

Unrelated to this, but seems like `golines` in my build of Golangci-lint complains about some long lines. Expand to see more. I can try fixing them as well as they seem to be all cosmetic changes. Let me know, anyway.

<details><summary>Details</summary>
<p>

```
internal/chezmoi/sourcestate.go:666:1: File is not properly formatted (golines)
                        if err := PersistentStateSet(persistentState, EntryStateBucket, sourceUpdate.destAbsPath.Bytes(), sourceUpdate.entryState); err != nil {
^
internal/cmd/githubtemplatefuncs.go:170:1: File is not properly formatted (golines)
        if err := chezmoi.PersistentStateSet(c.persistentState, gitHubVersionReleaseStateBucket, gitHubVersionReleaseKey, &gitHubLatestReleaseState{
^
internal/cmd/inittemplatefuncs_test.go:338:1: File is not properly formatted (golines)
                                assert.Equal(t, tc.expected, config.promptMultichoiceInteractiveTemplateFunc(tc.prompt, tc.multichoices, tc.args...))
^
internal/cmd/mergecmd.go:97:1: File is not properly formatted (golines)
        if targetStateEntry, err = sourceStateEntry.TargetStateEntry(c.destSystem, c.DestDirAbsPath.Join(targetRelPath)); err != nil {
^
4 issues:
* golines: 4
```

</p>
</details> 
