### PR TITLE
chore: Fix preview-docs PR lookup for forks

### DIFF
--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -30,11 +30,13 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GH_REPO: ${{ github.repository }}
-        HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
       run: |
-        PR_NUMBER=$(gh api "repos/${GH_REPO}/commits/${HEAD_SHA}/pulls" --jq '.[0].number')
+        PR_NUMBER=$(gh api "repos/${GH_REPO}/pulls" --paginate \
+          --jq ".[] | select(.head.ref == \"${HEAD_BRANCH}\" and .head.repo.full_name == \"${HEAD_REPO}\") | .number")
         if [ -z "${PR_NUMBER}" ]; then
-          echo "error: could not determine PR number for commit ${HEAD_SHA}"
+          echo "error: could not find PR for ${HEAD_REPO}:${HEAD_BRANCH}"
           exit 1
         fi
         echo "number=${PR_NUMBER}" >> "${GITHUB_OUTPUT}"
@@ -64,7 +66,7 @@ jobs:
         )
         EXISTING_COMMENT_ID=$(gh api \
           "repos/${GH_REPO}/issues/${PR_NUMBER}/comments" \
-          --jq ".[] | select(.body | startswith(\"${MARKER}\")) | .id" \
+          --paginate --jq ".[] | select(.body | startswith(\"${MARKER}\")) | .id" \
           | head -1)
         if [ -n "${EXISTING_COMMENT_ID}" ]; then
           gh api --method PATCH \


### PR DESCRIPTION
<!--

Thanks for contributing!

chezmoi has a strict zero-tolerance policy on LLM contributions. If you use an
LLM (Large Language Model, like ChatGPT, Claude, Gemini, GitHub Copilot, or
Llama) to make any kind of contribution then you will immediately be banned
without recourse.

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer-guide/contributing-changes/

-->
Two fixes for `preview-docs` workflow:

1. I noticed `commits/{sha}/pulls` API doesn't find commits that only exist on fork branches. Replaced with the pulls list API filtered by head branch and source repository, which works for both fork and same-repo PRs.

   Verified fields with:

   ```
   gh api repos/twpayne/chezmoi/pulls --jq ".[] | {number, draft, head_ref: .head.ref, head_repo: .head.repo.full_name}"
   ```

2. Add `--paginate` to the PR comment lookup to fetch all comment pages (30 comments per page). Initially I thought docs preview comment is always in the beginning but then I realised that docs changes theoretically can be added after lengthy discussion. Performance difference is negligible anyway.


