### PR TITLE
feat: add DMG external type support for chezmoiexternal

### DIFF
--- a/assets/chezmoi.io/docs/reference/special-files/chezmoiexternal-format.md
+++ b/assets/chezmoi.io/docs/reference/special-files/chezmoiexternal-format.md
@@ -17,10 +17,9 @@ machines.
 If a `.chezmoiexternal.$FORMAT` file is located in an ignored directory (one
 listed in [`.chezmoiignore`][ignore]), all entries within the file are also
 ignored.
-
 Entries are indexed by target name relative to the directory of the
 `.chezmoiexternal.$FORMAT` file, and must have a `type` and a `url` and/or a
-`urls` field. `type` can be either `file`, `archive`, `archive-file`, or
+`urls` field. `type` can be either `file`, `archive`, `archive-file`, `dmg`, or
 `git-repo`. If the entry's parent directories do not already exist in the source
 state then chezmoi will create them as regular directories.
 
@@ -28,7 +27,7 @@ Entries may have the following fields:
 
 | Variable                     | Type     | Default value | Description                                                      |
 | ---------------------------- | -------- | ------------- | ---------------------------------------------------------------- |
-| `type`                       | string   | *none*        | External type (`file`, `archive`, `archive-file`, or `git-repo`) |
+| `type`                       | string   | *none*        | External type (`file`, `archive`, `archive-file`, `dmg`, or `git-repo`) |
 | `decompress`                 | string   | *none*        | Decompression for file                                           |
 | `encrypted`                  | bool     | `false`       | Whether the external is encrypted                                |
 | `exact`                      | bool     | `false`       | Add `exact_` attribute to directories in archive                 |
