### PR TITLE
fix: Make joinPath template func accept string-like values

### DIFF
--- a/internal/cmd/templatefuncs.go
+++ b/internal/cmd/templatefuncs.go
@@ -295,8 +295,12 @@ func (c *Config) ioregTemplateFunc() map[string]any {
 	return value
 }
 
-func (c *Config) joinPathTemplateFunc(elem ...string) string {
-	return filepath.Join(elem...)
+func (c *Config) joinPathTemplateFunc(elems ...any) string {
+	args, err := anyToStringSlice(elems)
+	if err != nil {
+		panic(err)
+	}
+	return filepath.Join(args...)
 }
 
 func (c *Config) jqTemplateFunc(source string, input any) any {

--- a/internal/cmd/testdata/scripts/templatefuncs.txtar
+++ b/internal/cmd/testdata/scripts/templatefuncs.txtar
@@ -80,6 +80,8 @@ stdout ^data$
 # test joinPath template function
 exec chezmoi execute-template '{{ joinPath "a" "b" }}'
 stdout a${/}b
+exec chezmoi execute-template '{{ joinPath .chezmoi.destDir "string" }}'
+stdout home${/@R}user${/@R}string
 
 # test jq template function
 exec chezmoi execute-template '{{ dict "key" "value" | jq ".key" | first }}'


### PR DESCRIPTION
Fixes #4878.