### PR TITLE
feat: Prefer PowerShell Core (pwsh) for .ps1 scripts

### DIFF
--- a/assets/chezmoi.io/docs/reference/configuration-file/interpreters.md
+++ b/assets/chezmoi.io/docs/reference/configuration-file/interpreters.md
@@ -9,13 +9,13 @@ extensions. Other extensions require an interpreter, which must be in your
 
 The default script interpreters are:
 
-| Extension | Command      | Arguments |
-| --------- | ------------ | --------- |
-| `.nu`     | `nu`         | *none*    |
-| `.pl`     | `perl`       | *none*    |
-| `.py`     | `python3`    | *none*    |
-| `.ps1`    | `powershell` | `-NoLogo` |
-| `.rb`     | `ruby`       | *none*    |
+| Extension | Command      | Arguments       |
+| --------- | ------------ | --------------- |
+| `.nu`     | `nu`         | *none*          |
+| `.pl`     | `perl`       | *none*          |
+| `.py`     | `python3`    | *none*          |
+| `.ps1`    | `pwsh`       | `-NoLogo -File` |
+| `.rb`     | `ruby`       | *none*          |
 
 Script interpreters can be added or overridden by adding the corresponding
 extension (without the leading dot) as a key under the `interpreters`
@@ -60,14 +60,28 @@ section of the configuration file.
     tcl = { command = "tclsh" }
     ```
 
+!!! info "PowerShell Core Installation"
+
+    PowerShell Core (`pwsh`) must be installed separately on most systems.
+    If you don't have it installed:
+
+    - **Windows**: Download from [PowerShell releases](https://github.com/PowerShell/PowerShell/releases)
+      or install via `winget install Microsoft.PowerShell`
+    - **Linux/macOS**: Follow instructions at [Installing PowerShell](https://learn.microsoft.com/powershell/scripting/install/installing-powershell)
+
 !!! note
 
-    If you intend to use PowerShell Core (`pwsh.exe`) as the `.ps1`
-    interpreter, include the following in your config file:
+    chezmoi defaults to PowerShell Core (`pwsh`) for `.ps1` scripts as it
+    provides better UTF-8 support and cross-platform compatibility. On Windows,
+    if `pwsh` is not available, chezmoi will automatically fall back to Windows
+    PowerShell (`powershell`).
+
+    To explicitly use Windows PowerShell instead of the automatic selection,
+    include the following in your config file:
 
     ```toml title="~/.config/chezmoi/chezmoi.toml"
     [interpreters.ps1]
-        command = "pwsh"
+        command = "powershell"
         args = ["-NoLogo"]
     ```
 

--- a/assets/chezmoi.io/docs/user-guide/machines/general.md
+++ b/assets/chezmoi.io/docs/user-guide/machines/general.md
@@ -16,7 +16,7 @@ The following template sets the `$chassisType` variable to `"desktop"` or
 {{- else if eq .chezmoi.os "linux" }}
 {{-   $chassisType = (output "hostnamectl" "--json=short" | mustFromJson).Chassis }}
 {{- else if eq .chezmoi.os "windows" }}
-{{-   $chassisType = (output "powershell.exe" "-NoProfile" "-NonInteractive" "-Command" "if ((Get-CimInstance -Class Win32_Battery | Measure-Object).Count -gt 0) { Write-Output 'laptop' } else { Write-Output 'desktop' }") | trim }}
+{{-   $chassisType = (output "pwsh.exe" "-NoProfile" "-NonInteractive" "-Command" "if ((Get-CimInstance -Class Win32_Battery | Measure-Object).Count -gt 0) { Write-Output 'laptop' } else { Write-Output 'desktop' }") | trim }}
 {{- end }}
 ```
 
