### PR TITLE
chore: Exclude Python dependencies newer than 5 days

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,5 +54,8 @@ ignore = ["ANN003", "COM812"]
 [tool.ruff.format]
 quote-style = "single"
 
+[tool.uv]
+exclude-newer = "5 days"
+
 [tool.uv.workspace]
 members = ["chezmoi"]

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.14"
 
+[options]
+exclude-newer = "2026-03-29T11:03:57.088853Z"
+exclude-newer-span = "P5D"
+
 [[package]]
 name = "babel"
 version = "2.17.0"


### PR DESCRIPTION
<!--

Thanks for contributing!

chezmoi has a strict zero-tolerance policy on LLM contributions. If you use an
LLM (Large Language Model, like ChatGPT, Claude, Gemini, GitHub Copilot, or
Llama) to make any kind of contribution then you will immediately be banned
without recourse.

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer-guide/contributing-changes/

-->

With all recent supply chain attacks I think it makes sense to have it.

It makes newer versions impossible to use even if added manually to `pyproject.toml`.

https://docs.astral.sh/uv/reference/settings/#exclude-newer

Discussion about similar feature in Go: https://github.com/golang/go/issues/76485