### PR TITLE
fix: Adding copyright and license identifiers in install scripts (Closes: #5111).

### DIFF
--- a/assets/scripts/install-local-bin.sh
+++ b/assets/scripts/install-local-bin.sh
@@ -5,6 +5,10 @@
 # https://github.com/client9/shlib
 # https://github.com/goreleaser/godownloader
 
+# Copyright (C) 2017 Nick Galbreath
+# Copyright (C) 2018 Tom Payne
+# SPDX-License-Identifier: MIT
+
 set -e
 
 BINDIR="${BINDIR:-.local/bin}"

--- a/assets/scripts/install.sh
+++ b/assets/scripts/install.sh
@@ -5,6 +5,10 @@
 # https://github.com/client9/shlib
 # https://github.com/goreleaser/godownloader
 
+# Copyright (C) 2017 Nick Galbreath
+# Copyright (C) 2018 Tom Payne
+# SPDX-License-Identifier: MIT
+
 set -e
 
 BINDIR="${BINDIR:-bin}"

--- a/internal/cmds/generate-install.sh/install.sh.tmpl
+++ b/internal/cmds/generate-install.sh/install.sh.tmpl
@@ -5,6 +5,10 @@
 # https://github.com/client9/shlib
 # https://github.com/goreleaser/godownloader
 
+# Copyright (C) 2017 Nick Galbreath
+# Copyright (C) 2018 Tom Payne
+# SPDX-License-Identifier: MIT
+
 set -e
 
 BINDIR="${BINDIR:-{{ .BinDir }}}"


### PR DESCRIPTION
Hi,

as discussed in #5111, it would be nice to add the copyright and license identifiers to keep the "provenance" selfcontained in the sources.

Regards,
Daniel