### PR TITLE
docs: Make the AI/LLM stance even more obvious

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,4 +1,13 @@
 # Contributing
 
-See the [contributing
-guide](https://chezmoi.io/developer-guide/contributing-changes/).
+> [!WARNING]
+>
+> If you use an LLM (Large Language Model, like ChatGPT, Claude, Gemini, GitHub
+> Copilot, or Llama) to make any kind of contribution then you will immediately
+> be banned without recourse. See [`CODE_OF_CONDUCT.md`][coc] for more
+> information.
+
+See the [contributing guide][guide] for full details.
+
+[guide]: https://chezmoi.io/developer-guide/contributing-changes/
+[coc]: https://github.com/twpayne/chezmoi/blob/master/.github/CODE_OF_CONDUCT.md

--- a/.github/ISSUE_TEMPLATE/01_support_request.md
+++ b/.github/ISSUE_TEMPLATE/01_support_request.md
@@ -6,6 +6,15 @@ labels: support
 assignees: ''
 ---
 
+<!--
+
+chezmoi has a strict zero-tolerance policy on LLM contributions. If you use an
+LLM (Large Language Model, like ChatGPT, Claude, Gemini, GitHub Copilot, or
+Llama) to make any kind of contribution then you will immediately be banned
+without recourse.
+
+-->
+
 ## What exactly are you trying to do?
 
 Describe in as much detail as possible.

--- a/.github/ISSUE_TEMPLATE/02_feature_request.md
+++ b/.github/ISSUE_TEMPLATE/02_feature_request.md
@@ -6,6 +6,15 @@ labels: enhancement
 assignees: ''
 ---
 
+<!--
+
+chezmoi has a strict zero-tolerance policy on LLM contributions. If you use an
+LLM (Large Language Model, like ChatGPT, Claude, Gemini, GitHub Copilot, or
+Llama) to make any kind of contribution then you will immediately be banned
+without recourse.
+
+-->
+
 ## Is your feature request related to a problem? Please describe.
 
 A clear and concise description of what the problem is, for example "I'm always

--- a/.github/ISSUE_TEMPLATE/03_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/03_bug_report.md
@@ -5,6 +5,15 @@ title: ''
 assignees: ''
 ---
 
+<!--
+
+chezmoi has a strict zero-tolerance policy on LLM contributions. If you use an
+LLM (Large Language Model, like ChatGPT, Claude, Gemini, GitHub Copilot, or
+Llama) to make any kind of contribution then you will immediately be banned
+without recourse.
+
+-->
+
 ## Describe the bug
 
 A clear and concise description of what the bug is.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,10 @@
 
 Thanks for contributing!
 
-chezmoi does not accept contributions written by or with the assistance of LLMs.
+chezmoi has a strict zero-tolerance policy on LLM contributions. If you use an
+LLM (Large Language Model, like ChatGPT, Claude, Gemini, GitHub Copilot, or
+Llama) to make any kind of contribution then you will immediately be banned
+without recourse.
 
 Please make sure that you have followed the contributing guide:
 https://chezmoi.io/developer-guide/contributing-changes/

--- a/assets/chezmoi.io/docs/developer-guide/contributing-changes.md
+++ b/assets/chezmoi.io/docs/developer-guide/contributing-changes.md
@@ -2,10 +2,11 @@
 
 !!! warning
 
-    If you use an LLM (Large Language Model, like ChatGPT, Claude, Gemini,
-    GitHub Copilot, or Llama) to make any kind of contribution then you will
-    immediately be banned without recourse. See [`CODE_OF_CONDUCT.md`][coc]
-    for more information.
+    chezmoi has a strict zero-tolerance policy on LLM contributions. If you use
+    an LLM (Large Language Model, like ChatGPT, Claude, Gemini, GitHub Copilot,
+    or Llama) to make any kind of contribution then you will immediately be
+    banned without recourse. See [`CODE_OF_CONDUCT.md`][coc] for more
+    information.
 
 Bug reports, bug fixes, and documentation improvements are always welcome.
 Please [open an issue][issue] or [create a pull request][pr] with your report,
@@ -25,13 +26,13 @@ that:
 
 * The documentation is updated, if necessary. For new features you should add an
   entry in `assets/chezmoi.io/docs/user-guide/` and a complete description in
-  `assets/chezmoi.io/docs/reference/`. See the [website developer
-  guide][website] for instructions on how to build and view a local version of
-  the documentation. By default, chezmoi will panic if a flag is undocumented or
-  a long help is missing for a command. You can disable this panic during
-  development by setting the environment variable `CHEZMOIDEV` to
-  `ignoreflags=1,ignorehelp=1`. Once you have documented the command and its
-  flags, run `make generate` to generate the embedded documentation.
+  `assets/chezmoi.io/docs/reference/`. See the [website developer guide][website]
+  for instructions on how to build and view a local version of the documentation.
+  By default, chezmoi will panic if a flag is undocumented or a long help is
+  missing for a command. You can disable this panic during development by
+  setting the environment variable `CHEZMOIDEV` to `ignoreflags=1,ignorehelp=1`.
+  Once you have documented the command and its flags, run `make generate` to
+  generate the embedded documentation.
 
 * All generated files are up to date. You can ensure this by running `make
   generate` and including any modified files in your commit.
@@ -76,3 +77,4 @@ that:
 [commits]: https://www.conventionalcommits.org/en/v1.0.0/
 [history]: https://github.com/twpayne/chezmoi/commits/master/
 [website]: /developer-guide/website.md
+[coc]: https://github.com/twpayne/chezmoi/blob/master/.github/CODE_OF_CONDUCT.md


### PR DESCRIPTION
With recent contributions that people have made using LLM, it is possible that people aren't seeing chezmoi's strict no-LLM policy clearly enough. While this doesn't fix *everything*, it makes the policy clearer by repeating it in places where people would be most likely to see it.