### PR TITLE
chore: Suppress MkDocs 2 upgrade warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,9 +15,9 @@ dependencies = [
 ]
 
 [tool.taskipy.tasks]
-build-docs = { cmd = "mkdocs build -f assets/chezmoi.io/mkdocs.yml" }
-serve-docs = { cmd = "mkdocs serve -f assets/chezmoi.io/mkdocs.yml" }
-deploy-docs = { cmd = "cd assets/chezmoi.io && mkdocs gh-deploy" }
+build-docs = { cmd = "NO_MKDOCS_2_WARNING=1 mkdocs build -f assets/chezmoi.io/mkdocs.yml" }
+serve-docs = { cmd = "NO_MKDOCS_2_WARNING=1 mkdocs serve -f assets/chezmoi.io/mkdocs.yml" }
+deploy-docs = { cmd = "cd assets/chezmoi.io && NO_MKDOCS_2_WARNING=1 mkdocs gh-deploy" }
 lint = { cmd = "ruff check" }
 format = { cmd = "ruff format" }
 pycheck = { cmd = "task lint && task format --diff" }


### PR DESCRIPTION
<!--

Thanks for contributing!

chezmoi has a strict zero-tolerance policy on LLM contributions. If you use an
LLM (Large Language Model, like ChatGPT, Claude, Gemini, GitHub Copilot, or
Llama) to make any kind of contribution then you will immediately be banned
without recourse.

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer-guide/contributing-changes/

-->

Suppress the MkDocs 2 upgrade warning by setting `NO_MKDOCS_2_WARNING=1` in task definitions. 
The warning is styled in red, making it look like an error.

Warning is now gone in CI jobs.

The only issue is that because of bash syntax this won't work on Windows, not sure how important is this. I can move it just to CI if you prefer it this way.