### PR TITLE
fix: sanitize control characters in diff and status path display

### DIFF
--- a/internal/chezmoi/diff.go
+++ b/internal/chezmoi/diff.go
@@ -4,6 +4,7 @@ import (
 	"io/fs"
 	"net/http"
 	"strings"
+	"unicode"
 
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/filemode"
@@ -11,6 +12,23 @@ import (
 	znkrdiff "znkr.io/diff"
 	znkrtextdiff "znkr.io/diff/textdiff"
 )
+
+// SanitizePathForDisplay replaces control characters (which can include
+// terminal escape sequences) with the Unicode replacement character. A
+// source state entry's name comes directly from a dotfile repository,
+// which has no character restrictions, and chezmoi supports applying a
+// dotfile repository the user hasn't audited yet (chezmoi init followed
+// by chezmoi diff, a routine preview step). Applied only to the path
+// string returned to go-git's diff encoder for display; callers still
+// hold the unmodified RelPath for actual filesystem operations.
+func SanitizePathForDisplay(s string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) {
+			return '�'
+		}
+		return r
+	}, s)
+}
 
 var gitDiffOperation = [...]diff.Operation{
 	znkrdiff.Delete: diff.Delete,
@@ -38,7 +56,7 @@ type gitDiffFile struct {
 
 func (f *gitDiffFile) Hash() plumbing.Hash     { return f.hash }
 func (f *gitDiffFile) Mode() filemode.FileMode { return f.fileMode }
-func (f *gitDiffFile) Path() string            { return f.relPath.String() }
+func (f *gitDiffFile) Path() string            { return SanitizePathForDisplay(f.relPath.String()) }
 
 // A gitDiffFilePatch implements the
 // github.com/go-git/go-git/v5/plumbing/format/diff.FilePatch interface.

--- a/internal/cmd/statuscmd.go
+++ b/internal/cmd/statuscmd.go
@@ -82,7 +82,7 @@ func (c *Config) runStatusCmd(cmd *cobra.Command, args []string) error {
 				return fmt.Errorf("%s: invalid path style", pathStyle)
 			}
 
-			fmt.Fprintf(&builder, "%c%c %s\n", x, y, path)
+			fmt.Fprintf(&builder, "%c%c %s\n", x, y, chezmoi.SanitizePathForDisplay(path))
 		}
 		return fs.SkipDir
 	}


### PR DESCRIPTION
Fixes #5175.

`chezmoi diff` and `chezmoi status` print a target file's path with no filtering of control characters. A source state entry's name comes directly from the dotfile repository chezmoi was initialized from, which has no character restrictions, so a crafted file name can inject terminal escape sequences that get written to the terminal and interpreted live on an ordinary diff or status check, before apply is ever run.

Adds `SanitizePathForDisplay` (`internal/chezmoi/diff.go`), replacing control characters with the Unicode replacement character, applied at `gitDiffFile.Path()` (used by go-git's `diff.UnifiedEncoder` to build `diff`'s header lines) and at the one `fmt.Fprintf` call in `statuscmd.go`'s `preApplyFunc`.

I applied this only at the display point, not by sanitizing `RelPath` itself or where it's first read from the source state, since `RelPath` is used extensively for real filesystem operations throughout the codebase. This is safe because Go passes `RelPath` by value: the caller's own copy used for filesystem operations is unaffected by what `gitDiffFile.Path()` returns.

Verified against a scratch config with a source file named using a raw OSC title-set escape sequence, output captured directly to a file and inspected as a hex dump, for both `diff` and `status`. Confirmed no regression with a normal filename (`dot_bashrc` still renders as `.bashrc` in both outputs). `internal/chezmoi` and `internal/cmd` test suites pass.

One thing worth a follow-up separate from this PR: a few other call sites build interactive confirmation-prompt text from the same underlying path value (`internal/cmd/config.go`'s apply confirmation, `addcmd.go`, `readdcmd.go`, `forgetcmd.go`) and likely share this issue. I didn't touch those here since I wasn't able to verify them the same way (harder to reproduce without driving interactive stdin), so didn't want to claim a fix I hadn't actually confirmed.