### PR TITLE
chore: generate sigstore bundles rather than separate signature

### DIFF
--- a/.config/goreleaser.yaml
+++ b/.config/goreleaser.yaml
@@ -284,10 +284,11 @@ scoops:
 signs:
 - cmd: cosign
   stdin: '{{ .Env.COSIGN_PWD }}'
+  signature: '${artifact}.sigstore.json'
   args:
   - sign-blob
   - --key=assets/cosign/cosign.key
-  - --output-signature=${signature}
+  - --bundle=${signature}
   - --yes
   - ${artifact}
   artifacts: checksum

--- a/assets/chezmoi.io/docs/install.md.tmpl
+++ b/assets/chezmoi.io/docs/install.md.tmpl
@@ -288,14 +288,14 @@ Download the [checksum
 file](https://github.com/twpayne/chezmoi/releases/download/v{{ $version
 }}/chezmoi_{{ $version }}_checksums.txt), [checksum file
 signature](https://github.com/twpayne/chezmoi/releases/download/v{{ $version
-}}/chezmoi_{{ $version }}_checksums.txt.sig), and [public signing
+}}/chezmoi_{{ $version }}_checksums.txt.sigstore.json), and [public signing
 key](https://github.com/twpayne/chezmoi/releases/download/v{{ $version
 }}/chezmoi_cosign.pub).
 
    ```sh
    curl --location --remote-name-all \
           https://github.com/twpayne/chezmoi/releases/download/v{{ $version }}/chezmoi_{{ $version }}_checksums.txt \
-          https://github.com/twpayne/chezmoi/releases/download/v{{ $version }}/chezmoi_{{ $version }}_checksums.txt.sig \
+          https://github.com/twpayne/chezmoi/releases/download/v{{ $version }}/chezmoi_{{ $version }}_checksums.txt.sigstore.json \
           https://github.com/twpayne/chezmoi/releases/download/v{{ $version }}/chezmoi_cosign.pub
    ```
 
@@ -303,7 +303,7 @@ Verify the signature of the checksum file with cosign.
 
    ```sh
    cosign verify-blob --key=chezmoi_cosign.pub \
-                        --signature=chezmoi_{{ $version }}_checksums.txt.sig \
+                        --bundle=chezmoi_{{ $version }}_checksums.txt.sigstore.json \
                         chezmoi_{{ $version }}_checksums.txt
    ```
 


### PR DESCRIPTION
The latter is deprecated as of cosign 3.1.1,
ref https://github.com/sigstore/cosign/releases/tag/v3.1.1

<!--

Thanks for contributing!

chezmoi has a strict zero-tolerance policy on LLM contributions. If you use an
LLM (Large Language Model, like ChatGPT, Claude, Gemini, GitHub Copilot, or
Llama) to make any kind of contribution then you will immediately be banned
without recourse.

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer-guide/contributing-changes/

-->
