### PR TITLE
chore: Preview docs changes on PRs via Cloudflare Pages

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,0 +1,50 @@
+name: build-docs
+on:
+  pull_request:
+    branches:
+    - master
+    paths:
+    - 'assets/chezmoi.io/**'
+    - 'pyproject.toml'
+    - 'uv.lock'
+    - '.github/workflows/build-docs.yml'
+    - '.github/workflows/preview-docs.yml'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+env:
+  GO_VERSION: 1.26.2 # https://go.dev/doc/devel/release
+  PYTHON_VERSION: '3.14' # https://www.python.org/downloads/
+  UV_VERSION: 0.11.3 # https://github.com/astral-sh/uv/releases
+jobs:
+  build-docs:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd   # v6.0.2
+      with:
+        persist-credentials: false
+    - uses: ./.github/actions/setup-go
+      with:
+        cache-prefix: website-go
+        go-version: ${{ env.GO_VERSION }}
+    - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57   # v8.0.0
+      with:
+        enable-cache: false
+        version: ${{ env.UV_VERSION }}
+    - name: install-website-dependencies
+      run: |
+        uv python install ${{ env.PYTHON_VERSION }}
+        uv sync --locked
+    - name: build-website
+      run: uv run -v task build-docs
+      env:
+        CHEZMOI_GITHUB_TOKEN: ${{ secrets.CHEZMOI_GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: upload-docs-preview
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f   # v7.0.0
+      with:
+        name: docs-site-preview
+        path: assets/chezmoi.io/site/
+        retention-days: 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -311,6 +311,7 @@ jobs:
       run: uv run -v task build-docs
       env:
         CHEZMOI_GITHUB_TOKEN: ${{ secrets.CHEZMOI_GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   test-windows:
     name: test-windows
     needs: changes

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -1,0 +1,77 @@
+name: preview-docs
+on:
+  workflow_run:
+    workflows:
+    - build-docs
+    types:
+    - completed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+jobs:
+  deploy-preview:
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-22.04
+    permissions:
+      actions: read
+      pull-requests: write
+    steps:
+    - name: download-docs-site
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c   # v8.0.1
+      with:
+        name: docs-site-preview
+        path: artifact
+        run-id: ${{ github.event.workflow_run.id }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: find-pr-number
+      id: pr
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_REPO: ${{ github.repository }}
+        HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+      run: |
+        PR_NUMBER=$(gh api "repos/${GH_REPO}/commits/${HEAD_SHA}/pulls" --jq '.[0].number')
+        if [ -z "${PR_NUMBER}" ]; then
+          echo "error: could not determine PR number for commit ${HEAD_SHA}"
+          exit 1
+        fi
+        echo "number=${PR_NUMBER}" >> "${GITHUB_OUTPUT}"
+    - name: deploy-to-cloudflare-pages
+      id: deploy
+      uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65   # v3.14.1
+      with:
+        apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        command: pages deploy artifact --project-name=chezmoi-preview --branch=pr-${{ steps.pr.outputs.number }}
+    - name: comment-on-pr
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_REPO: ${{ github.repository }}
+        PR_NUMBER: ${{ steps.pr.outputs.number }}
+        PREVIEW_URL: ${{ steps.deploy.outputs.pages-deployment-alias-url }}
+        HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+      run: |
+        MARKER="<!-- chezmoi-docs-preview -->"
+        SHORT_SHA="${HEAD_SHA:0:7}"
+        BODY=$(cat <<EOF
+        ${MARKER}
+        📖 **Docs preview is ready:** ${PREVIEW_URL}
+
+        Built from ${SHORT_SHA}
+        EOF
+        )
+        EXISTING_COMMENT_ID=$(gh api \
+          "repos/${GH_REPO}/issues/${PR_NUMBER}/comments" \
+          --jq ".[] | select(.body | startswith(\"${MARKER}\")) | .id" \
+          | head -1)
+        if [ -n "${EXISTING_COMMENT_ID}" ]; then
+          gh api --method PATCH \
+            "repos/${GH_REPO}/issues/comments/${EXISTING_COMMENT_ID}" \
+            -f body="${BODY}"
+        else
+          gh api --method POST \
+            "repos/${GH_REPO}/issues/${PR_NUMBER}/comments" \
+            -f body="${BODY}"
+        fi


### PR DESCRIPTION
# Motivation

Allow everyone to preview docs changes easily without checking out code and running MkDocs build. For example it makes it easy to check how docs look on mobile devices.

Example: https://github.com/KapJI/chezmoi/pull/2

# Design

Two new workflows are added.

1. `build-docs.yml` (`pull_request` trigger) - runs on PRs that modify docs-related files. Builds the docs and uploads the result as an artifact.
2. `preview-docs.yml` (`workflow_run` trigger) - runs after `build-docs` completes successfully, with access to repo secrets. Downloads the artifact, looks up the PR number via GitHub API, deploys to Cloudflare Pages and creates or updates a comment on the PR with preview link and commit SHA.

Preview URL: `https://pr-<number>.chezmoi-preview.pages.dev`

# Security

- `build-docs` runs on `pull_request` events, which means it executes code from the fork. It has no access to repo secrets. Its outputs like `pr-number.txt` are not trusted.
- `preview-docs` uses `workflow_run` trigger, so its workflow file is always read from the default branch - fork PRs cannot modify the deploy logic. It never checks out fork code, only handles the pre-built static artifact.
- PR number is looked up via GitHub API (`commits/{sha}/pulls`) instead of reading from artifact, so a fork PR cannot spoof the PR number to comment on unrelated PRs.

# Other changes

Added `GITHUB_TOKEN` to `test-website` job so it can be used on forks where `CHEZMOI_GITHUB_TOKEN` isn't available. `GITHUB_TOKEN` has a higher API rate limit than unauthenticated requests. `CHEZMOI_GITHUB_TOKEN` takes priority when available so same-repo behavior is unchanged.

# Considered alternatives

## Uploading artifact from test-website job

Another option was uploading the artifact from the existing `test-website` job in `main.yml`. The problem is that `preview-docs` workflow only starts after the whole `main` workflow finishes, which can take a long time. The new `build-docs` workflow duplicates `test-website` a bit but it's fast (~40s), and I think it's better to have the preview ready 10 minutes earlier.

## GitHub Deployments instead of PR comments

GitHub Deployments were also considered, but the "View deployment" button disappears when a new commit is pushed until the deployment is updated. With a PR comment, the link stays visible at all times and the commit SHA clearly shows whether the preview is up to date.

Closes #4960