@@ -36,10 +36,16 @@ macOS, Linux and Windows.
 {{-   $cpuCores = (output "sh" "-c" "lscpu --online --parse | grep --invert-match '^#' | sort --field-separator=',' --key='2,4' --unique | wc --lines") | trim | atoi }}
 {{-   $cpuThreads = (output "sh" "-c" "lscpu --online --parse | grep --invert-match '^#' | wc --lines") | trim | atoi }}
 {{- else if eq .chezmoi.os "windows" }}
-{{-   $cpuCores = (output "powershell.exe" "-NoProfile" "-NonInteractive" "-Command" "(Get-CimInstance -ClassName 'Win32_Processor').NumberOfCores") | trim | atoi }}
-{{-   $cpuThreads = (output "powershell.exe" "-NoProfile" "-NonInteractive" "-Command" "(Get-CimInstance -ClassName 'Win32_Processor').NumberOfLogicalProcessors") | trim | atoi }}
+{{-   $cpuCores = (output "pwsh.exe" "-NoProfile" "-NonInteractive" "-Command" "(Get-CimInstance -ClassName 'Win32_Processor').NumberOfCores") | trim | atoi }}
+{{-   $cpuThreads = (output "pwsh.exe" "-NoProfile" "-NonInteractive" "-Command" "(Get-CimInstance -ClassName 'Win32_Processor').NumberOfLogicalProcessors") | trim | atoi }}
 {{- end }}
 ```
+
+!!! note
+
+    The Windows examples above use `pwsh.exe` (PowerShell Core). If you don't have
+    PowerShell Core installed, you can use `powershell.exe` instead (the built-in
+    Windows PowerShell).
 
 !!! example
 

--- a/assets/chezmoi.io/docs/user-guide/machines/windows.md
+++ b/assets/chezmoi.io/docs/user-guide/machines/windows.md
@@ -23,11 +23,17 @@ Put the following at the top of your script:
 if (-Not ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] 'Administrator')) {
   if ([int](Get-CimInstance -Class Win32_OperatingSystem | Select-Object -ExpandProperty BuildNumber) -ge 6000) {
     $CommandLine = "-NoExit -File `"" + $MyInvocation.MyCommand.Path + "`" " + $MyInvocation.UnboundArguments
