### PR TITLE
docs: add missing protonpass password manager entry

### DIFF
--- a/assets/chezmoi.io/docs/user-guide/password-managers/protonpass.md
+++ b/assets/chezmoi.io/docs/user-guide/password-managers/protonpass.md
@@ -1,0 +1,25 @@
+# pass
+
+chezmoi includes support for [Proton Pass][protonpass] using [proton pass CLI][cli].
+
+Log in to proton pass using 
+```shell
+pass-cli login
+```
+
+The  output of `pass-cli item view pass://$SHARE_ID/$ITEM_ID/$FIELD` is available as the
+`protonPass` template function, for example:
+
+```text
+{{ protonPass "pass://$SHARE_ID/$ITEM_ID/$FIELD" }}
+```
+
+The  output of `pass-cli item view pass://$SHARE_ID/$ITEM_ID` is available as the
+`protonPassJSON` and returns the structured data the item holds. For example:
+
+```text
+{{ (protonPassJSON "pass://$SHARE_ID/$ITEM_ID").item.content.content.key.password }}
+```
+
+[protonpass]: https://proton.me/pass
+[cli]: https://protonpass.github.io/pass-cli/

--- a/assets/chezmoi.io/mkdocs.yml
+++ b/assets/chezmoi.io/mkdocs.yml
@@ -80,6 +80,7 @@ nav:
     - LastPass: user-guide/password-managers/lastpass.md
     - pass: user-guide/password-managers/pass.md
     - passhole: user-guide/password-managers/passhole.md
+    - protonPass: user-guide/password-managers/protonpass.md
     - Vault: user-guide/password-managers/vault.md
     - Custom: user-guide/password-managers/custom.md
   - Encryption:


### PR DESCRIPTION
I wanted to add proton pass support to chezmoi, but I found out it was already impletmented, just missing a documentation entry in assets/chezmoi.io/docs/user-guide/password-managers/
So here it is.
I tried to match existing password manager entry.
Fixes #4965 
