### PR TITLE
fix: Don't warn on secrets when re-adding encrypted files

### DIFF
--- a/internal/chezmoi/sourcestate.go
+++ b/internal/chezmoi/sourcestate.go
@@ -334,7 +334,7 @@ func NewSourceState(options ...SourceStateOption) *SourceState {
 }
 
 // A PreAddFunc is called before a new source state entry is added.
-type PreAddFunc func(targetRelPath RelPath, fileInfo fs.FileInfo) error
+type PreAddFunc func(targetRelPath RelPath, fileInfo fs.FileInfo, sourceStateEntry SourceStateEntry) error
 
 // A ReplaceFunc is called before a source state entry is replaced.
 type ReplaceFunc func(targetRelPath RelPath, newSourceStateEntry, oldSourceStateEntry SourceStateEntry) error
@@ -541,7 +541,7 @@ DEST_ABS_PATH:
 		}
 
 		if options.PreAddFunc != nil && destAbsPathInfo != nil {
-			switch err := options.PreAddFunc(targetRelPath, destAbsPathInfo); {
+			switch err := options.PreAddFunc(targetRelPath, destAbsPathInfo, newSourceStateEntry); {
 			case errors.Is(err, fs.SkipDir):
 				continue DEST_ABS_PATH
 			case err != nil:

--- a/internal/cmd/addcmd.go
+++ b/internal/cmd/addcmd.go
@@ -87,9 +87,17 @@ func (c *Config) defaultOnIgnoreFunc(targetRelPath chezmoi.RelPath) {
 	}
 }
 
-func (c *Config) defaultPreAddFunc(targetRelPath chezmoi.RelPath, fileInfo fs.FileInfo) error {
+func (c *Config) defaultPreAddFunc(
+	targetRelPath chezmoi.RelPath,
+	fileInfo fs.FileInfo,
+	sourceStateEntry chezmoi.SourceStateEntry,
+) error {
 	// Scan unencrypted files for secrets, if configured.
-	if c.Add.Secrets.String() != severityIgnore && fileInfo.Mode().Type() == 0 && !c.Add.Encrypt {
+	encrypted := c.Add.Encrypt
+	if sourceStateFile, ok := sourceStateEntry.(*chezmoi.SourceStateFile); ok {
+		encrypted = sourceStateFile.Attr().Encrypted
+	}
+	if c.Add.Secrets.String() != severityIgnore && fileInfo.Mode().Type() == 0 && !encrypted {
 		absPath := c.DestDirAbsPath.Join(targetRelPath)
 		content, err := c.destSystem.ReadFile(absPath)
 		if err != nil {

--- a/internal/cmd/testdata/scripts/issue4976.txtar
+++ b/internal/cmd/testdata/scripts/issue4976.txtar
@@ -1,0 +1,13 @@
+mkageconfig
+appendline $CHEZMOICONFIGDIR/chezmoi.toml '[add]'
+appendline $CHEZMOICONFIGDIR/chezmoi.toml '    secrets = "error"'
+
+# test that chezmoi re-add --re-encrypt allows secrets in encrypted files
+exec chezmoi add --encrypt $HOME${/}.file
+! stderr .
+edit $HOME${/}.file
+exec chezmoi re-add --re-encrypt
+! stderr .
+
+-- home/user/.file --
+SUMO_ACCESS_KEY: gxq3rJQkS6qovOg9UY2Q70iH1jFZx0WBrrsiAYv4XHodogAwTKyLzvFK4neRN8Dk


### PR DESCRIPTION
Fixes #4976.