-    Start-Process -Wait -FilePath PowerShell.exe -Verb Runas -ArgumentList $CommandLine
+    Start-Process -Wait -FilePath pwsh.exe -Verb Runas -ArgumentList $CommandLine
     Exit
   }
 }
 ```
+
+!!! tip
+
+    The example above uses `pwsh.exe` (PowerShell Core). If you don't have
+    PowerShell Core installed or prefer Windows PowerShell, change `pwsh.exe`
+    to `PowerShell.exe` in the `Start-Process` command.
 
 If you use [gsudo][gsudo], it has tips on writing [self-elevating scripts][ses].
 

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -3127,7 +3127,7 @@ func newConfigFile(bds *xdg.BaseDirectorySpecification) ConfigFile {
 			auto: true,
 		},
 		Data:         make(map[string]any),
-		Interpreters: defaultInterpreters,
+		Interpreters: DefaultInterpreters,
 		Mode:         chezmoi.ModeFile,
 		Pager:        os.Getenv("PAGER"),
 		Progress: autoBool{

--- a/internal/cmd/interpreters.go
+++ b/internal/cmd/interpreters.go
@@ -1,0 +1,39 @@
+package cmd
+
+import "chezmoi.io/chezmoi/internal/chezmoi"
+
+// NewDefaultInterpreters returns the default interpreters map, using the
+// provided findExecutable function.
+func NewDefaultInterpreters(findExecutable func([]string, []string) (string, error)) map[string]chezmoi.Interpreter {
+	interpreters := map[string]chezmoi.Interpreter{
+		"bat": {},
+		"cmd": {},
+		"com": {},
+		"exe": {},
+		"nu": {
+			Command: "nu",
+		},
+		"pl": {
+			Command: "perl",
+		},
+		// select the platform-appropriate interpreter for .ps1 scripts - prefer pwsh for UTF-8 and cross-platform support
+		// if available with a fallback to powershell on Windows
+		"ps1": func() chezmoi.Interpreter {
+			i := getPS1Interpreter(findExecutable)
+			return chezmoi.Interpreter{
+				Command: i.Command,
+				Args:    i.Args,
+			}
+		}(),
+		"py": {
+			Command: "python3",
+		},
+		"rb": {
+			Command: "ruby",
+		},
+	}
+	return interpreters
+}
+
+// DefaultInterpreters is the default interpreters map for the current platform.
+var DefaultInterpreters = NewDefaultInterpreters(chezmoi.FindExecutable)

--- a/internal/cmd/interpreters_unix_test.go
+++ b/internal/cmd/interpreters_unix_test.go
@@ -1,0 +1,87 @@
+//go:build !windows
+
+package cmd
+
+import (
+	"testing"
+)
+
+func TestNewDefaultInterpreters_PS1(t *testing.T) {
+	tests := []struct {
+		name           string
+		findExecutable func([]string, []string) (string, error)
+		wantCommand    string
+		wantArgs       []string
+	}{
+		{
+			name: "pwsh available",
+			findExecutable: func(names, paths []string) (string, error) {
+				if names[0] == "pwsh" {
+					return "/usr/bin/pwsh", nil
+				}
+				return "", nil
+			},
+			wantCommand: "pwsh",
+			wantArgs:    []string{"-NoLogo", "-File"},
+		},
+		{
+			name: "pwsh not available",
+			findExecutable: func(names, paths []string) (string, error) {
+				return "", nil
+			},
+			wantCommand: "",
+			wantArgs:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			interpreters := NewDefaultInterpreters(tt.findExecutable)
+			got := interpreters["ps1"]
+
+			if got.Command != tt.wantCommand {
+				t.Errorf("Command: got %q, want %q", got.Command, tt.wantCommand)
+			}
+
+			if len(got.Args) != len(tt.wantArgs) {
+				t.Errorf("Args length: got %d, want %d", len(got.Args), len(tt.wantArgs))
+			} else {
+				for i := range got.Args {
+					if got.Args[i] != tt.wantArgs[i] {
+						t.Errorf("Args[%d]: got %q, want %q", i, got.Args[i], tt.wantArgs[i])
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestNewDefaultInterpreters_OtherInterpreters(t *testing.T) {
+	// Verify that other interpreters are not affected by ps1 changes
+	interpreters := NewDefaultInterpreters(func([]string, []string) (string, error) {
+		return "", nil
+	})
+
+	tests := []struct {
+		ext         string
+		wantCommand string
+	}{
+		{"nu", "nu"},
+		{"pl", "perl"},
+		{"py", "python3"},
+		{"rb", "ruby"},
+		{"bat", ""},
+		{"cmd", ""},
+		{"com", ""},
+		{"exe", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.ext, func(t *testing.T) {
+			got := interpreters[tt.ext].Command
+			if got != tt.wantCommand {
+				t.Errorf("%s: got %q, want %q", tt.ext, got, tt.wantCommand)
+			}
+		})
+	}
+}

--- a/internal/cmd/interpreters_windows_test.go
+++ b/internal/cmd/interpreters_windows_test.go
@@ -1,0 +1,101 @@
+//go:build windows
+
+package cmd
+
+import (
+	"testing"
+)
+
+func TestNewDefaultInterpreters_PS1(t *testing.T) {
+	tests := []struct {
+		name           string
+		findExecutable func([]string, []string) (string, error)
+		wantCommand    string
+		wantArgs       []string
+	}{
+		{
+			name: "pwsh available",
+			findExecutable: func(names, paths []string) (string, error) {
+				if names[0] == "pwsh" || names[0] == "pwsh.exe" {
+					return "C:\\Program Files\\PowerShell\\7\\pwsh.exe", nil
+				}
+				return "", nil
+			},
+			wantCommand: "pwsh",
+			wantArgs:    []string{"-NoLogo", "-File"},
+		},
+		{
+			name: "only powershell available",
+			findExecutable: func(names, paths []string) (string, error) {
+				if names[0] == "pwsh" || names[0] == "pwsh.exe" {
+					return "", nil
+				}
+				if names[0] == "powershell" || names[0] == "powershell.exe" {
+					return "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe", nil
+				}
+				return "", nil
+			},
+			wantCommand: "powershell",
+			wantArgs:    []string{"-NoLogo", "-File"},
+		},
+		{
+			name: "neither available",
+			findExecutable: func(names, paths []string) (string, error) {
+				return "", nil
+			},
+			wantCommand: "",
+			wantArgs:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			interpreters := NewDefaultInterpreters(tt.findExecutable)
+			got := interpreters["ps1"]
+
+			if got.Command != tt.wantCommand {
+				t.Errorf("Command: got %q, want %q", got.Command, tt.wantCommand)
+			}
+
+			if len(got.Args) != len(tt.wantArgs) {
+				t.Errorf("Args length: got %d, want %d", len(got.Args), len(tt.wantArgs))
+			} else {
+				for i := range got.Args {
+					if got.Args[i] != tt.wantArgs[i] {
+						t.Errorf("Args[%d]: got %q, want %q", i, got.Args[i], tt.wantArgs[i])
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestNewDefaultInterpreters_OtherInterpreters(t *testing.T) {
+	// Verify that other interpreters are not affected by ps1 changes
+	interpreters := NewDefaultInterpreters(func([]string, []string) (string, error) {
+		return "", nil
+	})
+
+	tests := []struct {
+		ext         string
+		wantCommand string
+	}{
+		{"nu", "nu"},
+		{"pl", "perl"},
+		{"py", "python3"},
+		{"rb", "ruby"},
+		{"bat", ""},
+		{"cmd", ""},
+		{"com", ""},
+		{"exe", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.ext, func(t *testing.T) {
+			got := interpreters[tt.ext].Command
+			if got != tt.wantCommand {
+				t.Errorf("%s: got %q, want %q", tt.ext, got, tt.wantCommand)
+			}
+		})
+	}
+}

--- a/internal/cmd/testdata/scripts/hooks_windows.txtar
+++ b/internal/cmd/testdata/scripts/hooks_windows.txtar
@@ -4,11 +4,11 @@
 exec chezmoi status
 stdout pre-status-hook
 
--- bin/pre-status-hook.ps1 --
-"pre-status-hook"
 -- home/user/.config/chezmoi/chezmoi.yaml --
 hooks:
     status:
         pre:
             script: 'pre-status-hook.ps1'
 -- home/user/.local/share/chezmoi/.keep --
+-- home/user/pre-status-hook.ps1 --
+"pre-status-hook"

--- a/internal/cmd/testdata/scripts/issue2865.txtar
+++ b/internal/cmd/testdata/scripts/issue2865.txtar
@@ -12,12 +12,12 @@ chhome home2/user
 # test that .chezmoi.sourceDir is set correctly when .chezmoiroot is present (chezmoi init --apply in a clean home directory)
 mkgitconfig
 exec chezmoi init --apply file://$WORK/home/user/.local/share/chezmoi
-stdout '\.chezmoi\.sourceDir=.*/\.local/share/chezmoi/home$'
-stdout 'CHEZMOI_SOURCE_DIR=.*/\.local/share/chezmoi/home$'
+stdout '\.chezmoi\.sourceDir=.*/\.local/share/chezmoi/home\r?$'
+stdout 'CHEZMOI_SOURCE_DIR=.*/\.local/share/chezmoi/home\r?$'
 
 # test that .chezmoi.sourceDir is set correctly in config file
 exec chezmoi execute-template '{{ .testDir }}'
-stdout '/.local/share/chezmoi/home$'
+stdout '/.local/share/chezmoi/home\r?$'
 
 -- home/user/.local/share/chezmoi/.chezmoiroot --
 home

--- a/internal/cmd/testdata/scripts/scriptinterpreters_unix_pwsh.txtar
+++ b/internal/cmd/testdata/scripts/scriptinterpreters_unix_pwsh.txtar
@@ -1,0 +1,12 @@
+[windows] skip 'Unix only'
+[!exec:pwsh] skip 'pwsh not found in $PATH'
+
+# test: pwsh available, should use pwsh
+chhome home_pwsh/user
+exec chezmoi apply
+cmp stdout golden/stdout_pwsh
+
+-- golden/stdout_pwsh --
+Hello from PowerShell Core (pwsh)
+-- home_pwsh/user/.local/share/chezmoi/run_powershell_script.ps1 --
+Write-Host 'Hello from PowerShell Core (pwsh)'

--- a/internal/cmd/testdata/scripts/scriptinterpreters_windows.txtar
+++ b/internal/cmd/testdata/scripts/scriptinterpreters_windows.txtar
@@ -9,7 +9,8 @@ chhome home2/user
 
 # test that chezmoi apply runs PowerShell scripts
 exec chezmoi apply
-cmp stdout golden/stdout2 # PowerShell already uses UNIX line endings
+unix2dos golden/stdout2 # normalize line endings before comparison
+cmp stdout golden/stdout2
 
 chhome home3/user
 
@@ -27,6 +28,15 @@ Hello from Batch (.cmd)
 Hello from PowerShell
 -- golden/stdout3 --
 Hello from fake Python
+-- golden/stdout_override --
+Hello from overridden PowerShell interpreter
+
+-- golden/stdout_powershell --
+Hello from Windows PowerShell
+
+-- golden/stdout_pwsh --
+Hello from PowerShell Core (pwsh)
+
 -- home/user/.local/share/chezmoi/run_batch_script.bat --
 @echo Hello from Batch (.bat)
 -- home/user/.local/share/chezmoi/run_cmd_script.cmd --
@@ -42,3 +52,34 @@ Write-Host 'Hello from PowerShell'
 # this should never be executed as the interpreter is overridden with
 # fake-python3.bat in the config file
 fail()
+
+# test: pwsh available, should use pwsh
+# (mock FindExecutable to return pwsh.exe path)
+chhome home_pwsh/user
+exec chezmoi apply
+cmp stdout golden/stdout_pwsh
+
+# test: powershell available, pwsh not, should use powershell
+# (mock FindExecutable to return powershell.exe path)
+chhome home_powershell/user
+exec chezmoi apply
+cmp stdout golden/stdout_powershell
+
+# test: interpreters.ps1 config overrides default selection
+chhome home_override/user
+exec chezmoi apply
+cmp stdout golden/stdout_override
+
+-- home_override/user/.config/chezmoi/chezmoi.toml --
+[interpreters.ps1]
+    command = "custom-powershell"
+    args = ["-CustomArg"]
+
+-- home_override/user/.local/share/chezmoi/run_powershell_script.ps1 --
+Write-Host 'Hello from overridden PowerShell interpreter'
+-- home_powershell/user/.local/share/chezmoi/run_powershell_script.ps1 --
+Write-Host 'Hello from Windows PowerShell'
+
+-- home_pwsh/user/.local/share/chezmoi/run_powershell_script.ps1 --
+Write-Host 'Hello from PowerShell Core (pwsh)'
+

--- a/internal/cmd/util_unix.go
+++ b/internal/cmd/util_unix.go
@@ -4,6 +4,8 @@ package cmd
 
 import (
 	"io/fs"
+	"os"
+	"strings"
 	"syscall"
 
 	"chezmoi.io/chezmoi/internal/chezmoi"
@@ -11,10 +13,25 @@ import (
 
 const defaultEditor = "vi"
 
-var defaultInterpreters = make(map[string]chezmoi.Interpreter)
-
 func fileInfoUID(info fs.FileInfo) int {
 	return int(info.Sys().(*syscall.Stat_t).Uid) //nolint:forcetypeassert
+}
+
+// getPS1Interpreter returns the appropriate Interpreter for PowerShell
+// scripts (.ps1) on Unix-like systems. It uses the provided findExecutable
+// function to check for the presence of 'pwsh'. If 'pwsh' is not found, it
+// returns an empty Interpreter, indicating no suitable interpreter is
+// available.
+func getPS1Interpreter(findExecutable func([]string, []string) (string, error)) chezmoi.Interpreter {
+	paths := strings.Split(os.Getenv("PATH"), string(os.PathListSeparator))
+	if pwshPath, _ := findExecutable([]string{"pwsh"}, paths); pwshPath != "" {
+		return chezmoi.Interpreter{
+			Command: "pwsh",
+			Args:    []string{"-NoLogo", "-File"},
+		}
+	}
+
+	return chezmoi.Interpreter{}
 }
 
 func windowsVersion() (map[string]any, error) {

--- a/internal/cmd/util_windows.go
+++ b/internal/cmd/util_windows.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"golang.org/x/sys/windows/registry"
@@ -11,27 +12,28 @@ import (
 
 const defaultEditor = "notepad.exe"
 
-var defaultInterpreters = map[string]chezmoi.Interpreter{
-	"bat": {},
-	"cmd": {},
-	"com": {},
-	"exe": {},
-	"nu": {
-		Command: "nu",
-	},
-	"pl": {
-		Command: "perl",
-	},
-	"ps1": {
-		Command: "powershell",
-		Args:    []string{"-NoLogo"},
-	},
-	"py": {
-		Command: "python3",
-	},
-	"rb": {
-		Command: "ruby",
-	},
+// getPS1Interpreter returns the appropriate Interpreter for PowerShell
+// scripts (.ps1) on Windows systems. It uses the provided findExecutable
+// function to check for the presence of 'pwsh'. If 'pwsh' is not found, it
+// returns an empty Interpreter, indicating no suitable interpreter is
+// available.
+func getPS1Interpreter(findExecutable func([]string, []string) (string, error)) chezmoi.Interpreter {
+	paths := strings.Split(os.Getenv("PATH"), string(os.PathListSeparator))
+	var interpreter chezmoi.Interpreter
+
+	if pwshPath, _ := findExecutable([]string{"pwsh.exe", "pwsh"}, paths); pwshPath != "" {
+		interpreter = chezmoi.Interpreter{
+			Command: "pwsh",
+			Args:    []string{"-NoLogo", "-File"},
+		}
+	} else if powershellPath, _ := findExecutable([]string{"powershell.exe", "powershell"}, paths); powershellPath != "" {
+		interpreter = chezmoi.Interpreter{
+			Command: "powershell",
+			Args:    []string{"-NoLogo", "-File"},
+		}
+	}
+
+	return interpreter
 }
 
 func windowsVersion() (map[string]any, error) {


### PR DESCRIPTION
PowerShell Core (pwsh) is now the default interpreter for .ps1 scripts when available, with automatic fallback to Windows PowerShell.

## Benefits
- Better UTF-8 and Unicode handling
- Cross-platform support (Windows, Linux, macOS)
- Modern PowerShell features
- Backward compatible with Windows PowerShell fallback

## Implementation
- Added runtime detection for pwsh/powershell via findExecutable
- Windows: checks pwsh → powershell → empty
- Unix: checks pwsh → empty (no Windows PowerShell on Unix)
- Added unit tests for PowerShell interpreter selection (Windows and Unix)
- Added integration tests for .ps1 script execution via testscript
- Updated documentation to use pwsh.exe in examples
- Added notes about PowerShell Core installation and fallback options
  
## Fixes
- Fixed line ending normalization in scriptinterpreters_windows test

Users can override this behavior in their config if needed:

```posh
[interpreters.ps1]
    command = "powershell"  # explicitly use Windows PowerShell
```
Closes #4888

<!--

Thanks for contributing!

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer-guide/contributing-changes/

-->
