### PR TITLE
chore: Deduplicate script cmd setup

### DIFF
--- a/internal/chezmoi/realsystem.go
+++ b/internal/chezmoi/realsystem.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"time"
 
 	vfs "github.com/twpayne/go-vfs/v5"
@@ -83,55 +84,117 @@ func (s *RealSystem) RunCmd(cmd *exec.Cmd) error {
 	return chezmoilog.LogCmdRun(slog.Default(), cmd)
 }
 
-// RunScript implements System.RunScript.
-func (s *RealSystem) RunScript(scriptName RelPath, dir AbsPath, data []byte, options RunScriptOptions) (err error) {
+type runScriptArgs struct {
+	scriptName    string
+	workingDir    AbsPath
+	setWorkingDir bool
+	data          []byte
+	interpreter   *Interpreter
+	sourceRelPath SourceRelPath
+}
+
+type runScriptState struct {
+	createScriptTempDirOnce *sync.Once
+	scriptTempDir           AbsPath
+	system                  System
+}
+
+type preparedScriptCmd struct {
+	cmd     *exec.Cmd
+	cleanup func() error
+}
+
+func prepareScriptCmd(args runScriptArgs, state runScriptState) (_ preparedScriptCmd, err error) {
 	// Create the script temporary directory, if needed.
-	s.createScriptTempDirOnce.Do(func() {
-		if !s.scriptTempDir.IsEmpty() {
-			err = os.MkdirAll(s.scriptTempDir.String(), 0o700)
+	state.createScriptTempDirOnce.Do(func() {
+		if !state.scriptTempDir.IsEmpty() {
+			err = os.MkdirAll(state.scriptTempDir.String(), 0o700)
 		}
 	})
 	if err != nil {
-		return err
+		return preparedScriptCmd{}, err
 	}
 
 	// Write the temporary script file. Put the randomness at the front of the
 	// filename to preserve any file extension for Windows scripts.
 	var f *os.File
-	f, err = os.CreateTemp(s.scriptTempDir.String(), "*."+scriptName.Base())
+	f, err = os.CreateTemp(state.scriptTempDir.String(), "*."+args.scriptName)
 	if err != nil {
-		return err
+		return preparedScriptCmd{}, err
 	}
-	defer chezmoierrors.CombineFunc(&err, func() error {
+
+	// Remove the temporary script file when we are done using it.
+	cleanup := func() error {
 		return os.RemoveAll(f.Name())
-	})
+	}
+	// If preparing the command fails after creating the temp file, clean it up here.
+	// On success, cleanup is returned to the caller to run after the command exits.
+	defer func() {
+		if err != nil {
+			chezmoierrors.CombineFunc(&err, cleanup)
+		}
+	}()
 
 	// Make the script private before writing it in case it contains any
 	// secrets.
 	if runtime.GOOS != "windows" {
 		if err := f.Chmod(0o700); err != nil {
-			return err
+			return preparedScriptCmd{}, err
 		}
 	}
-	_, err = f.Write(data)
+	_, err = f.Write(args.data)
 	err = chezmoierrors.Combine(err, f.Close())
 	if err != nil {
-		return err
+		return preparedScriptCmd{}, err
 	}
 
-	cmd := options.Interpreter.ExecCommand(f.Name())
-	cmd.Dir, err = s.getScriptWorkingDir(dir)
+	cmd := args.interpreter.ExecCommand(f.Name())
+
+	if args.setWorkingDir {
+		cmd.Dir, err = getScriptWorkingDir(state.system, args.workingDir)
+		if err != nil {
+			return preparedScriptCmd{}, err
+		}
+	}
+
+	cmd.Env = append(os.Environ(),
+		"CHEZMOI_SOURCE_FILE="+args.sourceRelPath.String(),
+	)
+
+	return preparedScriptCmd{
+		cmd:     cmd,
+		cleanup: cleanup,
+	}, nil
+}
+
+// RunScript implements System.RunScript.
+func (s *RealSystem) RunScript(scriptName RelPath, dir AbsPath, data []byte, options RunScriptOptions) (err error) {
+	args := runScriptArgs{
+		scriptName:    scriptName.Base(),
+		workingDir:    dir,
+		setWorkingDir: true,
+		data:          data,
+		interpreter:   options.Interpreter,
+		sourceRelPath: options.SourceRelPath,
+	}
+
+	state := runScriptState{
+		createScriptTempDirOnce: &s.createScriptTempDirOnce,
+		scriptTempDir:           s.scriptTempDir,
+		system:                  s,
+	}
+
+	preparedScript, err := prepareScriptCmd(args, state)
 	if err != nil {
 		return err
 	}
-	cmd.Env = append(os.Environ(),
-		"CHEZMOI_SOURCE_FILE="+options.SourceRelPath.String(),
-	)
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	defer chezmoierrors.CombineFunc(&err, preparedScript.cleanup)
 
-	return s.RunCmd(cmd)
+	preparedScript.cmd.Stdin = os.Stdin
+	preparedScript.cmd.Stdout = os.Stdout
+	preparedScript.cmd.Stderr = os.Stderr
+
+	return s.RunCmd(preparedScript.cmd)
 }
 
 // Stat implements System.Stat.
@@ -149,7 +212,7 @@ func (s *RealSystem) UnderlyingFS() vfs.FS {
 // If this is a before_ script then the requested working directory may not
 // actually exist yet, so search through the parent directory hierarchy until
 // we find a suitable working directory.
-func (s *RealSystem) getScriptWorkingDir(dir AbsPath) (string, error) {
+func getScriptWorkingDir(s System, dir AbsPath) (string, error) {
 	// This should always terminate because dir will eventually become ".", i.e.
 	// the current directory.
 	for {

--- a/internal/chezmoi/realsystem_test.go
+++ b/internal/chezmoi/realsystem_test.go
@@ -1,8 +1,12 @@
 package chezmoi
 
 import (
+	"errors"
+	"io/fs"
 	"path/filepath"
+	"runtime"
 	"slices"
+	"sync"
 	"testing"
 
 	"github.com/alecthomas/assert/v2"
@@ -68,4 +72,155 @@ func pathsToSlashes(paths []string) []string {
 		result = append(result, filepath.ToSlash(path))
 	}
 	return result
+}
+
+func TestPrepareScriptCmd(t *testing.T) {
+	chezmoitest.WithTestFS(t, map[string]any{
+		"/work": map[string]any{},
+	}, func(fileSystem vfs.FS) {
+		system := NewRealSystem(fileSystem)
+		scriptTempDir, err := system.RawPath(NewAbsPath("/scripts"))
+		assert.NoError(t, err)
+		workingDir := NewAbsPath("/work")
+		workingDirRawAbsPath, err := system.RawPath(workingDir)
+		assert.NoError(t, err)
+
+		for _, tc := range []struct {
+			name           string
+			setWorkingDir  bool
+			expectedCmdDir string
+		}{
+			{
+				name: "without_working_dir",
+			},
+			{
+				name:           "with_working_dir",
+				setWorkingDir:  true,
+				expectedCmdDir: workingDirRawAbsPath.String(),
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				var createScriptTempDirOnce sync.Once
+				interpreter := &Interpreter{
+					Command: "interpreter",
+					Args:    []string{"arg"},
+				}
+				args := runScriptArgs{
+					scriptName:    "script.sh",
+					workingDir:    workingDir,
+					setWorkingDir: tc.setWorkingDir,
+					data:          []byte("# script contents\n"),
+					interpreter:   interpreter,
+					sourceRelPath: NewSourceRelPath("run_script.sh"),
+				}
+				state := runScriptState{
+					createScriptTempDirOnce: &createScriptTempDirOnce,
+					scriptTempDir:           scriptTempDir,
+					system:                  system,
+				}
+
+				preparedScript, err := prepareScriptCmd(args, state)
+				assert.NoError(t, err)
+
+				// Assert the returned command matches expected values
+				scriptName := preparedScript.cmd.Args[len(preparedScript.cmd.Args)-1]
+				assert.Equal(t, interpreter.Command, preparedScript.cmd.Path)
+				assert.Equal(t, []string{"interpreter", "arg", scriptName}, preparedScript.cmd.Args)
+				assert.Equal(t, tc.expectedCmdDir, preparedScript.cmd.Dir)
+				assert.SliceContains(t, preparedScript.cmd.Env, "CHEZMOI_SOURCE_FILE=run_script.sh")
+
+				// Assert the directory was created with the appropriate permissions
+				scriptTempDirFileInfo, err := system.Stat(NewAbsPath("/scripts"))
+				assert.NoError(t, err)
+				assert.True(t, scriptTempDirFileInfo.IsDir())
+				if runtime.GOOS != "windows" {
+					assert.Equal(t, 0o700, scriptTempDirFileInfo.Mode().Perm())
+				}
+
+				// Assert the temporary script file has appropriate path and name
+				assert.HasPrefix(t, filepath.ToSlash(scriptName), scriptTempDir.String()+"/")
+				assert.HasSuffix(t, scriptName, ".script.sh")
+
+				// Assert the temporary script contents and permissions
+				scriptAbsPath := NewAbsPath("/scripts").JoinString(filepath.Base(scriptName))
+				data, err := system.ReadFile(scriptAbsPath)
+				assert.NoError(t, err)
+				assert.Equal(t, []byte("# script contents\n"), data)
+				if runtime.GOOS != "windows" {
+					fileInfo, err := system.Stat(scriptAbsPath)
+					assert.NoError(t, err)
+					assert.Equal(t, 0o700, fileInfo.Mode().Perm())
+				}
+
+				// Assert the cleanup function properly deleted the temporary script
+				assert.NoError(t, preparedScript.cleanup())
+				_, err = system.Stat(scriptAbsPath)
+				assert.True(t, errors.Is(err, fs.ErrNotExist))
+			})
+		}
+	})
+}
+
+func TestPrepareScriptCmdCleansUpOnError(t *testing.T) {
+	chezmoitest.WithTestFS(t, map[string]any{
+		"/work": map[string]any{},
+	}, func(fileSystem vfs.FS) {
+		system := NewRealSystem(fileSystem)
+		scriptTempDir, err := system.RawPath(NewAbsPath("/scripts"))
+		assert.NoError(t, err)
+		workingDir := NewAbsPath("/work")
+		workingDirFileInfo, err := system.Stat(workingDir)
+		assert.NoError(t, err)
+
+		var createScriptTempDirOnce sync.Once
+
+		// Manually trigger an error to validate the premature exit scenario
+		rawPathErr := errors.New("raw path error")
+		rawPathErrorSystem := &rawPathErrorSystem{
+			expectedRawPath: workingDir,
+			fileInfo:        workingDirFileInfo,
+			err:             rawPathErr,
+		}
+
+		_, err = prepareScriptCmd(
+			runScriptArgs{
+				scriptName:    "script.sh",
+				workingDir:    workingDir,
+				setWorkingDir: true,
+				data:          []byte("# script contents\n"),
+				interpreter:   &Interpreter{},
+				sourceRelPath: NewSourceRelPath("run_script.sh"),
+			},
+			runScriptState{
+				createScriptTempDirOnce: &createScriptTempDirOnce,
+				scriptTempDir:           scriptTempDir,
+				system:                  rawPathErrorSystem,
+			},
+		)
+		assert.True(t, errors.Is(err, rawPathErr))
+
+		dirEntries, err := system.ReadDir(NewAbsPath("/scripts"))
+		assert.NoError(t, err)
+		assert.Equal(t, 0, len(dirEntries))
+	})
+}
+
+type rawPathErrorSystem struct {
+	emptySystemMixin
+	noUpdateSystemMixin
+
+	expectedRawPath AbsPath
+	fileInfo        fs.FileInfo
+	err             error
+}
+
+func (s *rawPathErrorSystem) RawPath(absPath AbsPath) (AbsPath, error) {
+	if absPath == s.expectedRawPath {
+		return EmptyAbsPath, s.err
+	}
+	return absPath, nil
+}
+
+func (s *rawPathErrorSystem) Stat(AbsPath) (fs.FileInfo, error) {
+	return s.fileInfo, nil
 }

--- a/internal/chezmoi/sourcestate.go
+++ b/internal/chezmoi/sourcestate.go
@@ -21,7 +21,6 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"slices"
 	"strings"
 	"sync"
@@ -2014,8 +2013,6 @@ func (s *SourceState) newModifyTargetStateEntryFunc(
 ) TargetStateEntryFunc {
 	return func(destSystem System, destAbsPath AbsPath) (TargetStateEntry, error) {
 		contentsFunc := sync.OnceValues(func() (contents []byte, err error) {
-			// FIXME this should share code with RealSystem.RunScript
-
 			// Read the current contents of the target.
 			var currentContents []byte
 			currentContents, err = destSystem.ReadFile(destAbsPath)
@@ -2070,43 +2067,28 @@ func (s *SourceState) newModifyTargetStateEntryFunc(
 				return tmpl.Execute(templateData)
 			}
 
-			// Create the script temporary directory, if needed.
-			s.createScriptTempDirOnce.Do(func() {
-				if !s.scriptTempDirAbsPath.IsEmpty() {
-					err = os.MkdirAll(s.scriptTempDirAbsPath.String(), 0o700)
-				}
-			})
+			scriptArgs := runScriptArgs{
+				scriptName:    fileAttr.TargetName,
+				data:          modifierContents,
+				interpreter:   interpreter,
+				sourceRelPath: sourceRelPath,
+			}
+
+			scriptState := runScriptState{
+				createScriptTempDirOnce: &s.createScriptTempDirOnce,
+				scriptTempDir:           s.scriptTempDirAbsPath,
+				system:                  s.system,
+			}
+
+			preparedScript, err := prepareScriptCmd(scriptArgs, scriptState)
 			if err != nil {
 				return nil, err
 			}
+			defer chezmoierrors.CombineFunc(&err, preparedScript.cleanup)
 
-			// Write the modifier to a temporary file.
-			var tempFile *os.File
-			if tempFile, err = os.CreateTemp(s.scriptTempDirAbsPath.String(), "*."+fileAttr.TargetName); err != nil {
-				return nil, err
-			}
-			defer chezmoierrors.CombineFunc(&err, func() error {
-				return os.RemoveAll(tempFile.Name())
-			})
-			if runtime.GOOS != "windows" {
-				if err := tempFile.Chmod(0o700); err != nil {
-					return nil, err
-				}
-			}
-			_, err = tempFile.Write(modifierContents)
-			err = chezmoierrors.Combine(err, tempFile.Close())
-			if err != nil {
-				return nil, err
-			}
-
-			// Run the modifier on the current contents.
-			cmd := interpreter.ExecCommand(tempFile.Name())
-			cmd.Env = append(os.Environ(),
-				"CHEZMOI_SOURCE_FILE="+sourceRelPath.String(),
-			)
-			cmd.Stdin = bytes.NewReader(currentContents)
-			cmd.Stderr = os.Stderr
-			return chezmoilog.LogCmdOutput(s.logger, cmd)
+			preparedScript.cmd.Stdin = bytes.NewReader(currentContents)
+			preparedScript.cmd.Stderr = os.Stderr
+			return chezmoilog.LogCmdOutput(s.logger, preparedScript.cmd)
 		})
 		return &TargetStateFile{
 			contentsFunc:       contentsFunc,

--- a/internal/cmds/lint-commit-messages/main.go
+++ b/internal/cmds/lint-commit-messages/main.go
@@ -14,7 +14,7 @@ import (
 var commitRx = regexp.MustCompile(`\A([0-9a-f]{40}) (chore(?:\([\w\-]+\))?|docs|feat|fix): ([A-Z]|bump)`)
 
 func run() error {
-	args := append([]string{"log", "--format=oneline"}, os.Args[1:]...)
+	args := append([]string{"-c", "log.abbrevcommit=false", "log", "--format=oneline"}, os.Args[1:]...)
 	cmd := exec.Command("git", args...)
 	cmd.Stdin = os.Stdin
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
Create a shared helper function to setup the temporary directory/script and build an `exec.Cmd` struct value.

The duplicate implementations in `RealSystem.RunScript` and `SourceState.newModifyTargetStateEntryFunc` are nearly identical. Prefer the `RealSystem.RunScript` where different.

<!--

Thanks for contributing!

chezmoi has a strict zero-tolerance policy on LLM contributions. If you use an
LLM (Large Language Model, like ChatGPT, Claude, Gemini, GitHub Copilot, or
Llama) to make any kind of contribution then you will immediately be banned
without recourse.

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer-guide/contributing-changes/

-->
