### PR TITLE
docs: `pager` -> `command` for delta; remove old "Customize" section

### DIFF
--- a/assets/chezmoi.io/docs/user-guide/tools/diff.md
+++ b/assets/chezmoi.io/docs/user-guide/tools/diff.md
@@ -36,13 +36,13 @@ To use [VSCode][vscode] as the diff tool, add the following to your config:
 
 ## Use delta as the diff tool
 
-To use [delta][delta] as the diff tool you must set `diff.pager` to delta, for
+To use [delta][delta] as the diff tool you must set `diff.command` to delta, for
 example:
 
 <!-- example-formats -->
 ```toml title="~/.config/chezmoi/chezmoi.toml"
 [diff]
-    pager = "delta"
+    command = "delta"
 ```
 <!-- /example-formats -->
 
@@ -64,22 +64,6 @@ for example:
 
 To exclude diffs from externals, either pass the `--exclude=externals` flag or
 set `diff.exclude` to `["externals"]` in your config file.
-
-## Customize the diff pager
-
-You can change the diff format, and/or pipe the output into a pager of your
-choice by setting `diff.pager` configuration variable. For example, to use
-[`diff-so-fancy`][fancy] specify:
-
-<!-- example-formats -->
-```toml title="~/.config/chezmoi/chezmoi.toml"
-[diff]
-    pager = "diff-so-fancy"
-```
-<!-- /example-formats -->
-
-The pager can be disabled using the `--no-pager` flag or by setting `diff.pager`
-to an empty string.
 
 ## Show human-friendly diffs for binary files
 


### PR DESCRIPTION
I attempted to make `delta` my diff tool by following the documentation instructions and setting `diff.pager` to "delta", but `chezmoi doctor` continued to report that `diff-command` was `not set`. When I followed the other examples, and used `command` instead of `pager`, `chezmoi doctor` reported the tool as found, and `chezmoi diff` used it.

I'm guessing that `pager` was changed to `command` at some point, and the `delta` section was overlooked.

I've also removed the **Customize the diff pager** section, as that also refers to `diff.pager` and seems superseded by the **Use a custom diff tool** section at the top of the page.