### PR TITLE
install.sh: map armv6/armv7 uname to chezmoi armv6 release

### DIFF
--- a/assets/scripts/install-local-bin.sh
+++ b/assets/scripts/install-local-bin.sh
@@ -138,7 +138,9 @@ get_goarch() {
 	arch="$(uname -m)"
 	case "${arch}" in
 	aarch64) goarch="arm64" ;;
-	armv*) goarch="arm" ;;
+	arm64) goarch="arm64" ;;
+	armv5*) goarch="armv5" ;;
+	arm*) goarch="armv6" ;;
 	i386) goarch="386" ;;
 	i686) goarch="386" ;;
 	i86pc) goarch="amd64" ;;
@@ -158,9 +160,11 @@ check_goos_goarch() {
 	freebsd/amd64) return 0 ;;
 	freebsd/arm) return 0 ;;
 	freebsd/arm64) return 0 ;;
+	freebsd/riscv64) return 0 ;;
 	linux/386) return 0 ;;
 	linux/amd64) return 0 ;;
-	linux/arm) return 0 ;;
+	linux/armv5) return 0 ;;
+	linux/armv6) return 0 ;;
 	linux/arm64) return 0 ;;
 	linux/loong64) return 0 ;;
 	linux/mips64) return 0 ;;

--- a/assets/scripts/install.sh
+++ b/assets/scripts/install.sh
@@ -137,7 +137,9 @@ get_goarch() {
 	arch="$(uname -m)"
 	case "${arch}" in
 	aarch64) goarch="arm64" ;;
-	armv*) goarch="arm" ;;
+	arm64) goarch="arm64" ;;
+	armv5*) goarch="armv5" ;;
+	arm*) goarch="armv6" ;;
 	i386) goarch="386" ;;
 	i686) goarch="386" ;;
 	i86pc) goarch="amd64" ;;
@@ -157,9 +159,11 @@ check_goos_goarch() {
 	freebsd/amd64) return 0 ;;
 	freebsd/arm) return 0 ;;
 	freebsd/arm64) return 0 ;;
+	freebsd/riscv64) return 0 ;;
 	linux/386) return 0 ;;
 	linux/amd64) return 0 ;;
-	linux/arm) return 0 ;;
+	linux/armv5) return 0 ;;
+	linux/armv6) return 0 ;;
 	linux/arm64) return 0 ;;
 	linux/loong64) return 0 ;;
 	linux/mips64) return 0 ;;

--- a/internal/cmds/generate-install.sh/install.sh.tmpl
+++ b/internal/cmds/generate-install.sh/install.sh.tmpl
@@ -146,7 +146,9 @@ get_goarch() {
 	arch="$(uname -m)"
 	case "${arch}" in
 	aarch64) goarch="arm64" ;;
-	armv*) goarch="arm" ;;
+	arm64) goarch="arm64" ;;
+	armv5*) goarch="armv5" ;;
+	arm*) goarch="armv6" ;;
 	i386) goarch="386" ;;
 	i686) goarch="386" ;;
 	i86pc) goarch="amd64" ;;
@@ -160,7 +162,12 @@ get_goarch() {
 check_goos_goarch() {
 	case "${1}" in
 {{- range .Platforms }}
+	{{- if and (eq .GOOS "linux") (eq .GOARCH "arm") }}
+	linux/armv5) return 0 ;;
+	linux/armv6) return 0 ;;
+	{{- else }}
 	{{ .GOOS }}/{{ .GOARCH }}) return 0 ;;
+	{{- end }}
 {{- end }}
 	*)
 		log_crit '%s: unsupported platform\n' "${1}" 1>&2


### PR DESCRIPTION
Fixes #5047. The install script mapped every `armv*l` uname value to `goarch=arm`, which matched the `linux_arm` tarball that existed up to v2.69.2. Starting with v2.70.0 the release naming switched to per-version suffixes (`linux_armv5`, `linux_armv6`) and the bare `linux_arm` tarball is gone, so the install fails with a 404 on Raspberry Pi 1/Zero (`armv6l`) and on `armv7l` hardware too.

This maps `armv6l` to `armv6`, and `armv7l` to `armv6` as well — there's no `linux_armv7` tarball to point at, and armv7 hardware runs the armv6 binary fine.

Fixes #5047