### PR TITLE
chore: fix `golines` issues

### DIFF
--- a/internal/chezmoi/sourcestate.go
+++ b/internal/chezmoi/sourcestate.go
@@ -663,7 +663,12 @@ DEST_ABS_PATH:
 			}
 		}
 		if !sourceUpdate.destAbsPath.IsEmpty() {
-			if err := PersistentStateSet(persistentState, EntryStateBucket, sourceUpdate.destAbsPath.Bytes(), sourceUpdate.entryState); err != nil {
+			if err := PersistentStateSet(
+				persistentState,
+				EntryStateBucket,
+				sourceUpdate.destAbsPath.Bytes(),
+				sourceUpdate.entryState,
+			); err != nil {
 				return err
 			}
 		}

--- a/internal/cmd/githubtemplatefuncs.go
+++ b/internal/cmd/githubtemplatefuncs.go
@@ -167,10 +167,15 @@ func (c *Config) gitHubRelease(ownerRepo, version string) (*github.RepositoryRel
 		return nil, err
 	}
 
-	if err := chezmoi.PersistentStateSet(c.persistentState, gitHubVersionReleaseStateBucket, gitHubVersionReleaseKey, &gitHubLatestReleaseState{
-		RequestedAt: now,
-		Release:     release,
-	}); err != nil {
+	if err := chezmoi.PersistentStateSet(
+		c.persistentState,
+		gitHubVersionReleaseStateBucket,
+		gitHubVersionReleaseKey,
+		&gitHubLatestReleaseState{
+			RequestedAt: now,
+			Release:     release,
+		},
+	); err != nil {
 		return nil, err
 	}
 
@@ -214,10 +219,15 @@ func (c *Config) gitHubLatestRelease(ownerRepo string) (*github.RepositoryReleas
 		return nil, err
 	}
 
-	if err := chezmoi.PersistentStateSet(c.persistentState, gitHubLatestReleaseStateBucket, gitHubLatestReleaseKey, &gitHubLatestReleaseState{
-		RequestedAt: now,
-		Release:     release,
-	}); err != nil {
+	if err := chezmoi.PersistentStateSet(
+		c.persistentState,
+		gitHubLatestReleaseStateBucket,
+		gitHubLatestReleaseKey,
+		&gitHubLatestReleaseState{
+			RequestedAt: now,
+			Release:     release,
+		},
+	); err != nil {
 		return nil, err
 	}
 

--- a/internal/cmd/inittemplatefuncs_test.go
+++ b/internal/cmd/inittemplatefuncs_test.go
@@ -335,7 +335,11 @@ func TestPromptMultichoiceInteractiveTemplateFunc(t *testing.T) {
 					config.promptMultichoiceInteractiveTemplateFunc(tc.prompt, tc.multichoices, tc.args...)
 				})
 			} else {
-				assert.Equal(t, tc.expected, config.promptMultichoiceInteractiveTemplateFunc(tc.prompt, tc.multichoices, tc.args...))
+				assert.Equal(
+					t,
+					tc.expected,
+					config.promptMultichoiceInteractiveTemplateFunc(tc.prompt, tc.multichoices, tc.args...),
+				)
 
 				assert.Equal(t, tc.expectedStdoutStr, stdout.String())
 			}

--- a/internal/cmd/mergecmd.go
+++ b/internal/cmd/mergecmd.go
@@ -94,7 +94,10 @@ func (c *Config) doMerge(targetRelPath chezmoi.RelPath, sourceStateEntry chezmoi
 	// two-way merge if the source state's contents cannot be decrypted or
 	// are an invalid template
 	var targetStateEntry chezmoi.TargetStateEntry
-	if targetStateEntry, err = sourceStateEntry.TargetStateEntry(c.destSystem, c.DestDirAbsPath.Join(targetRelPath)); err != nil {
+	if targetStateEntry, err = sourceStateEntry.TargetStateEntry(
+		c.destSystem,
+		c.DestDirAbsPath.Join(targetRelPath),
+	); err != nil {
 		return fmt.Errorf("%s: %w", targetRelPath, err)
 	}
 	targetStateFile, ok := targetStateEntry.(*chezmoi.TargetStateFile)
@@ -184,7 +187,11 @@ func (c *Config) doMerge(targetRelPath chezmoi.RelPath, sourceStateEntry chezmoi
 		if encryptedContents, err = c.encryption.EncryptFile(plaintextAbsPath); err != nil {
 			return err
 		}
-		if err := c.baseSystem.WriteFile(c.SourceDirAbsPath.Join(sourceStateEntry.SourceRelPath().RelPath()), encryptedContents, 0o644); err != nil {
+		if err := c.baseSystem.WriteFile(
+			c.SourceDirAbsPath.Join(sourceStateEntry.SourceRelPath().RelPath()),
+			encryptedContents,
+			0o644,
+		); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This PR fixes the issues reported by `golines` (See #4858 description). The linter is not yet released (as part of Golangci-lint), though.

The changes are the result of running `golangci-lint fix` (built from latest `main`).