### PR TITLE
docs: Add new articles on using chezmoi with coding agent configuration

### DIFF
--- a/assets/chezmoi.io/docs/links/articles.md.yaml
+++ b/assets/chezmoi.io/docs/links/articles.md.yaml
@@ -662,3 +662,11 @@ articles:
   version: 2.69.4
   title: Syncing Dotfiles Across Machines with Chezmoi
   url: https://rifqimfahmi.dev/blog/chezmoi-to-backup-dotfiles
+- date: '2026-03-07'
+  version: 2.69.4
+  title: One Skills Brain for Codex, Claude, Cursor, and Copilot with chezmoi
+  url: https://dev.to/dotwee/one-skills-brain-for-codex-claude-cursor-and-copilot-with-chezmoi-2p3k
+- date: '2026-03-07'
+  version: 2.69.4
+  title: One MCP Configuration for Codex, Claude, Cursor, and Copilot with chezmoi
+  url: https://dev.to/dotwee/one-mcp-configuration-for-codex-claude-cursor-and-copilot-with-chezmoi-925


### PR DESCRIPTION
Published two little guides about how to use chezmoi to keep multiple Coding Agent tools configuration managed and in sync.

- [One Skills Brain for Codex, Claude, Cursor, and Copilot with chezmoi](https://dev.to/dotwee/one-skills-brain-for-codex-claude-cursor-and-copilot-with-chezmoi-2p3k)
- [One MCP Configuration for Codex, Claude, Cursor, and Copilot with chezmoi](https://dev.to/dotwee/one-mcp-configuration-for-codex-claude-cursor-and-copilot-with-chezmoi-925)

This PR adds those to the [`articles.md.yaml`‎](https://github.com/twpayne/chezmoi/pull/4946#diff-9a265b71871650fed5e9a97c82ae16739635851a2db334de93b72e5c15bab543).

---

(sincerely thank you @tcholewik for your awesome open source work! is really appreciated!)