### PR TITLE
fix/adding exact sub-directory adds exact parent directory

### DIFF
--- a/internal/chezmoi/sourcestate_test.go
+++ b/internal/chezmoi/sourcestate_test.go
@@ -19,6 +19,7 @@ import (
 	vfs "github.com/twpayne/go-vfs/v5"
 	"github.com/twpayne/go-vfs/v5/vfst"
 
+	"chezmoi.io/chezmoi/internal/chezmoiset"
 	"chezmoi.io/chezmoi/internal/chezmoitest"
 )
 
@@ -480,6 +481,33 @@ func TestSourceStateAdd(t *testing.T) {
 				vfst.TestPath("/home/user/.local/share/chezmoi/dot_dir/exact_subdir/file",
 					vfst.TestModeIsRegular(),
 					vfst.TestContentsString("# contents of .dir/subdir/file\n"),
+				),
+			},
+		},
+		{
+			name: "exact_subdir_not_exact_parent",
+			destAbsPaths: []AbsPath{
+				NewAbsPath("/home/user/.dir/subdir"),
+			},
+			addOptions: AddOptions{
+				Exact:               true,
+				ExactTargetRelPaths: chezmoiset.New(NewRelPath(".dir/subdir")),
+				Filter:              NewEntryTypeFilter(EntryTypesAll, EntryTypesNone),
+			},
+			tests: []any{
+				// Parent directory should NOT have exact_ prefix
+				vfst.TestPath("/home/user/.local/share/chezmoi/dot_dir",
+					vfst.TestIsDir(),
+					vfst.TestModePerm(fs.ModePerm&^chezmoitest.Umask),
+				),
+				// Target directory should have exact_ prefix
+				vfst.TestPath("/home/user/.local/share/chezmoi/dot_dir/exact_subdir",
+					vfst.TestIsDir(),
+					vfst.TestModePerm(fs.ModePerm&^chezmoitest.Umask),
+				),
+				// Verify that exact_dot_dir does NOT exist (parent should not be exact)
+				vfst.TestPath("/home/user/.local/share/chezmoi/exact_dot_dir",
+					vfst.TestDoesNotExist(),
 				),
 			},
 		},

--- a/internal/cmd/testdata/scripts/add.txtar
+++ b/internal/cmd/testdata/scripts/add.txtar
@@ -74,6 +74,23 @@ cmp $CHEZMOISOURCEDIR/dot_file golden/dot_file
 exec chezmoi add --force $HOME/.file
 cmp $CHEZMOISOURCEDIR/dot_file golden/edited_dot_file
 
+chhome home5/user
+
+# test that chezmoi add --exact only applies exact_ to the target, not parent directories
+# This is a regression test for the bug where adding a child with --exact would also
+# mark parent directories as exact
+exec chezmoi add --exact $HOME${/}.parent/child
+# child directory should have exact_ prefix
+exists $CHEZMOISOURCEDIR/dot_parent/exact_child
+cmp $CHEZMOISOURCEDIR/dot_parent/exact_child/file golden/dot_parent/exact_child/file
+# parent directory should NOT have exact_ prefix (bug fix verification)
+exists $CHEZMOISOURCEDIR/dot_parent
+! exists $CHEZMOISOURCEDIR/exact_dot_parent
+# parent's other files should NOT be tracked (parent is not exact)
+! exists $CHEZMOISOURCEDIR/dot_parent/other_file
+
+-- golden/dot_parent/exact_child/file --
+# contents of child file
 -- golden/edited_dot_file --
 # contents of .file
 # edited
@@ -87,3 +104,7 @@ cmp $CHEZMOISOURCEDIR/dot_file golden/edited_dot_file
 **/ignore
 -- home4/user/.file --
 # contents of .file
+-- home5/user/.parent/child/file --
+# contents of child file
+-- home5/user/.parent/other_file --
+# this file should not be tracked when only child is added with --exact


### PR DESCRIPTION
<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer-guide/contributing-changes/

-->

Hello again!

I recently noticed what I assume is a a weird logic bug. In a nutshell, when adding exact sub-directories, if the parent isn't already created and doesn't exist in the source directory, that parent gets added as an exact directory when it shouldn't be.

I'm creating this draft PR to make sure this logic aligns with what the maintainers believe should happen in this case. I created a quick test case for the failed logic. Naturally, this new test currently fails.

Please let me know if you agree that this should be fixed and I'll fix it!