### PR TITLE
chore: Fix misspell warnings

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -47,6 +47,7 @@ jobs:
     - uses: reviewdog/action-misspell@d6429416b12b09b4e2768307d53bef58d172e962   # v1.27.0
       with:
         locale: US
+        ignore: importas,Produktive
   test-install-sh:
     if: ${{ needs.changes.outputs.sh == 'true' }}
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,6 +85,7 @@ jobs:
     - uses: reviewdog/action-misspell@d6429416b12b09b4e2768307d53bef58d172e962   # v1.27.0
       with:
         locale: US
+        ignore: importas,Produktive
   test-alpine:
     needs: changes
     if: github.event_name == 'push' || needs.changes.outputs.code == 'true'


### PR DESCRIPTION
<!--

Thanks for contributing!

chezmoi has a strict zero-tolerance policy on LLM contributions. If you use an
LLM (Large Language Model, like ChatGPT, Claude, Gemini, GitHub Copilot, or
Llama) to make any kind of contribution then you will immediately be banned
without recourse.

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer-guide/contributing-changes/

-->

Follow up to 4c078fa69aac0be7666e2f42c3902091bfd53a1a.

These warnings are displayed on `main` workflow run results, e.g.: https://github.com/twpayne/chezmoi/actions/runs/24541200173

They are false positives: German word and Go linter name.

No longer displayed here: https://github.com/twpayne/chezmoi/actions/runs/24577983585?pr=5029