### PR TITLE
chore: Change XDG_SHARE_HOME to XDG_DATA_HOME for sourceDir

### DIFF
--- a/assets/chezmoi.io/docs/reference/configuration-file/variables.md.yaml
+++ b/assets/chezmoi.io/docs/reference/configuration-file/variables.md.yaml
@@ -44,7 +44,7 @@ sections:
     scriptTempDir:
       description: Temporary directory for scripts.
     sourceDir:
-      default: '`$XDG_SHARE_HOME/chezmoi` / `$HOME/.local/share/chezmoi` / `%USERPROFILE%/.local/share/chezmoi`'
+      default: '`$XDG_DATA_HOME/chezmoi` / `$HOME/.local/share/chezmoi` / `%USERPROFILE%/.local/share/chezmoi`'
       description: Source directory.
     tempDir:
       default: '*from system*'


### PR DESCRIPTION
The sourceDir variable in the docs incorrectly shows that you should set XDG_SHARE_HOME for the directory where user-specific data should be written to while XDG_DATA_HOME is the correct environment variable name for XDG Base Directories.

<!--

Thanks for contributing!

chezmoi has a strict zero-tolerance policy on LLM contributions. If you use an
LLM (Large Language Model, like ChatGPT, Claude, Gemini, GitHub Copilot, or
Llama) to make any kind of contribution then you will immediately be banned
without recourse.

Please make sure that you have followed the contributing guide:
https://chezmoi.io/developer-guide/contributing-changes/

-->
