### PR TITLE
feat: Use textconv filters for comparison in apply, status, and verify

### DIFF
--- a/assets/chezmoi.io/docs/reference/configuration-file/textconv.md
+++ b/assets/chezmoi.io/docs/reference/configuration-file/textconv.md
@@ -1,7 +1,14 @@
 # textconv
 
 A section called `textconv` in the configuration file controls how file contents
-are modified before being passed to diff.
+are modified before being compared and passed to diff.
+
+When configured, `textconv` filters affect comparison in `apply` (deciding
+whether to write), `status` (deciding whether to report changes), `verify`
+(deciding whether the destination matches), and `diff` (displaying differences).
+If `textconv`-filtered contents of the source and destination are identical, the
+file is considered up-to-date. If they differ, the raw (unfiltered) source
+contents are written to the destination.
 
 The `textconv` must contain an array of objects where each object has the
 following properties:
@@ -17,5 +24,5 @@ standard input of `command` with `args`, and new contents are read from the
 command's standard output.
 
 If a target path does not match any patterns then the file contents are passed
-unchanged to diff. If a target path matches multiple patterns then element with
-the longest `pattern` is used.
+unchanged. If a target path matches multiple patterns then element with the
+longest `pattern` is used.

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -731,6 +731,7 @@ func (c *Config) applyArgs(
 	applyOptions := chezmoi.ApplyOptions{
 		Filter:       options.filter,
 		PreApplyFunc: options.preApplyFunc,
+		TextConvFunc: c.TextConv.convert,
 		Umask:        options.umask,
 	}
 

--- a/internal/cmd/testdata/scripts/textconv.txtar
+++ b/internal/cmd/testdata/scripts/textconv.txtar
@@ -19,6 +19,34 @@ exec chezmoi apply --no-tty
 stdout '^ # CONTENTS OF FILE.TXT'
 stdout '^-# EDITED'
 
+# test that chezmoi status reports no changes when textconv-filtered contents match
+# Source: "# contents of file.txt" -> textconv -> "# CONTENTS OF FILE.TXT"
+# Dest:   "# CONTENTS OF FILE.TXT" -> textconv -> "# CONTENTS OF FILE.TXT"
+# After textconv, both produce the same output, so status should be empty.
+cp golden/file-uppercased.txt $HOME/file.txt
+exec chezmoi status
+! stdout .
+
+# test that chezmoi verify succeeds when textconv-filtered contents match
+exec chezmoi verify
+
+# test that chezmoi apply does not overwrite when textconv-filtered contents match
+exec chezmoi apply --force
+cmp $HOME/file.txt golden/file-uppercased.txt
+
+# test that chezmoi diff shows no output when textconv-filtered contents match
+exec chezmoi diff
+! stdout .
+
+# test that chezmoi apply writes raw contents when textconv-filtered contents differ
+cp golden/source-different.txt $CHEZMOISOURCEDIR/file.txt
+exec chezmoi apply --force
+cmp $HOME/file.txt golden/source-different.txt
+
+-- golden/file-uppercased.txt --
+# CONTENTS OF FILE.TXT
+-- golden/source-different.txt --
+# different contents of file.txt
 -- golden/diff-overwrite --
 diff
 overwrite


### PR DESCRIPTION
> [!NOTE]
> This PR was authored with the assistance of AI (Claude). While it has been tested manually and with the existing test suite, please review the implementation carefully.

## Summary

Implements the feature requested in #4920: `textconv` filters now affect the **comparison logic** in `apply`, `status`, and `verify`, not just diff display.

- When textconv-filtered contents of source and destination match, the file is considered up-to-date (no overwrite prompt, no `MM` in status, verify passes)
- When textconv-filtered contents differ, the raw (unfiltered) source contents are written to the destination
- Existing behavior is unchanged for files that don't match any textconv pattern

This solves the long-standing pain point with macOS plist files (and similar config files on other platforms) that are constantly rewritten by apps with volatile metadata (timestamps, window positions, update counters, etc.).

### Implementation

The change threads `TextConvFunc` through chezmoi's comparison pipeline at two levels:

1. **EntryState level** (`SourceState.Apply()`): filters `ContentsSHA256` in-place on both target and actual entry states before the `PreApplyFunc` comparison. This drives `status` output, `apply` prompting, and `verify` results.
2. **`TargetStateFile.Apply()` level**: uses textconv for the SHA256 comparison that decides whether to write, then falls back to raw comparison if no textconv pattern matches.

The existing stale-cache logic (line 831 of `sourcestate.go`) naturally handles first-run migration when textconv is newly configured.

## Test plan

- [x] New test cases in `textconv.txtar`:
  - `chezmoi status` reports no changes when textconv-filtered contents match
  - `chezmoi verify` succeeds when textconv-filtered contents match
  - `chezmoi apply` does not overwrite when textconv-filtered contents match
  - `chezmoi diff` shows no output when textconv-filtered contents match
  - `chezmoi apply` writes raw (unfiltered) contents when textconv-filtered contents differ
- [x] Existing `textconv.txtar` tests still pass (diff display, interactive diffs)
- [x] Full `internal/chezmoi/...` test suite passes
- [x] Tested manually with real macOS plist files and a textconv script stripping volatile keys