### PR TITLE
chore: Deduplicate parse script extensions

### DIFF
--- a/internal/chezmoi/sourcestate.go
+++ b/internal/chezmoi/sourcestate.go
@@ -2152,6 +2152,34 @@ func (s *SourceState) newSymlinkTargetStateEntryFunc(
 	}
 }
 
+type parsedScriptExtensionResult struct {
+	targetRelPathWithoutInterpreterExtension RelPath
+	interpreter                              *Interpreter
+}
+
+// Attempts to match the extension of the target to an interpreter
+// known to chezmoi. If the extension is recognized as an interpreter,
+// return the target file name without the extension and the interpreter.
+// Otherwise, return the target file as is and a nil Interpreter.
+// Callers that want the extension-stripped target name must use the returned
+// path because targetRelPath is passed by value.
+func (s *SourceState) attemptToParseScriptExtension(targetRelPath RelPath,
+) parsedScriptExtensionResult {
+	extension := strings.ToLower(strings.TrimPrefix(targetRelPath.Ext(), "."))
+	interpreter, ok := s.interpreters[extension]
+
+	var interpreterPtr *Interpreter
+	if ok {
+		targetRelPath = targetRelPath.Slice(0, targetRelPath.Len()-len(extension)-1)
+		interpreterPtr = &interpreter
+	}
+
+	return parsedScriptExtensionResult{
+		targetRelPathWithoutInterpreterExtension: targetRelPath,
+		interpreter:                              interpreterPtr,
+	}
+}
+
 // newSourceStateFile returns a possibly new target RalPath and a new
 // SourceStateFile.
 func (s *SourceState) newSourceStateFile(
@@ -2181,34 +2209,18 @@ func (s *SourceState) newSourceStateFile(
 	case SourceFileTypeFile:
 		targetStateEntryFunc = s.newFileTargetStateEntryFunc(sourceRelPath, fileAttr, contentsFunc)
 	case SourceFileTypeModify:
-		// If the target has an extension, determine if it indicates an
-		// interpreter to use.
-		extension := strings.ToLower(strings.TrimPrefix(targetRelPath.Ext(), "."))
-		if interpreter, ok := s.interpreters[extension]; ok {
-			// For modify scripts, the script extension is not considered part
-			// of the target name, so remove it.
-			targetRelPath = targetRelPath.Slice(0, targetRelPath.Len()-len(extension)-1)
-			targetStateEntryFunc = s.newModifyTargetStateEntryFunc(sourceRelPath, fileAttr, contentsFunc, &interpreter)
-		} else {
-			targetStateEntryFunc = s.newModifyTargetStateEntryFunc(sourceRelPath, fileAttr, contentsFunc, nil)
-		}
+		// For modify scripts, an interpreter extension *is not* considered part of the target name.
+		parsedScript := s.attemptToParseScriptExtension(targetRelPath)
+		targetRelPath = parsedScript.targetRelPathWithoutInterpreterExtension
+		targetStateEntryFunc = s.newModifyTargetStateEntryFunc(
+			sourceRelPath, fileAttr, contentsFunc, parsedScript.interpreter)
 	case SourceFileTypeRemove:
 		targetStateEntryFunc = s.newRemoveTargetStateEntryFunc()
 	case SourceFileTypeScript:
-		// If the script has an extension, determine if it indicates an
-		// interpreter to use.
-		extension := strings.ToLower(strings.TrimPrefix(targetRelPath.Ext(), "."))
-		if interpreter, ok := s.interpreters[extension]; ok {
-			targetStateEntryFunc = s.newScriptTargetStateEntryFunc(
-				sourceRelPath,
-				fileAttr,
-				targetRelPath,
-				contentsFunc,
-				&interpreter,
-			)
-		} else {
-			targetStateEntryFunc = s.newScriptTargetStateEntryFunc(sourceRelPath, fileAttr, targetRelPath, contentsFunc, nil)
-		}
+		// For run scripts, an interpreter extension *is* considered part of the target name.
+		parsedScript := s.attemptToParseScriptExtension(targetRelPath)
+		targetStateEntryFunc = s.newScriptTargetStateEntryFunc(
+			sourceRelPath, fileAttr, targetRelPath, contentsFunc, parsedScript.interpreter)
 	case SourceFileTypeSymlink:
 		targetStateEntryFunc = s.newSymlinkTargetStateEntryFunc(sourceRelPath, fileAttr, contentsFunc)
 	default:

--- a/internal/chezmoi/sourcestate_test.go
+++ b/internal/chezmoi/sourcestate_test.go
@@ -909,6 +909,49 @@ func TestSourceStateExecuteTemplateData(t *testing.T) {
 	}
 }
 
+func TestAttemptToParseScriptExtension(t *testing.T) {
+	shInterpreter := Interpreter{
+		Command: "bash",
+	}
+	for _, tc := range []struct {
+		name                  string
+		targetRelPath         string
+		expectedTargetRelPath string
+		expectedInterpreter   *Interpreter
+	}{
+		{
+			name:                  "no_extension",
+			targetRelPath:         "scripts/file.unrecognized",
+			expectedTargetRelPath: "scripts/file.unrecognized",
+		},
+		{
+			name:                  "has_extension",
+			targetRelPath:         "scripts/file.sh",
+			expectedTargetRelPath: "scripts/file",
+			expectedInterpreter:   &shInterpreter,
+		},
+		{
+			name:                  "case_insensitive_extension",
+			targetRelPath:         "scripts/file.SH",
+			expectedTargetRelPath: "scripts/file",
+			expectedInterpreter:   &shInterpreter,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := NewSourceState(WithInterpreters(map[string]Interpreter{
+				"sh": shInterpreter,
+			}))
+
+			parsedScript := s.attemptToParseScriptExtension(RelPath{relPath: tc.targetRelPath})
+
+			assert.Equal(t,
+				RelPath{relPath: tc.expectedTargetRelPath},
+				parsedScript.targetRelPathWithoutInterpreterExtension)
+			assert.Equal(t, tc.expectedInterpreter, parsedScript.interpreter)
+		})
+	}
+}
+
 func TestReadSourceFileAndApplyTemplate(t *testing.T) {
 	readErr := errors.New("read error")
 


### PR DESCRIPTION
Deduplicate the logic for mapping file extensions to interpreters and stripping the extension if it matches an interpreter. This is currently used by run and modify types.

**Review note:** The deduplicated logic here is a smaller scope than #5115 or #5119. However, I felt it would be best to submit this as a standalone PR before attempting a proposal for a `derive_` attribute as discussed in #5110. That implementation will also rely on the logic deduplicated here. 

<!--

Thanks for contributing!

chezmoi has a strict zero-tolerance policy on LLM contributions. If you use an
LLM (Large Language Model, like ChatGPT, Claude, Gemini, GitHub Copilot, or
Llama) to make any kind of contribution then you will immediately be banned
without recourse.

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer-guide/contributing-changes/

-->
