### PR TITLE
chore: Trust rage tap

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -161,6 +161,7 @@ jobs:
     - name: install-rage
       run: |
         brew tap str4d.xyz/rage https://str4d.xyz/rage
+        brew trust str4d.xyz/rage
         brew install rage
         rage --version
     - name: install-keepassxc


### PR DESCRIPTION
Tests on macOS currently give the warning:

```
test-macos
The following taps are not trusted:
  aws/tap
  str4d.xyz/rage

Homebrew is currently ignoring formulae, casks and commands from these taps because tap trust is required.
Untap them with:
  brew untap aws/tap str4d.xyz/rage
Trust specific formulae, casks and commands with:
  brew trust --formula <user>/<tap>/<formula>
  brew trust --cask <user>/<tap>/<cask>
  brew trust --command <user>/<tap>/<command>
Whole-tap trust is broader and includes all current and future formulae,
casks and commands from the listed taps. Trust whole taps with:
  brew trust aws/tap str4d.xyz/rage
To disable trust checks:
  export HOMEBREW_NO_REQUIRE_TAP_TRUST=1
This is not recommended and will be removed in a later release.
For more information, see:
  https://docs.brew.sh/Tap-Trust
```