### PR TITLE
chore: Deduplicate read file and apply template

### DIFF
--- a/internal/chezmoi/actualstateentry.go
+++ b/internal/chezmoi/actualstateentry.go
@@ -32,7 +32,7 @@ type ActualStateDir struct {
 type ActualStateFile struct {
 	absPath      AbsPath
 	perm         fs.FileMode
-	contentsFunc func() ([]byte, error)
+	contentsFunc ContentsFunc
 }
 
 // A ActualStateSymlink represents the state of a symlink in the filesystem.

--- a/internal/chezmoi/chezmoi.go
+++ b/internal/chezmoi/chezmoi.go
@@ -355,7 +355,7 @@ func md5Sum(data []byte) []byte {
 }
 
 // lazySHA256 returns a function that returns a SHA256 computed lazily.
-func lazySHA256(contentsFunc func() ([]byte, error)) func() ([32]byte, error) {
+func lazySHA256(contentsFunc ContentsFunc) func() ([32]byte, error) {
 	return sync.OnceValues(func() ([32]byte, error) {
 		contents, err := contentsFunc()
 		if err != nil {

--- a/internal/chezmoi/sourcestate.go
+++ b/internal/chezmoi/sourcestate.go
@@ -1902,34 +1902,48 @@ func (s *SourceState) newSourceStateDir(absPath AbsPath, sourceRelPath SourceRel
 	}
 }
 
+func (s *SourceState) readSourceFileAndApplyTemplate(
+	readFunc ContentsFunc,
+	fileAttr FileAttr,
+	sourceRelPath SourceRelPath,
+	destAbsPath AbsPath,
+) ([]byte, error) {
+	fileContents, err := readFunc()
+	if err != nil {
+		return nil, err
+	}
+	if fileAttr.Template {
+		fileContents, err = s.ExecuteTemplateData(ExecuteTemplateDataOptions{
+			NameRelPath: sourceRelPath.RelPath(),
+			Data:        fileContents,
+			DestAbsPath: destAbsPath,
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	return fileContents, nil
+}
+
 // newCreateTargetStateEntryFunc returns a targetStateEntryFunc that returns a
 // file with the value of sourceContentsFunc if the file does not already exist,
 // or returns the actual file's contents unchanged if the file already exists.
 func (s *SourceState) newCreateTargetStateEntryFunc(
 	sourceRelPath SourceRelPath,
 	fileAttr FileAttr,
-	sourceContentsFunc func() ([]byte, error),
+	sourceContentsFunc ContentsFunc,
 ) TargetStateEntryFunc {
 	return func(destSystem System, destAbsPath AbsPath) (TargetStateEntry, error) {
-		var contentsFunc func() ([]byte, error)
+		var contentsFunc ContentsFunc
 		switch contents, err := destSystem.ReadFile(destAbsPath); {
 		case err == nil:
 			contentsFunc = eagerNoErr(contents)
 		case errors.Is(err, fs.ErrNotExist):
 			contentsFunc = sync.OnceValues(func() ([]byte, error) {
-				contents, err = sourceContentsFunc()
+				contents, err = s.readSourceFileAndApplyTemplate(
+					sourceContentsFunc, fileAttr, sourceRelPath, destAbsPath)
 				if err != nil {
 					return nil, err
-				}
-				if fileAttr.Template {
-					contents, err = s.ExecuteTemplateData(ExecuteTemplateDataOptions{
-						NameRelPath: sourceRelPath.RelPath(),
-						Data:        contents,
-						DestAbsPath: destAbsPath,
-					})
-					if err != nil {
-						return nil, err
-					}
 				}
 				return contents, nil
 			})
@@ -1954,7 +1968,7 @@ func (s *SourceState) newCreateTargetStateEntryFunc(
 func (s *SourceState) newFileTargetStateEntryFunc(
 	sourceRelPath SourceRelPath,
 	fileAttr FileAttr,
-	sourceContentsFunc func() ([]byte, error),
+	sourceContentsFunc ContentsFunc,
 ) TargetStateEntryFunc {
 	return func(destSystem System, destAbsPath AbsPath) (TargetStateEntry, error) {
 		if s.mode == ModeSymlink && !fileAttr.Encrypted && !fileAttr.Executable && !fileAttr.Private && !fileAttr.Template {
@@ -1974,19 +1988,10 @@ func (s *SourceState) newFileTargetStateEntryFunc(
 			}
 		}
 		executedContentsFunc := sync.OnceValues(func() ([]byte, error) {
-			contents, err := sourceContentsFunc()
+			contents, err := s.readSourceFileAndApplyTemplate(
+				sourceContentsFunc, fileAttr, sourceRelPath, destAbsPath)
 			if err != nil {
 				return nil, err
-			}
-			if fileAttr.Template {
-				contents, err = s.ExecuteTemplateData(ExecuteTemplateDataOptions{
-					NameRelPath: sourceRelPath.RelPath(),
-					Data:        contents,
-					DestAbsPath: destAbsPath,
-				})
-				if err != nil {
-					return nil, err
-				}
 			}
 			return contents, nil
 		})
@@ -2008,7 +2013,7 @@ func (s *SourceState) newFileTargetStateEntryFunc(
 func (s *SourceState) newModifyTargetStateEntryFunc(
 	sourceRelPath SourceRelPath,
 	fileAttr FileAttr,
-	contentsFunc func() ([]byte, error),
+	contentsFunc ContentsFunc,
 	interpreter *Interpreter,
 ) TargetStateEntryFunc {
 	return func(destSystem System, destAbsPath AbsPath) (TargetStateEntry, error) {
@@ -2021,20 +2026,10 @@ func (s *SourceState) newModifyTargetStateEntryFunc(
 			}
 
 			// Compute the contents of the modifier.
-			var modifierContents []byte
-			modifierContents, err = contentsFunc()
+			modifierContents, err := s.readSourceFileAndApplyTemplate(
+				contentsFunc, fileAttr, sourceRelPath, destAbsPath)
 			if err != nil {
 				return nil, err
-			}
-			if fileAttr.Template {
-				modifierContents, err = s.ExecuteTemplateData(ExecuteTemplateDataOptions{
-					NameRelPath: sourceRelPath.RelPath(),
-					Data:        modifierContents,
-					DestAbsPath: destAbsPath,
-				})
-				if err != nil {
-					return nil, err
-				}
 			}
 
 			// If the modifier is empty then return the current contents unchanged.
@@ -2113,24 +2108,15 @@ func (s *SourceState) newScriptTargetStateEntryFunc(
 	sourceRelPath SourceRelPath,
 	fileAttr FileAttr,
 	targetRelPath RelPath,
-	sourceContentsFunc func() ([]byte, error),
+	sourceContentsFunc ContentsFunc,
 	interpreter *Interpreter,
 ) TargetStateEntryFunc {
 	return func(destSystem System, destAbsPath AbsPath) (TargetStateEntry, error) {
 		contentsFunc := sync.OnceValues(func() ([]byte, error) {
-			contents, err := sourceContentsFunc()
+			contents, err := s.readSourceFileAndApplyTemplate(
+				sourceContentsFunc, fileAttr, sourceRelPath, destAbsPath)
 			if err != nil {
 				return nil, err
-			}
-			if fileAttr.Template {
-				contents, err = s.ExecuteTemplateData(ExecuteTemplateDataOptions{
-					NameRelPath: sourceRelPath.RelPath(),
-					Data:        contents,
-					DestAbsPath: destAbsPath,
-				})
-				if err != nil {
-					return nil, err
-				}
 			}
 			return contents, nil
 		})
@@ -2153,23 +2139,14 @@ func (s *SourceState) newScriptTargetStateEntryFunc(
 func (s *SourceState) newSymlinkTargetStateEntryFunc(
 	sourceRelPath SourceRelPath,
 	fileAttr FileAttr,
-	contentsFunc func() ([]byte, error),
+	contentsFunc ContentsFunc,
 ) TargetStateEntryFunc {
 	return func(destSystem System, destAbsPath AbsPath) (TargetStateEntry, error) {
 		linknameFunc := func() (string, error) {
-			linknameBytes, err := contentsFunc()
+			linknameBytes, err := s.readSourceFileAndApplyTemplate(
+				contentsFunc, fileAttr, sourceRelPath, destAbsPath)
 			if err != nil {
 				return "", err
-			}
-			if fileAttr.Template {
-				linknameBytes, err = s.ExecuteTemplateData(ExecuteTemplateDataOptions{
-					NameRelPath: sourceRelPath.RelPath(),
-					Data:        linknameBytes,
-					DestAbsPath: destAbsPath,
-				})
-				if err != nil {
-					return "", err
-				}
 			}
 			linkname := normalizeLinkname(string(bytes.TrimSpace(linknameBytes)))
 			return linkname, nil

--- a/internal/chezmoi/sourcestate_test.go
+++ b/internal/chezmoi/sourcestate_test.go
@@ -909,6 +909,73 @@ func TestSourceStateExecuteTemplateData(t *testing.T) {
 	}
 }
 
+func TestReadSourceFileAndApplyTemplate(t *testing.T) {
+	readErr := errors.New("read error")
+
+	for _, tc := range []struct {
+		name              string
+		fileSourceRelPath string
+		fileAttr          FileAttr
+		contents          string
+		readErr           error
+		expectedStr       string
+		expectErr         bool
+	}{
+		{
+			name:              "not_template",
+			fileSourceRelPath: "dot_file",
+			contents:          "hello {{ /* this is not a template file */ }} world\n",
+			expectedStr:       "hello {{ /* this is not a template file */ }} world\n",
+		},
+		{
+			name:              "template",
+			fileSourceRelPath: "dot_file.tmpl",
+			fileAttr:          FileAttr{Template: true},
+			contents: "" +
+				"templated file\n" +
+				"source: {{ .chezmoi.sourceFile }}\n" +
+				"target: {{ .chezmoi.targetFile }}\n",
+			expectedStr: "" +
+				"templated file\n" +
+				"source: dot_file.tmpl\n" +
+				"target: /home/user/.file\n",
+		},
+		{
+			name:      "read_error",
+			readErr:   readErr,
+			expectErr: true,
+		},
+		{
+			name:              "template_error",
+			fileSourceRelPath: "dot_file.tmpl",
+			fileAttr:          FileAttr{Template: true},
+			contents:          "{{",
+			expectErr:         true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := NewSourceState(withUserTemplateData(map[string]any{
+				"chezmoi": map[string]any{},
+			}))
+			actual, err := s.readSourceFileAndApplyTemplate(
+				func() ([]byte, error) {
+					return []byte(tc.contents), tc.readErr
+				},
+				tc.fileAttr,
+				NewSourceRelPath(tc.fileSourceRelPath),
+				NewAbsPath("/home/user/.file"),
+			)
+
+			if tc.expectErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedStr, string(actual))
+		})
+	}
+}
+
 func TestSourceStateRead(t *testing.T) {
 	for _, tc := range []struct {
 		name                string

--- a/internal/chezmoi/sourcestateentry.go
+++ b/internal/chezmoi/sourcestateentry.go
@@ -56,8 +56,8 @@ type SourceStateDir struct {
 // A SourceStateFile represents the state of a file in the source state.
 type SourceStateFile struct {
 	attr                 FileAttr
-	contentsFunc         func() ([]byte, error)
-	contentsSHA256Func   func() ([32]byte, error)
+	contentsFunc         ContentsFunc
+	contentsSHA256Func   ContentsSHA256Func
 	origin               SourceStateOrigin
 	sourceRelPath        SourceRelPath
 	targetStateEntryFunc TargetStateEntryFunc

--- a/internal/chezmoi/targetstateentry.go
+++ b/internal/chezmoi/targetstateentry.go
@@ -39,10 +39,14 @@ type TargetStateDir struct {
 	sourceAttr SourceAttr
 }
 
+type ContentsFunc func() ([]byte, error)
+
+type ContentsSHA256Func func() ([32]byte, error)
+
 // A TargetStateFile represents the state of a file in the target state.
 type TargetStateFile struct {
-	contentsFunc       func() ([]byte, error)
-	contentsSHA256Func func() ([32]byte, error)
+	contentsFunc       ContentsFunc
+	contentsSHA256Func ContentsSHA256Func
 	empty              bool
 	overwrite          bool
 	perm               fs.FileMode
@@ -55,8 +59,8 @@ type TargetStateRemove struct{}
 // A TargetStateScript represents the state of a script.
 type TargetStateScript struct {
 	name               RelPath
-	contentsFunc       func() ([]byte, error)
-	contentsSHA256Func func() ([32]byte, error)
+	contentsFunc       ContentsFunc
+	contentsSHA256Func ContentsSHA256Func
 	interpreter        *Interpreter
 	condition          ScriptCondition
 	sourceAttr         SourceAttr


### PR DESCRIPTION
Create a shared helper function to read the contents of a source file and apply the contents as a template if necessary.

Also, the function type `func() (byte[], error)` and `func() (byte[], error)` are used frequently throughout the code base, so make explicit `ProduceBytesFunc` and `Produce32BytesFunc` types.

<!--

Thanks for contributing!

chezmoi has a strict zero-tolerance policy on LLM contributions. If you use an
LLM (Large Language Model, like ChatGPT, Claude, Gemini, GitHub Copilot, or
Llama) to make any kind of contribution then you will immediately be banned
without recourse.

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer-guide/contributing-changes/

-->
