### PR TITLE
fix: Run git lfs pull in working copy directory

### DIFF
--- a/internal/cmd/initcmd.go
+++ b/internal/cmd/initcmd.go
@@ -133,15 +133,15 @@ func (c *Config) runInitCmd(cmd *cobra.Command, args []string) error {
 
 	useBuiltinGit := c.UseBuiltinGit.Value(c.useBuiltinGitAutoFunc)
 
-	// If we're not in a working tree then init it or clone it.
 	gitDirAbsPath := c.WorkingTreeAbsPath.JoinString(git.GitDirName)
+	workingTreeRawPath, err := c.baseSystem.RawPath(c.WorkingTreeAbsPath)
+	if err != nil {
+		return err
+	}
+
+	// If we're not in a working tree then init it or clone it.
 	switch _, err := c.baseSystem.Stat(gitDirAbsPath); {
 	case errors.Is(err, fs.ErrNotExist):
-		workingTreeRawPath, err := c.baseSystem.RawPath(c.WorkingTreeAbsPath)
-		if err != nil {
-			return err
-		}
-
 		if len(args) == 0 {
 			if useBuiltinGit {
 				if err := c.builtinGitInit(workingTreeRawPath); err != nil {
@@ -200,7 +200,7 @@ func (c *Config) runInitCmd(cmd *cobra.Command, args []string) error {
 
 	if c.Git.LFS && !useBuiltinGit {
 		args := []string{"lfs", "pull"}
-		if err := c.run(chezmoi.EmptyAbsPath, c.Git.Command, args); err != nil {
+		if err := c.run(workingTreeRawPath, c.Git.Command, args); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
When `chezmoi init --git-lfs` runs `git lfs pull`, it should run it in the working copy directory, or Git fails with exit status 128: `Not in a Git repository.`

<!--

Thanks for contributing!

chezmoi has a strict zero-tolerance policy on LLM contributions. If you use an
LLM (Large Language Model, like ChatGPT, Claude, Gemini, GitHub Copilot, or
Llama) to make any kind of contribution then you will immediately be banned
without recourse.

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer-guide/contributing-changes/

-->
