### PR TITLE
chore: Print previous and new version when upgrading

### DIFF
--- a/internal/cmd/upgradecmd.go
+++ b/internal/cmd/upgradecmd.go
@@ -121,12 +121,6 @@ func (c *Config) runUpgradeCmd(cmd *cobra.Command, args []string) error {
 	}
 	c.logger.Info("upgradeMethod", slog.String("executable", c.upgrade.executable), slog.String("method", method))
 
-	// get old chezmoi version for logging later
-	oldChezmoiVersion, err := getChezmoiVersion(executableAbsPath.String())
-	if err != nil {
-		return err
-	}
-
 	// Replace the executable with the updated version.
 	switch method {
 	case upgradeMethodBrewUpgrade:
@@ -170,9 +164,16 @@ func (c *Config) runUpgradeCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	// Execute the new version.
-	chezmoiVersion, err := getChezmoiVersion(path)
-	fmt.Fprintf(c.stdout, "Upgraded from %s to %s\n", oldChezmoiVersion, chezmoiVersion)
-	return err
+	chezmoiVersionCmd := exec.Command(path, "--version")
+	chezmoiVersionCmd.Stdin = os.Stdin
+	chezmoiVersionCmd.Stdout = os.Stdout
+	chezmoiVersionCmd.Stderr = os.Stderr
+	chezmoiVersion, err := chezmoilog.LogCmdOutput(c.logger, chezmoiVersionCmd)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(c.stdout, "Upgraded from %s to %s\n", c.versionInfo, string(chezmoiVersion))
+	return nil
 }
 
 func (c *Config) getChecksums(ctx context.Context, rr *github.RepositoryRelease) (map[string][]byte, error) {
@@ -327,16 +328,4 @@ func getReleaseAssetByName(rr *github.RepositoryRelease, name string) *github.Re
 		}
 	}
 	return nil
-}
-
-func getChezmoiVersion(executablePath string) (string, error) {
-	buf := new(bytes.Buffer)
-	versionCmd := exec.Command(executablePath, "--version")
-	versionCmd.Stdin = os.Stdin
-	versionCmd.Stdout = buf
-	versionCmd.Stderr = os.Stderr
-	if err := chezmoilog.LogCmdRun(nil, versionCmd); err != nil {
-		return "", err
-	}
-	return buf.String(), nil
 }

--- a/internal/cmd/upgradecmd.go
+++ b/internal/cmd/upgradecmd.go
@@ -121,6 +121,12 @@ func (c *Config) runUpgradeCmd(cmd *cobra.Command, args []string) error {
 	}
 	c.logger.Info("upgradeMethod", slog.String("executable", c.upgrade.executable), slog.String("method", method))
 
+	// get old chezmoi version for logging later
+	oldChezmoiVersion, err := getChezmoiVersion(executableAbsPath.String())
+	if err != nil {
+		return err
+	}
+
 	// Replace the executable with the updated version.
 	switch method {
 	case upgradeMethodBrewUpgrade:
@@ -164,11 +170,9 @@ func (c *Config) runUpgradeCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	// Execute the new version.
-	chezmoiVersionCmd := exec.Command(path, "--version")
-	chezmoiVersionCmd.Stdin = os.Stdin
-	chezmoiVersionCmd.Stdout = os.Stdout
-	chezmoiVersionCmd.Stderr = os.Stderr
-	return chezmoilog.LogCmdRun(c.logger, chezmoiVersionCmd)
+	chezmoiVersion, err := getChezmoiVersion(path)
+	fmt.Fprintf(c.stdout, "Upgraded from %s to %s\n", oldChezmoiVersion, chezmoiVersion)
+	return err
 }
 
 func (c *Config) getChecksums(ctx context.Context, rr *github.RepositoryRelease) (map[string][]byte, error) {
@@ -323,4 +327,16 @@ func getReleaseAssetByName(rr *github.RepositoryRelease, name string) *github.Re
 		}
 	}
 	return nil
+}
+
+func getChezmoiVersion(executablePath string) (string, error) {
+	buf := new(bytes.Buffer)
+	versionCmd := exec.Command(executablePath, "--version")
+	versionCmd.Stdin = os.Stdin
+	versionCmd.Stdout = buf
+	versionCmd.Stderr = os.Stderr
+	if err := chezmoilog.LogCmdRun(nil, versionCmd); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
 }

--- a/internal/cmd/upgradecmd.go
+++ b/internal/cmd/upgradecmd.go
@@ -166,13 +166,12 @@ func (c *Config) runUpgradeCmd(cmd *cobra.Command, args []string) error {
 	// Execute the new version.
 	chezmoiVersionCmd := exec.Command(path, "--version")
 	chezmoiVersionCmd.Stdin = os.Stdin
-	chezmoiVersionCmd.Stdout = os.Stdout
 	chezmoiVersionCmd.Stderr = os.Stderr
 	chezmoiVersion, err := chezmoilog.LogCmdOutput(c.logger, chezmoiVersionCmd)
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(c.stdout, "Upgraded from %s to %s\n", c.versionInfo, string(chezmoiVersion))
+	fmt.Fprintf(c.stdout, "Upgraded from %s to %s\n", c.versionStr, string(chezmoiVersion))
 	return nil
 }
 


### PR DESCRIPTION
This PR solves #5124.

During `chezmoi upgrade`, it now calls `chezmoi --version` before swapping the executable (old version) and after (new version), getting both version strings to print a summary of the upgrade at the end.

In the issue I talked about switching between a simple and verbose version of the message. I decided to leave that feature out and only use the output from `chezmoi --version` since that has always been the output.