### PR TITLE
feat: Add build-info check to doctor command

### DIFF
--- a/internal/cmd/doctorcmd.go
+++ b/internal/cmd/doctorcmd.go
@@ -14,6 +14,7 @@ import (
 	"os/exec"
 	"regexp"
 	"runtime"
+	"runtime/debug"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -86,6 +87,9 @@ type binaryCheck struct {
 	versionRx   *regexp.Regexp
 	minVersion  *semver.Version
 }
+
+// A buildInfoCheck checks the values of [runtime/debug.BuildInfo].
+type buildInfoCheck struct{}
 
 // A configFileCheck checks that only one config file exists and that is
 // readable.
@@ -195,6 +199,7 @@ func (c *Config) runDoctorCmd(cmd *cobra.Command, args []string) error {
 			version:       c.version,
 		},
 		osArchCheck{},
+		buildInfoCheck{},
 		unameCheck{},
 		systeminfoCheck{},
 		goVersionCheck{},
@@ -520,6 +525,41 @@ func (c *binaryCheck) Run(config *Config) (checkResult, string) {
 	}
 
 	return checkResultOK, fmt.Sprintf("found %s, version %s", pathAbsPath, version)
+}
+
+func (c buildInfoCheck) Name() string {
+	return "build-info"
+}
+
+func (c buildInfoCheck) Run(config *Config) (checkResult, string) {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return checkResultError, "debug.ReadBuildInfo() failed"
+	}
+	ignoredKeys := map[string]struct{}{
+		"-buildmode":     {}, // Always "exe".
+		"-compiler":      {}, // Checked by goVersionCheck.
+		"DefaultGODEBUG": {}, // Implicit in Go version.
+		"GOOS":           {}, // Checked by osArchCheck.
+		"GOARCH":         {}, // Checked by osArchCheck.
+		"vcs":            {}, // Checked by versionCheck.
+		"vcs.revision":   {}, // Checked by versionCheck.
+		"vcs.time":       {}, // Checked by versionCheck.
+		"vcs.modified":   {}, // Checked by versionCheck.
+	}
+	checkResult := checkResultOK
+	pairs := make([]string, 0, len(info.Settings))
+	for _, setting := range info.Settings {
+		if _, ok := ignoredKeys[setting.Key]; ok || setting.Value == "" {
+			continue
+		}
+		if setting.Key == "CGO_ENABLED" && setting.Value == "0" {
+			// No cgo is not necessarily a problem, but also isn't always OK.
+			checkResult = checkResultInfo
+		}
+		pairs = append(pairs, setting.Key+"="+setting.Value)
+	}
+	return checkResult, strings.Join(pairs, ", ")
 }
 
 func (c *configFileCheck) Name() string {

--- a/internal/cmd/testdata/scripts/doctor_unix.txtar
+++ b/internal/cmd/testdata/scripts/doctor_unix.txtar
@@ -30,6 +30,7 @@ exec chezmoi doctor
 stdout '^ok\s+version\s+'
 stdout '^\w+\s+latest-version\s+'
 stdout '^ok\s+os-arch\s+'
+stdout '\s+build-info\s+'
 ! stdout '^\S+\s+systeminfo\s+'
 stdout '^ok\s+uname\s+'
 stdout '^ok\s+config-file\s+'


### PR DESCRIPTION
Refs #4961. This is mainly to get the output of `GOARM` at compile time.

Example output on a x86 box:

```
ok        build-info                  CGO_ENABLED=1, GOAMD64=v1
```

Example output on an ARM box:

```
info      build-info                  CGO_ENABLED=0, GOARM=5
```