### PR TITLE
fix: skip secret scanning for encrypted files on re-add

### DIFF
--- a/internal/cmd/addcmd.go
+++ b/internal/cmd/addcmd.go
@@ -88,8 +88,18 @@ func (c *Config) defaultOnIgnoreFunc(targetRelPath chezmoi.RelPath) {
 }
 
 func (c *Config) defaultPreAddFunc(targetRelPath chezmoi.RelPath, fileInfo fs.FileInfo) error {
+	return c.preAddFunc(false)(targetRelPath, fileInfo)
+}
+
+func (c *Config) preAddFunc(encrypt bool) chezmoi.PreAddFunc {
+	return func(targetRelPath chezmoi.RelPath, fileInfo fs.FileInfo) error {
+		return c.doPreAdd(targetRelPath, fileInfo, encrypt)
+	}
+}
+
+func (c *Config) doPreAdd(targetRelPath chezmoi.RelPath, fileInfo fs.FileInfo, encrypt bool) error {
 	// Scan unencrypted files for secrets, if configured.
-	if c.Add.Secrets.String() != severityIgnore && fileInfo.Mode().Type() == 0 && !c.Add.Encrypt {
+	if c.Add.Secrets.String() != severityIgnore && fileInfo.Mode().Type() == 0 && !c.Add.Encrypt && !encrypt {
 		absPath := c.DestDirAbsPath.Join(targetRelPath)
 		content, err := c.destSystem.ReadFile(absPath)
 		if err != nil {

--- a/internal/cmd/readdcmd.go
+++ b/internal/cmd/readdcmd.go
@@ -203,7 +203,7 @@ TARGET_REL_PATH:
 			EncryptedSuffix: c.encryption.EncryptedSuffix(),
 			Errorf:          c.errorf,
 			Filter:          c.reAdd.filter,
-			PreAddFunc:      c.defaultPreAddFunc,
+			PreAddFunc:      c.preAddFunc(sourceStateFile.Attr().Encrypted),
 		}); err != nil {
 			return err
 		}


### PR DESCRIPTION
Files with the `encrypted_` attribute are expected to contain secrets. The gitleaks scan currently runs on these files during `re-add --re-encrypt`, producing false positive warnings (or blocking the operation entirely when `add.secrets` is set to `error`).

This introduces a `preAddFunc` helper that accepts an `encrypt` parameter, allowing the re-add path to pass through the source entry's encryption state. When a file is marked encrypted, the secret scan is skipped.

Closes #4976