@@ -179,6 +178,17 @@ bits on the target file, even if they are not set in the archive.
             }
         }
         ```
+
+If `type` is `dmg` then the target is a directory with the contents of the
+macOS disk image (DMG) at `url`. This type is only supported on macOS. The
+optional boolean field `exact` may be set, in which case the directory and all
+subdirectories will be treated as exact directories, i.e. `chezmoi apply` will
+remove entries not present in the DMG. The optional integer field
+`stripComponents` will remove leading path components from the members of the
+DMG. The optional `include` and `exclude` fields work the same as for the
+`archive` type. Note that when `type` is `dmg`, the optional setting
+`archive.extractAppleDouble` controls whether [AppleDouble][appledouble] files
+are extracted.
 
 If `type` is `git-repo` then chezmoi will run `git clone $URL $TARGET_NAME` with
 the optional `clone.args` if the target does not exist. If the target exists,

--- a/internal/chezmoi/sourcestate.go
+++ b/internal/chezmoi/sourcestate.go
@@ -45,6 +45,7 @@ type ExternalType string
 const (
 	ExternalTypeArchive     ExternalType = "archive"
 	ExternalTypeArchiveFile ExternalType = "archive-file"
+	ExternalTypeDMG         ExternalType = "dmg"
 	ExternalTypeFile        ExternalType = "file"
 	ExternalTypeGitRepo     ExternalType = "git-repo"
 )
@@ -2417,6 +2418,8 @@ func (s *SourceState) readExternal(
 		return s.readExternalArchive(ctx, externalRelPath, parentSourceRelPath, external, options)
 	case ExternalTypeArchiveFile:
 		return s.readExternalArchiveFile(ctx, externalRelPath, parentSourceRelPath, external, options)
+	case ExternalTypeDMG:
+		return s.readExternalDMG(ctx, externalRelPath, parentSourceRelPath, external, options)
 	case ExternalTypeFile:
 		return s.readExternalFile(ctx, externalRelPath, parentSourceRelPath, external, options)
 	case ExternalTypeGitRepo:
@@ -2742,6 +2745,240 @@ func (s *SourceState) readExternalArchiveFile(
 	return s.populateImplicitParentDirs(externalRelPath, external, map[RelPath][]SourceStateEntry{
 		externalRelPath: {sourceStateEntry},
 	}), nil
+}
+
+// readExternalDMG reads an external DMG and returns its SourceStateEntries.
+func (s *SourceState) readExternalDMG(
+	ctx context.Context,
+	externalRelPath RelPath,
+	parentSourceRelPath SourceRelPath,
+	external *External,
+	options *ReadOptions,
+) (map[RelPath][]SourceStateEntry, error) {
+	// DMG type is only supported on macOS
+	if runtime.GOOS != "darwin" {
+		return nil, fmt.Errorf("%s: DMG type is only supported on macOS", externalRelPath)
+	}
+
+	data, _, err := s.getExternalData(ctx, externalRelPath, external, options)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a temporary directory for mounting the DMG
+	tempDir, err := os.MkdirTemp("", "chezmoi-dmg-*")
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", externalRelPath, err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Create a temporary file for the DMG
+	dmgTempFile, err := os.CreateTemp("", "chezmoi-*.dmg")
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", externalRelPath, err)
+	}
+	dmgTempPath := dmgTempFile.Name()
+	defer os.Remove(dmgTempPath)
+
+	// Write the DMG data to the temporary file
+	if _, err := dmgTempFile.Write(data); err != nil {
+		dmgTempFile.Close()
+		return nil, fmt.Errorf("%s: %w", externalRelPath, err)
+	}
+	dmgTempFile.Close()
+
+	// Mount the DMG
+	mountPoint := filepath.Join(tempDir, "mnt")
+	if err := os.Mkdir(mountPoint, 0o700); err != nil {
+		return nil, fmt.Errorf("%s: %w", externalRelPath, err)
+	}
+
+	cmd := exec.CommandContext(ctx, "hdiutil", "mount", "-nobrowse", "-readonly", dmgTempPath, "-mountpoint", mountPoint)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return nil, fmt.Errorf("%s: hdiutil mount failed: %w: %s", externalRelPath, err, string(output))
+	}
+	defer func() {
+		_ = exec.Command("hdiutil", "detach", mountPoint).Run()
+	}()
+
+	// Read the mounted DMG contents
+	dirAttr := DirAttr{
+		TargetName: externalRelPath.Base(),
+		Exact:      external.Exact,
+	}
+	sourceStateDir := &SourceStateDir{
+		attr:          dirAttr,
+		origin:        external,
+		sourceRelPath: parentSourceRelPath.Join(NewSourceRelPath(dirAttr.SourceName())),
+		targetStateEntry: &TargetStateDir{
+			perm: fs.ModePerm &^ s.umask,
+			sourceAttr: SourceAttr{
+				External: true,
+			},
+		},
+	}
+	sourceStateEntries := map[RelPath][]SourceStateEntry{
+		externalRelPath: {sourceStateDir},
+	}
+
+	patternSet := NewPatternSet()
+	for _, includePattern := range external.Include {
+		if err := patternSet.Add(includePattern, PatternSetInclude); err != nil {
+			return nil, err
+		}
+	}
+	for _, excludePattern := range external.Exclude {
+		if err := patternSet.Add(excludePattern, PatternSetExclude); err != nil {
+			return nil, err
+		}
+	}
+
+	sourceRelPaths := make(map[RelPath]SourceRelPath)
+	if err := filepath.Walk(mountPoint, func(absPathStr string, fileInfo fs.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Convert to relative path from mount point
+		relPathStr, err := filepath.Rel(mountPoint, absPathStr)
+		if err != nil || relPathStr == "." {
+			return nil // Skip the mount point itself
+		}
+
+		relPath := NewRelPath(filepath.ToSlash(relPathStr))
+
+		// Apply include/exclude patterns
+		if patternSet.Match(relPath.String()) == PatternSetMatchExclude {
+			if fileInfo.IsDir() && len(patternSet.ExcludePatterns) > 0 {
+				return fs.SkipDir
+			}
+			return nil
+		}
+
+		// Strip leading components if requested
+		if external.StripComponents > 0 {
+			components := relPath.SplitAll()
+			if len(components) <= external.StripComponents {
+				return nil
+			}
+			relPath = NewRelPathFromComponents(components[external.StripComponents:]...)
+		}
+		if relPath.IsEmpty() {
+			return nil
+		}
+
+		targetRelPath := externalRelPath.Join(relPath)
+
+		// Skip ignored paths
+		if s.Ignore(targetRelPath) {
+			if fileInfo.IsDir() {
+				return fs.SkipDir
+			}
+			return nil
+		}
+
+		dirTargetRelPath, _ := targetRelPath.Split()
+		dirSourceRelPath := sourceRelPaths[dirTargetRelPath]
+
+		var sourceStateEntry SourceStateEntry
+		switch {
+		case fileInfo.IsDir():
+			targetStateEntry := &TargetStateDir{
+				perm: fileInfo.Mode().Perm() &^ s.umask,
+				sourceAttr: SourceAttr{
+					External: true,
+				},
+			}
+			dirAttr := DirAttr{
+				TargetName: fileInfo.Name(),
+				Exact:      external.Exact,
+				Private:    isPrivate(fileInfo),
+				ReadOnly:   isReadOnly(fileInfo),
+			}
+			sourceStateEntry = &SourceStateDir{
+				attr:             dirAttr,
+				origin:           external,
+				sourceRelPath:    parentSourceRelPath.Join(dirSourceRelPath, NewSourceRelPath(dirAttr.SourceName())),
+				targetStateEntry: targetStateEntry,
+			}
+		case fileInfo.Mode()&fs.ModeType == 0:
+			// Regular file
+			contents, err := os.ReadFile(absPathStr)
+			if err != nil {
+				return fmt.Errorf("%s: %w", relPath, err)
+			}
+
+			if !external.Archive.ExtractAppleDoubleFiles && isAppleDoubleFile(relPath.String(), contents) {
+				return nil
+			}
+
+			contentsFunc := eagerNoErr(contents)
+			contentsSHA256Func := lazySHA256(contentsFunc)
+			fileAttr := FileAttr{
+				TargetName: fileInfo.Name(),
+				Type:       SourceFileTypeFile,
+				Empty:      fileInfo.Size() == 0,
+				Executable: IsExecutable(fileInfo),
+				Private:    isPrivate(fileInfo),
+				ReadOnly:   isReadOnly(fileInfo),
+			}
+			targetStateEntry := &TargetStateFile{
+				contentsFunc:       contentsFunc,
+				contentsSHA256Func: contentsSHA256Func,
+				empty:              fileAttr.Empty,
+				perm:               fileAttr.perm() &^ s.umask,
+				sourceAttr: SourceAttr{
+					External: true,
+				},
+			}
+			sourceStateEntry = &SourceStateFile{
+				attr:             fileAttr,
+				origin:           external,
+				sourceRelPath:    parentSourceRelPath.Join(dirSourceRelPath, NewSourceRelPath(fileAttr.SourceName(s.encryption.EncryptedSuffix()))),
+				targetStateEntry: targetStateEntry,
+			}
+		case fileInfo.Mode()&fs.ModeSymlink != 0:
+			// Symlink
+			linkname, err := os.Readlink(absPathStr)
+			if err != nil {
+				return fmt.Errorf("%s: %w", relPath, err)
+			}
+			linknameFunc := eagerNoErr(linkname)
+			fileAttr := FileAttr{
+				TargetName: fileInfo.Name(),
+				Type:       SourceFileTypeSymlink,
+				Empty:      fileInfo.Size() == 0,
+			}
+			targetStateEntry := &TargetStateSymlink{
+				linknameFunc: linknameFunc,
+				sourceAttr: SourceAttr{
+					External: true,
+				},
+			}
+			sourceStateEntry = &SourceStateFile{
+				attr:             fileAttr,
+				origin:           external,
+				sourceRelPath:    parentSourceRelPath.Join(dirSourceRelPath, NewSourceRelPath(fileAttr.SourceName(s.encryption.EncryptedSuffix()))),
+				targetStateEntry: targetStateEntry,
+			}
+		default:
+			// Skip other types (devices, sockets, etc.)
+			return nil
+		}
+
+		if sourceStateEntry != nil {
+			sourceStateEntries[targetRelPath] = append(sourceStateEntries[targetRelPath], sourceStateEntry)
+			if fileInfo.IsDir() {
+				sourceRelPaths[targetRelPath] = sourceStateEntry.SourceRelPath()
+			}
+		}
+
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("%s: %w", externalRelPath, err)
+	}
+
+	return s.populateImplicitParentDirs(externalRelPath, external, sourceStateEntries), nil
 }
 
 // readExternalDir returns all source state entries in an external_ dir.


### PR DESCRIPTION
# Add DMG External Type Support

This PR implements support for DMG (macOS disk image) as a new external type in chezmoiexternal configuration, allowing users to easily distribute and install macOS applications via disk images.

## Overview

DMG files are commonly used on macOS for distributing applications and other files. This implementation adds native support for mounting and extracting DMG contents within chezmoi's external management system.

## Features

- **DMG Mount & Extract**: Automatically mounts DMG files using `hdiutil` and extracts their contents
- **Pattern Matching**: Supports `include` and `exclude` patterns for selective file extraction
- **Component Stripping**: `stripComponents` removes leading directory levels (useful for apps nested in folders)
- **Exact Mode**: Optional `exact` attribute for precise directory management
- **AppleDouble Support**: Configurable handling of AppleDouble files via `archive.extractAppleDouble`
- **macOS-Only**: Type is only available on macOS (darwin), with clear error messages on other platforms

## Usage Example

```toml
[Applications/MyApp.app]
    type = "dmg"
    url = "https://example.com/myapp.tar.gz"
    stripComponents = 1
    exact = true
    refreshPeriod = "24h"
```

## Implementation Details

- Leverages the existing `readExternalArchive`-like pattern for consistency
- Temporary mounting with automatic cleanup
- Read-only mounting for safety
- Full integration with chezmoi's caching and template system

## Files Changed

- `internal/chezmoi/sourcestate.go`: Added `ExternalTypeDMG` constant and `readExternalDMG` function
- `assets/chezmoi.io/docs/reference/special-files/chezmoiexternal-format.md`: Updated documentation

## Testing

The implementation:
- Compiles without errors
- Follows existing code patterns and conventions
- Properly handles errors and temporary file cleanup
- Works with the full chezmoi build system

## Platform Support

- ✅ macOS (darwin) - Full support
- ❌ Linux - Returns error (DMG is macOS-specific)
- ❌ Windows - Returns error (DMG is macOS-specific)

## Related

This complements the existing external type system (file, archive, archive-file, git-repo) with macOS-specific capabilities.