### PR TITLE
chore: Fix potential code injection in preview-docs.yml

### DIFF
--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -36,8 +36,10 @@ jobs:
         HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
       run: |
-        PR=$(gh api "repos/${GH_REPO}/pulls" --paginate \
-          --jq ".[] | select(.head.ref == \"${HEAD_BRANCH}\" and .head.repo.full_name == \"${HEAD_REPO}\") | {number, base_sha: .base.sha}")
+        PR=$(gh api "repos/${GH_REPO}/pulls" --paginate | \
+          jq -c --arg branch "${HEAD_BRANCH}" --arg repo "${HEAD_REPO}" \
+            '.[] | select(.head.ref == $branch and .head.repo.full_name == $repo) | {number, base_sha: .base.sha}' | \
+          head -1)
         if [ -z "${PR}" ]; then
           echo "error: could not find PR for ${HEAD_REPO}:${HEAD_BRANCH}"
           exit 1


### PR DESCRIPTION
This was found by an independent security audit of chezmoi.

In the `preview-docs.yml` workflow, an attacker controls the branch name in `${HEAD_BRANCH}`. Git branch names can include the `"` character, which allows them to escape the argument passed to `--jq` and get local shell access.

cc @KapJI for information